### PR TITLE
ci(docs-agent): wire docs-agent CI workflow for user-facing documentation

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -1,0 +1,93 @@
+# Docs Agent CI for extrachill-artist-platform
+#
+# Runs Automattic/docs-agent against this repository to generate or
+# maintain user-facing documentation under docs/user/. Output is opened
+# as a pull request for human review.
+#
+# This workflow is a thin wrapper around homeboy-extensions's reusable
+# datamachine-agent-ci.yml. It adds two Extra-Chill-specific pieces:
+#
+#   1. Lists Extra-Chill/extrachill-docs as a validation dependency so
+#      that plugin loads in the ephemeral WordPress runtime. Loading it
+#      registers the `docs` agent execution mode and supplies its
+#      editorial voice rules via the datamachine_agent_mode_docs filter.
+#      See https://github.com/Extra-Chill/extrachill-docs (PR #35).
+#
+#   2. Passes pipeline_step_patches to set agent_modes: ['docs'] on the
+#      docs-agent bundle's AI step at runtime. This activates the docs
+#      mode without forking or modifying the upstream bundle.
+#
+# When triggered, the agent reads this repo's source code (PHP, JS,
+# templates, UI strings, existing docs), produces markdown files in
+# docs/user/, and opens one pull request. The strict end-user voice
+# rules from extrachill-docs#6 are enforced through the docs mode's
+# system context injection — the agent never names plugins, hooks,
+# slugs, or any developer-visible surface.
+#
+# Triggering:
+#   - workflow_dispatch (manual) for ad-hoc runs during pilot phase
+#   - Scheduled runs can be added after the bootstrap PR is reviewed
+#     and merged, by uncommenting the `schedule:` block below.
+
+name: Docs Agent
+
+on:
+  workflow_dispatch:
+    inputs:
+      flow_kind:
+        description: Which docs flow to run.
+        type: choice
+        options:
+          - user-docs-bootstrap-flow
+          - user-docs-maintenance-flow
+          - user-docs-flow
+        default: user-docs-bootstrap-flow
+      openai_model:
+        description: OpenAI model to use.
+        required: false
+        default: gpt-5.5
+
+  # schedule:
+  #   # Weekly maintenance pass, Sundays at 14:00 UTC. Uncomment after
+  #   # bootstrap PR is merged.
+  #   - cron: '0 14 * * 0'
+
+jobs:
+  run-docs-agent:
+    uses: Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml@main
+    with:
+      bundle_repo: https://github.com/Automattic/docs-agent.git
+      bundle_ref: main
+      bundle_path_in_repo: bundles/docs-agent
+      bundle_path: bundles/docs-agent
+      agent_slug: docs-agent
+      pipeline_slug: user-docs-pipeline
+      flow_slug: ${{ inputs.flow_kind || 'user-docs-maintenance-flow' }}
+      target_repo: ${{ github.repository }}
+      prompt: >-
+        ${{
+          contains(inputs.flow_kind, 'bootstrap') &&
+          'Run the user docs bootstrap flow. Build the broadest complete initial user-facing documentation surface possible from source code, UI strings, existing docs, issues, and pull requests. Open one documentation PR unless the repo already has complete user docs.' ||
+          'Run the user docs maintenance flow. Update non-technical user-facing living documentation only where source code, UI strings, recent issues, recent pull requests, or existing docs show stale, missing, fragmented, or misleading coverage. Open a documentation PR only if needed.'
+        }}
+      model: ${{ inputs.openai_model || 'gpt-5.5' }}
+      validation_dependencies: >-
+        Automattic/agents-api@main,Extra-Chill/data-machine@main,Extra-Chill/data-machine-code@main,Extra-Chill/extrachill-docs@main,WordPress/ai-provider-for-openai@trunk
+      runner_workspace: |
+        {
+          "enabled": true,
+          "repo": "${{ github.repository }}",
+          "clone_url": "https://github.com/${{ github.repository }}.git",
+          "branch_prefix": "docs/agent-run",
+          "from": "origin/main",
+          "bootstrap": false
+        }
+      pipeline_step_patches: |
+        [{"step_type": "ai", "set": {"agent_modes": ["docs"]}}]
+      success_requires_pr: false
+      extra_required_abilities: |
+        ["datamachine/workspace-worktree-add"]
+      app_token_repos: ${{ github.repository }}
+      engine_data_outputs: '{"docs_pr_url":"metadata.engine_data.docs_agent.pr_url"}'
+      transcript_artifact_name: docs-agent-transcript-${{ github.run_id }}
+    secrets: inherit


### PR DESCRIPTION
First row of **extrachill-docs#34**'s per-repo wiring tracker. Pilot repo for the dual-runtime docs architecture (extrachill-docs#31).

