### PR TITLE
feat(abilities): register artist-domain abilities (#27)

### DIFF
--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -21,3 +21,19 @@ require_once __DIR__ . '/handlers/save-link-page-links.php';
 require_once __DIR__ . '/handlers/save-link-page-styles.php';
 require_once __DIR__ . '/handlers/save-link-page-settings.php';
 require_once __DIR__ . '/handlers/save-social-links.php';
+
+// Artist-domain ability handlers (issue #27).
+require_once __DIR__ . '/handlers/artists-list.php';
+require_once __DIR__ . '/handlers/artist-get.php';
+require_once __DIR__ . '/handlers/artist-get-links.php';
+require_once __DIR__ . '/handlers/artist-update-links.php';
+require_once __DIR__ . '/handlers/artist-get-permissions.php';
+require_once __DIR__ . '/handlers/artist-get-roster.php';
+require_once __DIR__ . '/handlers/artist-list-socials.php';
+require_once __DIR__ . '/handlers/artist-create-social.php';
+require_once __DIR__ . '/handlers/artist-update-social.php';
+require_once __DIR__ . '/handlers/artist-delete-social.php';
+require_once __DIR__ . '/handlers/artist-subscribe.php';
+require_once __DIR__ . '/handlers/artist-list-subscribers.php';
+require_once __DIR__ . '/handlers/artist-export-subscribers.php';
+require_once __DIR__ . '/handlers/artist-get-analytics.php';

--- a/inc/abilities/category.php
+++ b/inc/abilities/category.php
@@ -9,7 +9,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Register artist platform ability category.
+ * Register artist platform ability categories.
  */
 function extrachill_artist_platform_register_category() {
 	wp_register_ability_category(
@@ -17,6 +17,14 @@ function extrachill_artist_platform_register_category() {
 		array(
 			'label'       => __( 'Artist Platform', 'extrachill-artist-platform' ),
 			'description' => __( 'Artist profile and link page management for Extra Chill.', 'extrachill-artist-platform' ),
+		)
+	);
+
+	wp_register_ability_category(
+		'extrachill-artists',
+		array(
+			'label'       => __( 'Artists', 'extrachill-artist-platform' ),
+			'description' => __( 'Artist-domain abilities: profiles, links, socials, subscribers, analytics.', 'extrachill-artist-platform' ),
 		)
 	);
 }

--- a/inc/abilities/handlers/artist-create-social.php
+++ b/inc/abilities/handlers/artist-create-social.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-create-social
+ *
+ * Adds a single social link to an artist profile.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Create (append) a social link for an artist.
+ *
+ * @param array $input {
+ *     @type int    $id   Artist profile post ID.
+ *     @type string $type Social platform type.
+ *     @type string $url  Social link URL.
+ * }
+ * @return array|WP_Error Updated social links.
+ */
+function extrachill_artist_platform_ability_artist_create_social( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$type      = isset( $input['type'] ) ? sanitize_text_field( $input['type'] ) : '';
+	$url       = isset( $input['url'] ) ? esc_url_raw( $input['url'] ) : '';
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	if ( empty( $type ) || empty( $url ) ) {
+		return new WP_Error( 'missing_fields', 'type and url are required.' );
+	}
+
+	if ( ! function_exists( 'extrachill_artist_platform_social_links' ) ) {
+		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
+	}
+
+	$social_manager = extrachill_artist_platform_social_links();
+	$existing       = $social_manager->get( $artist_id );
+
+	if ( ! is_array( $existing ) ) {
+		$existing = array();
+	}
+
+	// Append the new social link (ID will be assigned during sanitize).
+	$existing[] = array(
+		'id'   => '',
+		'type' => $type,
+		'url'  => $url,
+	);
+
+	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
+
+	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
+	$result    = $social_manager->save( $artist_id, $sanitized );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	// Build enriched response.
+	$saved_socials = $social_manager->get( $artist_id );
+	$enriched      = array();
+
+	if ( is_array( $saved_socials ) ) {
+		foreach ( $saved_socials as $social_link ) {
+			if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
+				continue;
+			}
+			$social_link['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
+			$enriched[]                = $social_link;
+		}
+	}
+
+	return array( 'social_links' => $enriched );
+}

--- a/inc/abilities/handlers/artist-delete-social.php
+++ b/inc/abilities/handlers/artist-delete-social.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-delete-social
+ *
+ * Removes a single social link from an artist profile.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Delete a single social link by social_id.
+ *
+ * @param array $input {
+ *     @type int    $id        Artist profile post ID.
+ *     @type string $social_id Social link ID to delete.
+ * }
+ * @return array|WP_Error Updated social links.
+ */
+function extrachill_artist_platform_ability_artist_delete_social( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$social_id = isset( $input['social_id'] ) ? sanitize_text_field( $input['social_id'] ) : '';
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	if ( empty( $social_id ) ) {
+		return new WP_Error( 'missing_social_id', 'social_id is required.' );
+	}
+
+	if ( ! function_exists( 'extrachill_artist_platform_social_links' ) ) {
+		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
+	}
+
+	$social_manager = extrachill_artist_platform_social_links();
+	$existing       = $social_manager->get( $artist_id );
+
+	if ( ! is_array( $existing ) ) {
+		return new WP_Error( 'not_found', 'Social link not found.' );
+	}
+
+	$filtered = array();
+	$found    = false;
+	foreach ( $existing as $social_link ) {
+		if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
+			$found = true;
+			continue; // Skip this one (delete it).
+		}
+		$filtered[] = $social_link;
+	}
+
+	if ( ! $found ) {
+		return new WP_Error( 'not_found', 'Social link not found.' );
+	}
+
+	$result = $social_manager->save( $artist_id, $filtered );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	// Build enriched response.
+	$saved_socials = $social_manager->get( $artist_id );
+	$enriched      = array();
+
+	if ( is_array( $saved_socials ) ) {
+		foreach ( $saved_socials as $s ) {
+			if ( ! is_array( $s ) || empty( $s['type'] ) || empty( $s['id'] ) ) {
+				continue;
+			}
+			$s['icon_class'] = $social_manager->get_icon_class( $s['type'], $s );
+			$enriched[]      = $s;
+		}
+	}
+
+	return array(
+		'deleted'      => true,
+		'social_id'    => $social_id,
+		'social_links' => $enriched,
+	);
+}

--- a/inc/abilities/handlers/artist-export-subscribers.php
+++ b/inc/abilities/handlers/artist-export-subscribers.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-export-subscribers
+ *
+ * Returns all subscribers for client-side CSV generation.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Export all subscribers for an artist.
+ *
+ * @param array $input {
+ *     @type int  $id               Artist profile post ID.
+ *     @type bool $include_exported Whether to include already exported subscribers (default false).
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_export_subscribers( array $input ): array|WP_Error {
+	$artist_id        = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$include_exported = ! empty( $input['include_exported'] );
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', __( 'Invalid artist specified.', 'extrachill-artist-platform' ) );
+	}
+
+	if ( ! function_exists( 'extrachill_artist_get_artist_subscribers' ) ) {
+		return new WP_Error( 'dependency_missing', 'Subscriber functions not available.' );
+	}
+
+	$exported_filter = $include_exported ? null : 0;
+
+	$subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array(
+		'limit'    => -1,
+		'exported' => $exported_filter,
+	) );
+
+	$subscriber_ids_to_mark = array();
+	$export_data            = array();
+
+	foreach ( $subscribers as $subscriber ) {
+		$is_exported = isset( $subscriber->exported ) && $subscriber->exported == 1;
+
+		$export_data[] = array(
+			'email'         => $subscriber->subscriber_email,
+			'username'      => $subscriber->username ?? '',
+			'subscribed_at' => $subscriber->subscribed_at,
+			'exported'      => $is_exported,
+		);
+
+		if ( ! $is_exported && ! $include_exported ) {
+			$subscriber_ids_to_mark[] = $subscriber->subscriber_id;
+		}
+	}
+
+	// Mark newly exported subscribers.
+	if ( ! $include_exported && ! empty( $subscriber_ids_to_mark ) ) {
+		global $wpdb;
+		$table      = $wpdb->prefix . 'artist_subscribers';
+		$ids_string = implode( ', ', array_map( 'absint', $subscriber_ids_to_mark ) );
+		$wpdb->query( "UPDATE {$table} SET exported = 1 WHERE subscriber_id IN ({$ids_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	$artist_name = get_the_title( $artist_id );
+
+	return array(
+		'subscribers'  => $export_data,
+		'artist_name'  => $artist_name,
+		'export_date'  => current_time( 'Y-m-d' ),
+		'total'        => count( $export_data ),
+		'marked_count' => count( $subscriber_ids_to_mark ),
+	);
+}

--- a/inc/abilities/handlers/artist-get-analytics.php
+++ b/inc/abilities/handlers/artist-get-analytics.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-get-analytics
+ *
+ * Returns link page analytics for an artist.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get link page analytics for an artist.
+ *
+ * @param array $input {
+ *     @type int $id         Artist profile post ID.
+ *     @type int $date_range Number of days to query (default 30, max 90).
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_get_analytics( array $input ): array|WP_Error {
+	$artist_id  = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$date_range = isset( $input['date_range'] ) ? (int) $input['date_range'] : 30;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( ! function_exists( 'ec_get_link_page_for_artist' ) ) {
+		return new WP_Error( 'dependency_missing', 'Artist platform not active.' );
+	}
+
+	$link_page_id = ec_get_link_page_for_artist( $artist_id );
+
+	if ( ! $link_page_id ) {
+		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
+	}
+
+	$date_range = max( 1, min( 90, $date_range ) );
+
+	/**
+	 * Retrieve link page analytics via filter hook.
+	 *
+	 * @param mixed $result       Previous filter result (null if no handler).
+	 * @param int   $link_page_id The link page post ID.
+	 * @param int   $date_range   Number of days to query.
+	 */
+	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	if ( ! is_array( $result ) ) {
+		return new WP_Error( 'analytics_unavailable', 'Analytics data could not be retrieved.' );
+	}
+
+	return $result;
+}

--- a/inc/abilities/handlers/artist-get-links.php
+++ b/inc/abilities/handlers/artist-get-links.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-get-links
+ *
+ * Retrieves complete link page data for an artist.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get complete link page data for an artist.
+ *
+ * @param array $input { @type int $id Artist profile post ID. }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_get_links( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( ! function_exists( 'ec_get_link_page_data' ) ) {
+		return new WP_Error( 'dependency_missing', 'Link page data function not available.' );
+	}
+
+	$data = ec_get_link_page_data( $artist_id );
+
+	if ( empty( $data ) || empty( $data['link_page_id'] ) ) {
+		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
+	}
+
+	return $data;
+}

--- a/inc/abilities/handlers/artist-get-permissions.php
+++ b/inc/abilities/handlers/artist-get-permissions.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-get-permissions
+ *
+ * Checks current user permissions for an artist profile.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Check current user permissions for an artist.
+ *
+ * @param array $input { @type int $id Artist profile post ID. }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_get_permissions( array $input ): array|WP_Error {
+	$artist_id       = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$current_user_id = get_current_user_id();
+	$can_edit        = false;
+	$manage_url      = '';
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( $artist_id && $current_user_id && function_exists( 'ec_can_manage_artist' ) && ec_can_manage_artist( $current_user_id, $artist_id ) ) {
+		$can_edit   = true;
+		$manage_url = home_url( '/manage-link-page/' );
+	}
+
+	return array(
+		'can_edit'   => $can_edit,
+		'manage_url' => $manage_url,
+		'user_id'    => $current_user_id,
+	);
+}

--- a/inc/abilities/handlers/artist-get-roster.php
+++ b/inc/abilities/handlers/artist-get-roster.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-get-roster
+ *
+ * Lists linked members and pending invites for an artist.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get roster (members + pending invites) for an artist.
+ *
+ * @param array $input { @type int $id Artist profile post ID. }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_get_roster( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Invalid artist specified.' );
+	}
+
+	// Build members list.
+	$members = array();
+	if ( function_exists( 'ec_get_linked_members' ) ) {
+		$linked_members = ec_get_linked_members( $artist_id );
+		if ( is_array( $linked_members ) ) {
+			foreach ( $linked_members as $member ) {
+				$user_info = get_userdata( $member->ID );
+				if ( $user_info ) {
+					$members[] = array(
+						'id'           => (int) $user_info->ID,
+						'display_name' => $user_info->display_name,
+						'username'     => $user_info->user_login,
+						'email'        => $user_info->user_email,
+						'avatar_url'   => get_avatar_url( $user_info->ID, array( 'size' => 60 ) ),
+						'profile_url'  => function_exists( 'extrachill_get_user_profile_url' )
+							? extrachill_get_user_profile_url( $user_info->ID, $user_info->user_email )
+							: '',
+					);
+				}
+			}
+		}
+	}
+
+	// Build pending invites list.
+	$invites = array();
+	if ( function_exists( 'ec_get_pending_invitations' ) ) {
+		$pending = ec_get_pending_invitations( $artist_id );
+		if ( is_array( $pending ) ) {
+			foreach ( $pending as $invite ) {
+				$invited_on = isset( $invite['invited_on'] ) ? (int) $invite['invited_on'] : 0;
+				$invites[]  = array(
+					'id'                   => $invite['id'] ?? '',
+					'email'                => $invite['email'] ?? '',
+					'of_existing_user'     => email_exists( $invite['email'] ?? '' ) ? true : false,
+					'status'               => $invite['status'] ?? '',
+					'invited_on'           => $invited_on,
+					'invited_on_formatted' => $invited_on ? date_i18n( get_option( 'date_format' ), $invited_on ) : '',
+				);
+			}
+		}
+	}
+
+	return array(
+		'members' => $members,
+		'invites' => $invites,
+	);
+}

--- a/inc/abilities/handlers/artist-get.php
+++ b/inc/abilities/handlers/artist-get.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-get
+ *
+ * Returns a single artist profile payload.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get a single artist profile by ID.
+ *
+ * @param array $input { @type int $id Artist profile post ID. }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_get( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$did_switch     = false;
+
+	if ( $artist_blog_id && get_current_blog_id() !== $artist_blog_id ) {
+		switch_to_blog( $artist_blog_id );
+		$did_switch = true;
+	}
+
+	$artist = get_post( $artist_id );
+
+	if ( ! $artist || $artist->post_type !== 'artist_profile' ) {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	$local_city = get_post_meta( $artist_id, '_local_city', true );
+	$genre      = get_post_meta( $artist_id, '_genre', true );
+
+	$profile_image_id  = get_post_thumbnail_id( $artist_id );
+	$profile_image_url = $profile_image_id ? wp_get_attachment_image_url( (int) $profile_image_id, 'medium' ) : null;
+
+	$header_image_id  = get_post_meta( $artist_id, '_artist_profile_header_image_id', true );
+	$header_image_url = $header_image_id ? wp_get_attachment_image_url( (int) $header_image_id, 'large' ) : null;
+
+	$link_page_id = null;
+	if ( function_exists( 'ec_get_link_page_id' ) ) {
+		$link_page_id = ec_get_link_page_id( $artist_id );
+	}
+
+	if ( $did_switch ) {
+		restore_current_blog();
+	}
+
+	return array(
+		'id'                => (int) $artist_id,
+		'name'              => $artist->post_title,
+		'slug'              => $artist->post_name,
+		'bio'               => $artist->post_content,
+		'local_city'        => $local_city !== '' ? $local_city : null,
+		'genre'             => $genre !== '' ? $genre : null,
+		'profile_image_id'  => $profile_image_id ? (int) $profile_image_id : null,
+		'profile_image_url' => $profile_image_url,
+		'header_image_id'   => $header_image_id ? (int) $header_image_id : null,
+		'header_image_url'  => $header_image_url,
+		'link_page_id'      => $link_page_id ? (int) $link_page_id : null,
+	);
+}

--- a/inc/abilities/handlers/artist-list-socials.php
+++ b/inc/abilities/handlers/artist-list-socials.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-list-socials
+ *
+ * Lists social links for an artist profile.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List social links for an artist.
+ *
+ * @param array $input { @type int $id Artist profile post ID. }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_list_socials( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	$social_links = array();
+
+	if ( function_exists( 'extrachill_artist_platform_social_links' ) ) {
+		$social_manager = extrachill_artist_platform_social_links();
+		$social_links   = $social_manager->get( $artist_id );
+
+		if ( is_array( $social_links ) ) {
+			foreach ( $social_links as $index => $social_link ) {
+				if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
+					continue;
+				}
+				$social_links[ $index ]['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
+			}
+		}
+	}
+
+	return array(
+		'social_links' => is_array( $social_links ) ? $social_links : array(),
+	);
+}

--- a/inc/abilities/handlers/artist-list-subscribers.php
+++ b/inc/abilities/handlers/artist-list-subscribers.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-list-subscribers
+ *
+ * Returns paginated subscriber list for an artist.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List subscribers for an artist (paginated).
+ *
+ * @param array $input {
+ *     @type int $id       Artist profile post ID.
+ *     @type int $page     Page number (default 1).
+ *     @type int $per_page Results per page (default 20, max 100).
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_list_subscribers( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$page      = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+	$per_page  = isset( $input['per_page'] ) ? max( 1, min( 100, (int) $input['per_page'] ) ) : 20;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', __( 'Invalid artist specified.', 'extrachill-artist-platform' ) );
+	}
+
+	if ( ! function_exists( 'extrachill_artist_get_artist_subscribers' ) ) {
+		return new WP_Error( 'dependency_missing', 'Subscriber functions not available.' );
+	}
+
+	$offset      = ( $page - 1 ) * $per_page;
+	$subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array(
+		'limit'  => $per_page,
+		'offset' => $offset,
+	) );
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'artist_subscribers';
+	$total = (int) $wpdb->get_var(
+		$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d", $artist_id )
+	);
+
+	return array(
+		'subscribers' => $subscribers,
+		'total'       => $total,
+		'per_page'    => $per_page,
+		'page'        => $page,
+	);
+}

--- a/inc/abilities/handlers/artist-subscribe.php
+++ b/inc/abilities/handlers/artist-subscribe.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-subscribe
+ *
+ * Public subscription to an artist's updates.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Subscribe an email address to an artist.
+ *
+ * @param array $input {
+ *     @type int    $id    Artist profile post ID.
+ *     @type string $email Subscriber email address.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_subscribe( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$email     = isset( $input['email'] ) ? sanitize_email( $input['email'] ) : '';
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( ! is_email( $email ) ) {
+		return new WP_Error( 'invalid_email', __( 'Please enter a valid email address.', 'extrachill-artist-platform' ) );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', __( 'Invalid artist specified.', 'extrachill-artist-platform' ) );
+	}
+
+	global $wpdb;
+	$table = $wpdb->prefix . 'artist_subscribers';
+
+	// Check for existing subscription.
+	$exists = $wpdb->get_var(
+		$wpdb->prepare(
+			"SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d AND subscriber_email = %s",
+			$artist_id,
+			$email
+		)
+	);
+
+	if ( $exists ) {
+		return new WP_Error(
+			'already_subscribed',
+			__( 'You are already subscribed to this artist.', 'extrachill-artist-platform' ),
+			array( 'status' => 409 )
+		);
+	}
+
+	// Insert new subscriber.
+	$inserted = $wpdb->insert(
+		$table,
+		array(
+			'artist_profile_id' => $artist_id,
+			'subscriber_email'  => $email,
+			'username'          => '',
+			'subscribed_at'     => current_time( 'mysql', 1 ),
+			'exported'          => 0,
+		),
+		array( '%d', '%s', '%s', '%s', '%d' )
+	);
+
+	if ( ! $inserted ) {
+		return new WP_Error(
+			'subscription_failed',
+			__( 'Could not save your subscription. Please try again later.', 'extrachill-artist-platform' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	return array(
+		'message' => __( 'Thank you for subscribing!', 'extrachill-artist-platform' ),
+	);
+}

--- a/inc/abilities/handlers/artist-update-links.php
+++ b/inc/abilities/handlers/artist-update-links.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-update-links
+ *
+ * Updates link page data (links, styles, settings, socials) for an artist.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Update link page data for an artist. Supports partial updates.
+ *
+ * @param array $input {
+ *     @type int    $id       Artist profile post ID.
+ *     @type array  $links    Link sections with nested links.
+ *     @type array  $css_vars CSS variables.
+ *     @type array  $settings Advanced settings.
+ *     @type array  $socials  Social link objects.
+ *     @type int    $background_image_id Background image attachment ID.
+ *     @type int    $profile_image_id    Profile image attachment ID.
+ *     @type string $bio      Short bio for the link page.
+ * }
+ * @return array|WP_Error Fresh link page data on success.
+ */
+function extrachill_artist_platform_ability_artist_update_links( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	// Save links.
+	if ( isset( $input['links'] ) ) {
+		if ( ! is_array( $input['links'] ) ) {
+			return new WP_Error( 'invalid_format', 'links must be an array.' );
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-link-page-links' ) : null;
+		if ( $ability ) {
+			$result = $ability->execute( array(
+				'artist_id' => $artist_id,
+				'links'     => $input['links'],
+			) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+	}
+
+	// Save CSS vars.
+	if ( isset( $input['css_vars'] ) ) {
+		if ( ! is_array( $input['css_vars'] ) ) {
+			return new WP_Error( 'invalid_format', 'css_vars must be an object.' );
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-link-page-styles' ) : null;
+		if ( $ability ) {
+			$result = $ability->execute( array(
+				'artist_id' => $artist_id,
+				'css_vars'  => $input['css_vars'],
+			) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+	}
+
+	// Save settings.
+	$has_settings = isset( $input['settings'] ) || isset( $input['background_image_id'] ) || isset( $input['profile_image_id'] ) || isset( $input['bio'] );
+	if ( $has_settings ) {
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-link-page-settings' ) : null;
+		if ( $ability ) {
+			$settings_input = array( 'artist_id' => $artist_id );
+			if ( isset( $input['settings'] ) ) {
+				$settings_input['settings'] = $input['settings'];
+			}
+			if ( isset( $input['background_image_id'] ) ) {
+				$settings_input['background_image_id'] = (int) $input['background_image_id'];
+			}
+			if ( isset( $input['profile_image_id'] ) ) {
+				$settings_input['profile_image_id'] = (int) $input['profile_image_id'];
+			}
+			if ( isset( $input['bio'] ) ) {
+				$settings_input['bio'] = $input['bio'];
+			}
+
+			$result = $ability->execute( $settings_input );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+	}
+
+	// Save socials.
+	if ( isset( $input['socials'] ) ) {
+		if ( ! is_array( $input['socials'] ) ) {
+			return new WP_Error( 'invalid_format', 'socials must be an array.' );
+		}
+
+		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-social-links' ) : null;
+		if ( $ability ) {
+			$result = $ability->execute( array(
+				'artist_id'    => $artist_id,
+				'social_links' => $input['socials'],
+			) );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+	}
+
+	// Return fresh data.
+	if ( ! function_exists( 'ec_get_link_page_data' ) ) {
+		return new WP_Error( 'dependency_missing', 'Link page data function not available.' );
+	}
+
+	$fresh_data = ec_get_link_page_data( $artist_id );
+
+	if ( empty( $fresh_data ) || empty( $fresh_data['link_page_id'] ) ) {
+		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
+	}
+
+	return $fresh_data;
+}

--- a/inc/abilities/handlers/artist-update-social.php
+++ b/inc/abilities/handlers/artist-update-social.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artist-update-social
+ *
+ * Updates a single social link on an artist profile.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Update a single social link by social_id.
+ *
+ * @param array $input {
+ *     @type int    $id        Artist profile post ID.
+ *     @type string $social_id Social link ID to update.
+ *     @type string $type      Social platform type (optional).
+ *     @type string $url       Social link URL (optional).
+ * }
+ * @return array|WP_Error Updated social links.
+ */
+function extrachill_artist_platform_ability_artist_update_social( array $input ): array|WP_Error {
+	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
+	$social_id = isset( $input['social_id'] ) ? sanitize_text_field( $input['social_id'] ) : '';
+
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist', 'Artist not found.' );
+	}
+
+	if ( empty( $social_id ) ) {
+		return new WP_Error( 'missing_social_id', 'social_id is required.' );
+	}
+
+	if ( ! function_exists( 'extrachill_artist_platform_social_links' ) ) {
+		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
+	}
+
+	$social_manager = extrachill_artist_platform_social_links();
+	$existing       = $social_manager->get( $artist_id );
+
+	if ( ! is_array( $existing ) ) {
+		return new WP_Error( 'not_found', 'Social link not found.' );
+	}
+
+	$found = false;
+	foreach ( $existing as &$social_link ) {
+		if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
+			if ( isset( $input['type'] ) ) {
+				$social_link['type'] = sanitize_text_field( $input['type'] );
+			}
+			if ( isset( $input['url'] ) ) {
+				$social_link['url'] = esc_url_raw( $input['url'] );
+			}
+			$found = true;
+			break;
+		}
+	}
+	unset( $social_link );
+
+	if ( ! $found ) {
+		return new WP_Error( 'not_found', 'Social link not found.' );
+	}
+
+	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
+
+	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
+	$result    = $social_manager->save( $artist_id, $sanitized );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	// Build enriched response.
+	$saved_socials = $social_manager->get( $artist_id );
+	$enriched      = array();
+
+	if ( is_array( $saved_socials ) ) {
+		foreach ( $saved_socials as $s ) {
+			if ( ! is_array( $s ) || empty( $s['type'] ) || empty( $s['id'] ) ) {
+				continue;
+			}
+			$s['icon_class'] = $social_manager->get_icon_class( $s['type'], $s );
+			$enriched[]      = $s;
+		}
+	}
+
+	return array( 'social_links' => $enriched );
+}

--- a/inc/abilities/handlers/artists-list.php
+++ b/inc/abilities/handlers/artists-list.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/artists-list
+ *
+ * Lists all published artist profiles sorted by recent activity.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List all published artist profiles.
+ *
+ * @param array $input {
+ *     @type int    $page     Page number (default 1).
+ *     @type int    $per_page Results per page (default 24, max 100).
+ *     @type string $search   Optional search term to filter by title.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artists_list( array $input ): array|WP_Error {
+	$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+	$per_page = isset( $input['per_page'] ) ? max( 1, min( 100, (int) $input['per_page'] ) ) : 24;
+	$search   = isset( $input['search'] ) ? sanitize_text_field( $input['search'] ) : '';
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$did_switch     = false;
+
+	if ( $artist_blog_id && get_current_blog_id() !== $artist_blog_id ) {
+		switch_to_blog( $artist_blog_id );
+		$did_switch = true;
+	}
+
+	$query_args = array(
+		'post_type'      => 'artist_profile',
+		'post_status'    => 'publish',
+		'posts_per_page' => $per_page,
+		'paged'          => $page,
+		'orderby'        => 'modified',
+		'order'          => 'DESC',
+	);
+
+	if ( $search !== '' ) {
+		$query_args['s'] = $search;
+	}
+
+	$query   = new WP_Query( $query_args );
+	$artists = array();
+
+	if ( $query->have_posts() ) {
+		while ( $query->have_posts() ) {
+			$query->the_post();
+			$artist_id = get_the_ID();
+
+			$profile_image_id  = get_post_thumbnail_id( $artist_id );
+			$profile_image_url = $profile_image_id
+				? wp_get_attachment_image_url( (int) $profile_image_id, 'medium' )
+				: null;
+
+			$artists[] = array(
+				'id'                => (int) $artist_id,
+				'name'              => get_the_title(),
+				'slug'              => get_post_field( 'post_name', $artist_id ),
+				'local_city'        => get_post_meta( $artist_id, '_local_city', true ) ?: null,
+				'genre'             => get_post_meta( $artist_id, '_genre', true ) ?: null,
+				'profile_image_url' => $profile_image_url,
+			);
+		}
+		wp_reset_postdata();
+	}
+
+	$result = array(
+		'artists'  => $artists,
+		'total'    => (int) $query->found_posts,
+		'page'     => $page,
+		'per_page' => $per_page,
+		'pages'    => (int) $query->max_num_pages,
+	);
+
+	if ( $did_switch ) {
+		restore_current_blog();
+	}
+
+	return $result;
+}

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -352,4 +352,514 @@ function extrachill_artist_platform_register_abilities() {
 			),
 		)
 	);
+
+	// ──────────────────────────────────────────────────────────────────────
+	// Artist-domain abilities (extrachill-artists category) — issue #27
+	// ──────────────────────────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/artists-list',
+		array(
+			'label'               => __( 'List artists', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns paginated list of published artist profiles.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array(),
+				'properties'           => array(
+					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
+					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
+					'search'   => array( 'type' => 'string', 'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'artists'  => array( 'type' => 'array' ),
+					'total'    => array( 'type' => 'integer' ),
+					'page'     => array( 'type' => 'integer' ),
+					'per_page' => array( 'type' => 'integer' ),
+					'pages'    => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artists_list',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-get',
+		array(
+			'label'               => __( 'Get artist by ID', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns a single artist payload.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'id'                => array( 'type' => 'integer' ),
+					'name'              => array( 'type' => 'string' ),
+					'slug'              => array( 'type' => 'string' ),
+					'bio'               => array( 'type' => 'string' ),
+					'local_city'        => array( 'type' => array( 'string', 'null' ) ),
+					'genre'             => array( 'type' => array( 'string', 'null' ) ),
+					'profile_image_id'  => array( 'type' => array( 'integer', 'null' ) ),
+					'profile_image_url' => array( 'type' => array( 'string', 'null' ) ),
+					'header_image_id'   => array( 'type' => array( 'integer', 'null' ) ),
+					'header_image_url'  => array( 'type' => array( 'string', 'null' ) ),
+					'link_page_id'      => array( 'type' => array( 'integer', 'null' ) ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-get-links',
+		array(
+			'label'               => __( 'Get artist link page', 'extrachill-artist-platform' ),
+			'description'         => __( 'Retrieves complete link page data for an artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Complete link page data.', 'extrachill-artist-platform' ),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_links',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-update-links',
+		array(
+			'label'               => __( 'Update artist link page', 'extrachill-artist-platform' ),
+			'description'         => __( 'Updates link page data (links, styles, settings, socials).', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'                 => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'links'              => array( 'type' => 'array', 'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ) ),
+					'css_vars'           => array( 'type' => 'object', 'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ) ),
+					'settings'           => array( 'type' => 'object', 'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ) ),
+					'socials'            => array( 'type' => 'array', 'description' => __( 'Social link objects.', 'extrachill-artist-platform' ) ),
+					'background_image_id' => array( 'type' => 'integer', 'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ) ),
+					'profile_image_id'   => array( 'type' => 'integer', 'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ) ),
+					'bio'                => array( 'type' => 'string', 'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'        => 'object',
+				'description' => __( 'Fresh link page data after update.', 'extrachill-artist-platform' ),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_update_links',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-get-permissions',
+		array(
+			'label'               => __( 'Get artist permissions', 'extrachill-artist-platform' ),
+			'description'         => __( 'Checks current user permissions for an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'can_edit'   => array( 'type' => 'boolean' ),
+					'manage_url' => array( 'type' => 'string' ),
+					'user_id'    => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_permissions',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-get-roster',
+		array(
+			'label'               => __( 'Get artist roster', 'extrachill-artist-platform' ),
+			'description'         => __( 'Lists linked members and pending invites for an artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'members' => array( 'type' => 'array' ),
+					'invites' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_roster',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-list-socials',
+		array(
+			'label'               => __( 'List artist socials', 'extrachill-artist-platform' ),
+			'description'         => __( 'Lists social links for an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'social_links' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_list_socials',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-create-social',
+		array(
+			'label'               => __( 'Create artist social', 'extrachill-artist-platform' ),
+			'description'         => __( 'Adds a social link to an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id', 'type', 'url' ),
+				'properties'           => array(
+					'id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'type' => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
+					'url'  => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'social_links' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_create_social',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-update-social',
+		array(
+			'label'               => __( 'Update artist social', 'extrachill-artist-platform' ),
+			'description'         => __( 'Updates a single social link on an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id', 'social_id' ),
+				'properties'           => array(
+					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ) ),
+					'type'      => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
+					'url'       => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'social_links' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_update_social',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-delete-social',
+		array(
+			'label'               => __( 'Delete artist social', 'extrachill-artist-platform' ),
+			'description'         => __( 'Removes a social link from an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id', 'social_id' ),
+				'properties'           => array(
+					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'deleted'      => array( 'type' => 'boolean' ),
+					'social_id'    => array( 'type' => 'string' ),
+					'social_links' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_delete_social',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-subscribe',
+		array(
+			'label'               => __( 'Subscribe to artist', 'extrachill-artist-platform' ),
+			'description'         => __( 'Subscribes an email address to an artist for updates.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id', 'email' ),
+				'properties'           => array(
+					'id'    => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'email' => array( 'type' => 'string', 'format' => 'email', 'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'message' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_subscribe',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-list-subscribers',
+		array(
+			'label'               => __( 'List artist subscribers', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns paginated subscriber list for an artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'       => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
+					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'subscribers' => array( 'type' => 'array' ),
+					'total'       => array( 'type' => 'integer' ),
+					'per_page'    => array( 'type' => 'integer' ),
+					'page'        => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_list_subscribers',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-export-subscribers',
+		array(
+			'label'               => __( 'Export artist subscribers', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns all subscribers for client-side CSV generation.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'               => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'include_exported' => array( 'type' => 'boolean', 'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'subscribers'  => array( 'type' => 'array' ),
+					'artist_name'  => array( 'type' => 'string' ),
+					'export_date'  => array( 'type' => 'string' ),
+					'total'        => array( 'type' => 'integer' ),
+					'marked_count' => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_export_subscribers',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-get-analytics',
+		array(
+			'label'               => __( 'Get artist analytics', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns link page analytics for an artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array(
+					'id'         => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'date_range' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 90, 'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'summary'    => array( 'type' => 'object' ),
+					'chart_data' => array( 'type' => 'object' ),
+					'top_links'  => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_analytics',
+			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
 }


### PR DESCRIPTION
## Summary

- Registers **14 new artist-domain abilities** under the `extrachill-artists` category, each with canonical `execute_callback` implementations
- Adds the `extrachill-artists` ability category for artist-domain operations
- All abilities have `meta.show_in_rest: true` so core auto-exposes them via the abilities REST controller

## Abilities registered

| Ability | Readonly | Source endpoint |
|---------|----------|----------------|
| `extrachill/artists-list` | ✅ | `GET /artists` |
| `extrachill/artist-get` | ✅ | `GET /artists/{id}` |
| `extrachill/artist-get-links` | ✅ | `GET /artists/{id}/links` |
| `extrachill/artist-update-links` | ❌ | `PUT /artists/{id}/links` |
| `extrachill/artist-get-permissions` | ✅ | `GET /artists/{id}/permissions` |
| `extrachill/artist-get-roster` | ✅ | `GET /artists/{id}/roster` |
| `extrachill/artist-list-socials` | ✅ | `GET /artists/{id}/socials` |
| `extrachill/artist-create-social` | ❌ | `POST /artists/{id}/socials` |
| `extrachill/artist-update-social` | ❌ | `PUT /artists/{id}/socials/{social_id}` |
| `extrachill/artist-delete-social` | ❌ | `DELETE /artists/{id}/socials/{social_id}` |
| `extrachill/artist-subscribe` | ❌ | `POST /artists/{id}/subscribe` |
| `extrachill/artist-list-subscribers` | ✅ | `GET /artists/{id}/subscribers` |
| `extrachill/artist-export-subscribers` | ✅ | `GET /artists/{id}/subscribers/export` |
| `extrachill/artist-get-analytics` | ✅ | `GET /artists/{id}/analytics` |

## File layout

- One handler file per ability under `inc/abilities/handlers/`
- Registry updated in `inc/abilities/registry.php`
- Bootstrap loader updated in `inc/abilities/abilities.php`
- New `extrachill-artists` category in `inc/abilities/category.php`

## Architecture

Per [WP core's `wp_register_core_abilities()`](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/abilities.php): the ability is the source of truth. `execute_callback` IS the canonical implementation, NOT a wrapper. The branded `/extrachill/v1/artists/*` routes in extrachill-api will refactor to thin ability shims separately.

## Verification

All files pass `php -l` (zero syntax errors across 27 ability files).

Closes #27.