### PR TITLE
feat(abilities): register artist-relationships admin abilities

### DIFF
--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -37,3 +37,10 @@ require_once __DIR__ . '/handlers/artist-subscribe.php';
 require_once __DIR__ . '/handlers/artist-list-subscribers.php';
 require_once __DIR__ . '/handlers/artist-export-subscribers.php';
 require_once __DIR__ . '/handlers/artist-get-analytics.php';
+
+// Admin artist-relationships ability handlers.
+require_once __DIR__ . '/handlers/admin-list-artist-relationships.php';
+require_once __DIR__ . '/handlers/admin-link-artist-relationship.php';
+require_once __DIR__ . '/handlers/admin-unlink-artist-relationship.php';
+require_once __DIR__ . '/handlers/admin-list-orphan-artist-relationships.php';
+require_once __DIR__ . '/handlers/admin-cleanup-artist-relationships.php';

--- a/inc/abilities/category.php
+++ b/inc/abilities/category.php
@@ -27,4 +27,12 @@ function extrachill_artist_platform_register_category() {
 			'description' => __( 'Artist-domain abilities: profiles, links, socials, subscribers, analytics.', 'extrachill-artist-platform' ),
 		)
 	);
+
+	wp_register_ability_category(
+		'extrachill-admin-artist-relationships',
+		array(
+			'label'       => __( 'Admin: Artist Relationships', 'extrachill-artist-platform' ),
+			'description' => __( 'Network-admin abilities for managing artist-user relationships.', 'extrachill-artist-platform' ),
+		)
+	);
 }