## What this PR does

Adds \`.github/workflows/docs-agent.yml\` — a thin wrapper around \`Extra-Chill/homeboy-extensions/.github/workflows/datamachine-agent-ci.yml\` that runs \`Automattic/docs-agent\` against this repository to generate or maintain user-facing documentation under \`docs/user/\`. Output is opened as a pull request for human review.

## How the Extra-Chill voice rules get applied

Two pieces, both passed as inputs to the reusable workflow — no upstream bundle fork required:

1. **\`validation_dependencies\`** includes \`Extra-Chill/extrachill-docs@main\` so that plugin loads in the ephemeral WordPress runtime. Loading it registers the \`docs\` agent execution mode and supplies its editorial voice rules (\`writing-rules.md\`) via the \`datamachine_agent_mode_docs\` filter. See https://github.com/Extra-Chill/extrachill-docs/pull/35.

2. **\`pipeline_step_patches\`** activates the docs mode on docs-agent's AI step:
   \`\`\`json
   [{\"step_type\": \"ai\", \"set\": {\"agent_modes\": [\"docs\"]}}]
   \`\`\`
   This patches every AI step in the imported pipeline (docs-agent has exactly one) so its \`agent_modes\` config is set without modifying the upstream bundle. \`homeboy-extensions\`' workload PHP applies these patches between \`datamachine/import-agent\` and \`datamachine/run-flow\`.

When the run fires, Data Machine's \`AgentModeDirective\` (priority 22) picks up the registered guidance and injects \`extrachill-docs\`' writing rules into the AI's system context. The rules forbid naming any plugin, hook, slug, post type, library, file path, or technical surface in generated content. The agent must translate everything into what end users see on their screens.

## Triggering

Manual via \`workflow_dispatch\` during pilot. Three flow choices:

- **\`user-docs-bootstrap-flow\`** — first-run sweep, builds the broadest initial user-facing documentation surface possible
- **\`user-docs-maintenance-flow\`** — ongoing drift correction
- **\`user-docs-flow\`** — alias for maintenance

Scheduled runs are commented out in the workflow. After the bootstrap PR is reviewed and merged, uncomment the \`schedule:\` block (weekly Sundays 14:00 UTC) to enable ongoing maintenance.

## What this produces

Markdown files under \`docs/user/*.md\` covering user-visible features:
- Getting started with the artist platform
- Managing your artist profile
- Managing link pages
- Advanced link page features
- Understanding link page analytics
- Managing artist roster
- Artist access and permissions
- Creating your artist merch store

The hand-written drafts already filed in this repo at **#32** (Rescue user docs from extrachill-docs#26) are calibration anchors for the first pass. The agent may incorporate, refine, or replace them.

## Where the output goes from there

Once a markdown PR is merged into \`main\`:

1. \`extrachill-docs\`' hourly sync cron (PR #40) reads \`docs/user/*.md\` via \`datamachine/list-github-tree\` + \`get-github-file\`
2. \`block-format-bridge/convert\` renders markdown → Gutenberg blocks
3. \`extrachill-docs/upsert-doc-page\` creates/updates a hierarchical WP page at \`docs.extrachill.com/artist-platform/<slug>/\`
4. Synced pages are locked against direct WP-admin edits — round-tripping through this repo is the only way to update them

## Pilot test plan

Once this PR merges:

1. Trigger \`Docs Agent\` workflow manually with \`flow_kind: user-docs-bootstrap-flow\`
2. Wait for the PR to land
3. Audit the markdown content against extrachill-docs#6's voice rules:
   - No plugin / hook / slug / post type names anywhere
   - End-user audience throughout
   - Sixth-grade reading level
   - Benefit-focused framing
4. If voice audit passes, merge the markdown PR
5. Wait one hour for the sync cron, or run \`wp extrachill docs sync --repo=Extra-Chill/extrachill-artist-platform\` manually
6. Visit \`docs.extrachill.com/artist-platform/<slug>/\` and verify the page renders correctly
7. If everything is clean, comment on extrachill-docs#34 and proceed to wire the next plugin repo

If voice audit fails, iterate on \`extrachill-docs/runner-configs/writing-rules.md\` or on the bundle's per-flow \`prompt:\` input before re-running.

## Cross-refs

- Extra-Chill/extrachill-docs#34 — per-repo wiring tracker
- Extra-Chill/extrachill-docs#31 — dual-runtime architecture RFC
- Extra-Chill/extrachill-docs/pull/35 — docs mode registration
- Extra-Chill/extrachill-docs/pull/40 — production sync infrastructure
- #32 — rescued draft content (calibration anchors for the first run)