### PR TITLE
Fix link page short bio saves

### DIFF
--- a/inc/abilities/handlers/save-link-page-settings.php
+++ b/inc/abilities/handlers/save-link-page-settings.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Save advanced settings for a link page. Merges with existing settings.
  *
- * @param array $input { artist_id: int, settings?: array, background_image_id?: int, profile_image_id?: int }
+ * @param array $input { artist_id: int, settings?: array, bio?: string, background_image_id?: int, profile_image_id?: int }
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_save_link_page_settings( $input ) {
@@ -31,6 +31,10 @@ function extrachill_artist_platform_ability_save_link_page_settings( $input ) {
 	if ( isset( $input['settings'] ) && is_array( $input['settings'] ) ) {
 		$sanitized_settings = extrachill_artist_platform_sanitize_link_settings( $input['settings'] );
 		$save_data          = array_merge( $save_data, $sanitized_settings );
+	}
+
+	if ( array_key_exists( 'bio', $input ) ) {
+		$save_data['bio'] = sanitize_text_field( wp_unslash( (string) $input['bio'] ) );
 	}
 
 	if ( isset( $input['background_image_id'] ) ) {

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -250,6 +250,7 @@ function extrachill_artist_platform_sanitize_link_settings( $settings ) {
 	}
 
 	$string_fields = array(
+		'bio',
 		'redirect_target_url',
 		'meta_pixel_id',
 		'google_tag_id',

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -284,6 +284,10 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'object',
 						'description' => __( 'Settings to save.', 'extrachill-artist-platform' ),
 					),
+					'bio' => array(
+						'type'        => 'string',
+						'description' => __( 'Short bio displayed on the public link page.', 'extrachill-artist-platform' ),
+					),
 					'background_image_id' => array(
 						'type'        => 'integer',
 						'description' => __( 'Background image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),

--- a/inc/core/actions/save.php
+++ b/inc/core/actions/save.php
@@ -31,6 +31,15 @@ function ec_handle_link_page_save( $link_page_id, $save_data = array(), $files_d
         
     }
 
+    // Short bio displayed on the public link page.
+    if ( array_key_exists( 'bio', $save_data ) ) {
+        if ( $save_data['bio'] === '' || $save_data['bio'] === null ) {
+            delete_post_meta( $link_page_id, '_link_page_bio_text' );
+        } else {
+            update_post_meta( $link_page_id, '_link_page_bio_text', $save_data['bio'] );
+        }
+    }
+
     // Advanced settings (Advanced tab fields only)
     $advanced_fields = array(
         'link_expiration_enabled' => '_link_expiration_enabled',
@@ -135,6 +144,84 @@ function ec_handle_link_page_save_completion( $link_page_id ) {
     }
 }
 add_action( 'ec_link_page_save', 'ec_handle_link_page_save_completion', 10, 1 );
+
+/**
+ * Get public URLs for a link page on the extrachill.link domain.
+ *
+ * @param int $link_page_id The link page post ID.
+ * @return string[] Public link page URLs.
+ */
+function ec_get_link_page_public_urls( $link_page_id ) {
+    if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+        return array();
+    }
+
+    $slug = get_post_field( 'post_name', $link_page_id );
+    if ( ! $slug ) {
+        return array();
+    }
+
+    $urls = array( 'https://extrachill.link/' . rawurlencode( $slug ) . '/' );
+
+    if ( 'extra-chill' === $slug ) {
+        $urls[] = 'https://extrachill.link/';
+    }
+
+    return $urls;
+}
+
+/**
+ * Include public link page URLs when Breeze purges a link page post.
+ *
+ * @param string[] $urls    URLs queued for purge.
+ * @param int      $post_id Post ID being purged.
+ * @param string   $context Purge context.
+ * @return string[] URLs queued for purge.
+ */
+function ec_add_link_page_urls_to_breeze_purge( $urls, $post_id, $context ) {
+    if ( get_post_type( $post_id ) !== 'artist_link_page' ) {
+        return $urls;
+    }
+
+    return array_merge( $urls, ec_get_link_page_public_urls( $post_id ) );
+}
+add_filter( 'breeze_purge_post_cache_urls', 'ec_add_link_page_urls_to_breeze_purge', 10, 3 );
+
+/**
+ * Request cache purge after link page saves.
+ *
+ * @param int $link_page_id The saved link page ID.
+ */
+function ec_purge_link_page_cache( $link_page_id ) {
+    $urls = ec_get_link_page_public_urls( $link_page_id );
+    if ( empty( $urls ) ) {
+        return;
+    }
+
+    if ( function_exists( 'breeze_get_filesystem' ) && function_exists( 'breeze_get_cache_base_path' ) ) {
+        $wp_filesystem = breeze_get_filesystem();
+        foreach ( $urls as $url ) {
+            $cache_path = breeze_get_cache_base_path() . hash( 'sha512', $url );
+            if ( $wp_filesystem->exists( $cache_path ) ) {
+                $wp_filesystem->rmdir( $cache_path, true );
+            }
+        }
+    }
+
+    if ( class_exists( 'Breeze_CloudFlare_Helper' ) && method_exists( 'Breeze_CloudFlare_Helper', 'purge_cloudflare_cache_urls' ) ) {
+        Breeze_CloudFlare_Helper::purge_cloudflare_cache_urls( $urls );
+    }
+
+    if ( class_exists( 'Breeze_PurgeVarnish' ) ) {
+        $varnish = new Breeze_PurgeVarnish();
+        foreach ( $urls as $url ) {
+            $varnish->purge_cache( untrailingslashit( $url ) . '/?breeze' );
+        }
+    }
+
+    do_action( 'ec_link_page_cache_purged', $link_page_id, $urls );
+}
+add_action( 'ec_link_page_save', 'ec_purge_link_page_cache', 20, 1 );
 
 
 /**

--- a/src/blocks/link-page-editor/context/EditorContext.js
+++ b/src/blocks/link-page-editor/context/EditorContext.js
@@ -99,7 +99,6 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 				promises.push(
 					artistData.update( {
 						name: artistData.artist?.name,
-						bio: artistData.artist?.bio,
 						profile_image_id: artistData.artist?.profile_image_id,
 					} )
 				);
@@ -109,7 +108,7 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 				promises.push(
 					linksData.update( {
 						links: linksData.links,
-						settings: linksData.settings,
+						settings: { ...linksData.settings, bio: linksData.bio },
 						css_vars: linksData.cssVars,
 						background_image_id: linksData.backgroundImageId,
 					} )
@@ -221,13 +220,18 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 		return getGoogleFontsUrl( fontValues, fonts );
 	}, [ linksData.rawFontValues, fonts ] );
 
+	const editorArtist = useMemo(
+		() => artistData.artist ? { ...artistData.artist, bio: linksData.bio || '' } : null,
+		[ artistData.artist, linksData.bio ]
+	);
+
 	/**
 	 * Preview data - structured data for the Preview component.
 	 */
 	const previewData = useMemo(
 		() => ( {
 			name: artistData.artist?.name || '',
-			bio: artistData.artist?.bio || '',
+			bio: linksData.bio || '',
 			profileImageUrl: artistData.artist?.profile_image_url || '',
 			profileShape: linksData.settings?.profile_image_shape || 'circle',
 			links: linksData.links || [],
@@ -237,7 +241,7 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 			overlayEnabled: linksData.cssVars?.overlay !== '0',
 			backgroundType: linksData.cssVars?.[ '--link-page-background-type' ] || 'color',
 		} ),
-		[ artistData.artist, linksData.links, linksData.settings, linksData.cssVars, socialsData.socials ]
+		[ artistData.artist, linksData.bio, linksData.links, linksData.settings, linksData.cssVars, socialsData.socials ]
 	);
 
 	const value = useMemo(
@@ -251,14 +255,14 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 			saveError,
 			hasUnsavedChanges,
 
-			artist: artistData.artist,
+			artist: editorArtist,
 			setName: ( name ) => {
 				artistData.setName( name );
 				markDirty( 'artist' );
 			},
 			setBio: ( bio ) => {
-				artistData.setBio( bio );
-				markDirty( 'artist' );
+				linksData.updateLocalBio( bio );
+				markDirty( 'links' );
 			},
 			setProfileImage: ( id, url ) => {
 				artistData.setProfileImage( id, url );
@@ -334,6 +338,7 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 			linksData,
 			socialsData,
 			mediaUpload,
+			editorArtist,
 			config.userArtists,
 			fonts,
 			config.socialTypes,

--- a/src/blocks/link-page-editor/hooks/useArtist.js
+++ b/src/blocks/link-page-editor/hooks/useArtist.js
@@ -1,7 +1,7 @@
 /**
  * useArtist Hook
  *
- * Manages artist core data (name, bio, profile image).
+ * Manages artist core data (name and profile image).
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
@@ -67,19 +67,9 @@ export default function useArtist( artistId ) {
 		[ artistId ]
 	);
 
-	const setName = useCallback(
-		( name ) => {
-			setArtist( ( prev ) => ( { ...prev, name } ) );
-		},
-		[]
-	);
-
-	const setBio = useCallback(
-		( bio ) => {
-			setArtist( ( prev ) => ( { ...prev, bio } ) );
-		},
-		[]
-	);
+	const setName = useCallback( ( name ) => {
+		setArtist( ( prev ) => ( { ...prev, name } ) );
+	}, [] );
 
 	const setProfileImage = useCallback(
 		( profileImageId, profileImageUrl ) => {
@@ -99,7 +89,6 @@ export default function useArtist( artistId ) {
 		refetch: fetchArtist,
 		update,
 		setName,
-		setBio,
 		setProfileImage,
 	};
 }

--- a/src/blocks/link-page-editor/hooks/useLinks.js
+++ b/src/blocks/link-page-editor/hooks/useLinks.js
@@ -1,7 +1,7 @@
 /**
  * useLinks Hook
  *
- * Manages link page data (links, settings, cssVars, rawFontValues).
+ * Manages link page data (bio, links, settings, cssVars, rawFontValues).
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
@@ -9,6 +9,7 @@ import { getLinks, updateLinks, getConfig } from '../../shared/api/client';
 
 export default function useLinks( artistId ) {
 	const [ links, setLinks ] = useState( [] );
+	const [ bio, setBio ] = useState( '' );
 	const [ settings, setSettings ] = useState( {} );
 	const [ cssVars, setCssVars ] = useState( {} );
 	const [ rawFontValues, setRawFontValues ] = useState( {
@@ -39,9 +40,12 @@ export default function useLinks( artistId ) {
 		try {
 			const data = await getLinks( artistId );
 			setLinks( data.links || [] );
+			setBio( data.bio || '' );
 			setSettings( data.settings || {} );
 			setCssVars( data.css_vars || {} );
-			setRawFontValues( data.raw_font_values || { title_font: '', body_font: '' } );
+			setRawFontValues(
+				data.raw_font_values || { title_font: '', body_font: '' }
+			);
 			setBackgroundImageId( data.background_image_id || null );
 			setBackgroundImageUrl( data.background_image_url || null );
 		} catch ( err ) {
@@ -70,9 +74,12 @@ export default function useLinks( artistId ) {
 			try {
 				const updated = await updateLinks( artistId, data );
 				setLinks( updated.links || [] );
+				setBio( updated.bio || '' );
 				setSettings( updated.settings || {} );
 				setCssVars( updated.css_vars || {} );
-				setRawFontValues( updated.raw_font_values || { title_font: '', body_font: '' } );
+				setRawFontValues(
+					updated.raw_font_values || { title_font: '', body_font: '' }
+				);
 				setBackgroundImageId( updated.background_image_id || null );
 				setBackgroundImageUrl( updated.background_image_url || null );
 				return updated;
@@ -86,6 +93,10 @@ export default function useLinks( artistId ) {
 
 	const updateLocalLinks = useCallback( ( newLinks ) => {
 		setLinks( newLinks );
+	}, [] );
+
+	const updateLocalBio = useCallback( ( newBio ) => {
+		setBio( newBio );
 	}, [] );
 
 	const updateLocalSettings = useCallback( ( newSettings ) => {
@@ -107,6 +118,7 @@ export default function useLinks( artistId ) {
 
 	return {
 		links,
+		bio,
 		settings,
 		cssVars,
 		rawFontValues,
@@ -117,6 +129,7 @@ export default function useLinks( artistId ) {
 		refetch: fetchLinks,
 		update,
 		updateLocalLinks,
+		updateLocalBio,
 		updateLocalSettings,
 		updateLocalCssVars,
 		updateLocalRawFontValues,


### PR DESCRIPTION
## Summary
- Save the link page editor bio to `_link_page_bio_text` instead of artist profile `post_content`.
- Read and preview the link page short bio from the link-page data payload.
- Purge the public `extrachill.link` URL after link page saves.

Closes #22.

## Testing
- `php -l inc/abilities/helpers.php inc/abilities/handlers/save-link-page-settings.php inc/abilities/registry.php inc/core/actions/save.php`
- `git diff --check`
- `npm run build`

## Notes
- Existing misrouted bios are not backfilled automatically. Sarah Summer's page needs one targeted data repair: copy artist profile `post_content` from post `12151` into link page `12152` meta `_link_page_bio_text`, then purge that public link page URL.
- Helper copy is tracked separately in #24 because this PR merged before that follow-up commit landed.
- `npm run lint:js` still fails on existing repo-wide formatter/a11y issues unrelated to this patch.