--- a/inc/abilities/handlers/admin-cleanup-artist-relationships.php
+++ b/inc/abilities/handlers/admin-cleanup-artist-relationships.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/admin-cleanup-artist-relationships
+ *
+ * Cleans up an orphaned artist-user relationship (admin-only).
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Clean up an orphaned artist-user relationship.
+ *
+ * @param array $input {
+ *     @type int $user_id   WordPress user ID.
+ *     @type int $artist_id Artist profile post ID.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_admin_cleanup_artist_relationships( array $input ): array|WP_Error {
+	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
+		return new WP_Error(
+			'missing_params',
+			__( 'Both user_id and artist_id are required.', 'extrachill-artist-platform' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/cleanup' );
+	$request->set_param( 'user_id', (int) $input['user_id'] );
+	$request->set_param( 'artist_id', (int) $input['artist_id'] );
+
+	$response = extrachill_api_cleanup_orphan( $request );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
+
+	return is_array( $data ) ? $data : array( 'success' => true );
+}

--- a/inc/abilities/handlers/admin-link-artist-relationship.php
+++ b/inc/abilities/handlers/admin-link-artist-relationship.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/admin-link-artist-relationship
+ *
+ * Links a user to an artist profile (admin-only).
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Link a user to an artist profile.
+ *
+ * @param array $input {
+ *     @type int $user_id   WordPress user ID.
+ *     @type int $artist_id Artist profile post ID.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_admin_link_artist_relationship( array $input ): array|WP_Error {
+	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
+		return new WP_Error(
+			'missing_params',
+			__( 'Both user_id and artist_id are required.', 'extrachill-artist-platform' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/link' );
+	$request->set_param( 'user_id', (int) $input['user_id'] );
+	$request->set_param( 'artist_id', (int) $input['artist_id'] );
+
+	$response = extrachill_api_link_user_to_artist( $request );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
+
+	return is_array( $data ) ? $data : array( 'success' => true );
+}

--- a/inc/abilities/handlers/admin-list-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-artist-relationships.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/admin-list-artist-relationships
+ *
+ * Lists artist-user relationships (artists view or users view).
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List artist-user relationships.
+ *
+ * @param array $input {
+ *     @type string $view   View mode: 'artists' or 'users' (default 'artists').
+ *     @type string $search Optional search term.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_admin_list_artist_relationships( array $input ): array|WP_Error {
+	$view   = isset( $input['view'] ) ? sanitize_text_field( $input['view'] ) : 'artists';
+	$search = isset( $input['search'] ) ? sanitize_text_field( $input['search'] ) : '';
+
+	$request = new WP_REST_Request( 'GET', '/extrachill/v1/admin/artist-relationships' );
+	$request->set_param( 'view', $view );
+	$request->set_param( 'search', $search );
+
+	$response = extrachill_api_get_artist_relationships( $request );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
+
+	return is_array( $data ) ? $data : array( 'items' => array() );
+}

--- a/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/admin-list-orphan-artist-relationships
+ *
+ * Lists orphaned artist-user relationships (admin-only).
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * List orphaned artist-user relationships.
+ *
+ * @param array $input Unused — endpoint takes no parameters.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_admin_list_orphan_artist_relationships( array $input ): array|WP_Error {
+	$response = extrachill_api_get_orphaned_relationships();
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
+
+	return is_array( $data ) ? $data : array( 'orphans' => array() );
+}

--- a/inc/abilities/handlers/admin-unlink-artist-relationship.php
+++ b/inc/abilities/handlers/admin-unlink-artist-relationship.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/admin-unlink-artist-relationship
+ *
+ * Unlinks a user from an artist profile (admin-only).
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Unlink a user from an artist profile.
+ *
+ * @param array $input {
+ *     @type int $user_id   WordPress user ID.
+ *     @type int $artist_id Artist profile post ID.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_admin_unlink_artist_relationship( array $input ): array|WP_Error {
+	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
+		return new WP_Error(
+			'missing_params',
+			__( 'Both user_id and artist_id are required.', 'extrachill-artist-platform' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/unlink' );
+	$request->set_param( 'user_id', (int) $input['user_id'] );
+	$request->set_param( 'artist_id', (int) $input['artist_id'] );
+
+	$response = extrachill_api_unlink_user_from_artist( $request );
+
+	if ( is_wp_error( $response ) ) {
+		return $response;
+	}
+
+	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
+
+	return is_array( $data ) ? $data : array( 'success' => true );
+}

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -862,4 +862,175 @@ function extrachill_artist_platform_register_abilities() {
 			),
 		)
 	);
+
+	// ──────────────────────────────────────────────────────────────────────
+	// Admin artist-relationships abilities (network admin only)
+	// ──────────────────────────────────────────────────────────────────────
+
+	wp_register_ability(
+		'extrachill/admin-list-artist-relationships',
+		array(
+			'label'               => __( 'List artist relationships', 'extrachill-artist-platform' ),
+			'description'         => __( 'Lists artist-user relationships by artists or users view.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-admin-artist-relationships',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array(),
+				'properties'           => array(
+					'view'   => array( 'type' => 'string', 'enum' => array( 'artists', 'users' ), 'description' => __( 'View mode.', 'extrachill-artist-platform' ) ),
+					'search' => array( 'type' => 'string', 'description' => __( 'Search term.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'items' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_admin_list_artist_relationships',
+			'permission_callback' => 'extrachill_artist_platform_ability_admin_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/admin-link-artist-relationship',
+		array(
+			'label'               => __( 'Link artist relationship', 'extrachill-artist-platform' ),
+			'description'         => __( 'Links a user to an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-admin-artist-relationships',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'user_id', 'artist_id' ),
+				'properties'           => array(
+					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
+					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_admin_link_artist_relationship',
+			'permission_callback' => 'extrachill_artist_platform_ability_admin_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/admin-unlink-artist-relationship',
+		array(
+			'label'               => __( 'Unlink artist relationship', 'extrachill-artist-platform' ),
+			'description'         => __( 'Unlinks a user from an artist profile.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-admin-artist-relationships',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'user_id', 'artist_id' ),
+				'properties'           => array(
+					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
+					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_admin_unlink_artist_relationship',
+			'permission_callback' => 'extrachill_artist_platform_ability_admin_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/admin-list-orphan-artist-relationships',
+		array(
+			'label'               => __( 'List orphan artist relationships', 'extrachill-artist-platform' ),
+			'description'         => __( 'Lists orphaned artist-user relationships where the artist post no longer exists.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-admin-artist-relationships',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array(),
+				'properties'           => array(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'orphans' => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_admin_list_orphan_artist_relationships',
+			'permission_callback' => 'extrachill_artist_platform_ability_admin_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/admin-cleanup-artist-relationships',
+		array(
+			'label'               => __( 'Cleanup artist relationships', 'extrachill-artist-platform' ),
+			'description'         => __( 'Removes an orphaned artist-user relationship entry.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-admin-artist-relationships',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'user_id', 'artist_id' ),
+				'properties'           => array(
+					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
+					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success' => array( 'type' => 'boolean' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_admin_cleanup_artist_relationships',
+			'permission_callback' => 'extrachill_artist_platform_ability_admin_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => true,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
 }


### PR DESCRIPTION
## Summary

- Registers **5 admin artist-relationships abilities** corresponding to the existing REST endpoints in `extrachill-api/inc/routes/admin/artist-relationships.php`
- All abilities require **network admin** permission (`extrachill_artist_platform_ability_admin_permission`)
- All abilities have `meta.show_in_rest: true`

## Abilities

| Ability | Endpoint | Type |
|---|---|---|
| `extrachill/admin-list-artist-relationships` | `GET /admin/artist-relationships` | read |
| `extrachill/admin-link-artist-relationship` | `POST /admin/artist-relationships/link` | write |
| `extrachill/admin-unlink-artist-relationship` | `POST /admin/artist-relationships/unlink` | write/destructive |
| `extrachill/admin-list-orphan-artist-relationships` | `GET /admin/artist-relationships/orphans` | read |
| `extrachill/admin-cleanup-artist-relationships` | `POST /admin/artist-relationships/cleanup` | write/destructive |

## Files changed

- `inc/abilities/handlers/admin-list-artist-relationships.php` — new handler
- `inc/abilities/handlers/admin-link-artist-relationship.php` — new handler
- `inc/abilities/handlers/admin-unlink-artist-relationship.php` — new handler
- `inc/abilities/handlers/admin-list-orphan-artist-relationships.php` — new handler
- `inc/abilities/handlers/admin-cleanup-artist-relationships.php` — new handler
- `inc/abilities/registry.php` — 5 new ability registrations
- `inc/abilities/category.php` — new `extrachill-admin-artist-relationships` category
- `inc/abilities/abilities.php` — bootstrap loader updated

## Verification

All files pass `php -l` lint check.