### PR TITLE
fix(link-page-editor): surface dirty state, fix partial-failure save, persist unsaved changes to sessionStorage

### DIFF
--- a/src/blocks/link-page-editor/components/Editor.js
+++ b/src/blocks/link-page-editor/components/Editor.js
@@ -35,6 +35,7 @@ export default function Editor() {
 		isSaving,
 		error,
 		saveError,
+		hasUnsavedChanges,
 		userArtists,
 		artist,
 		saveAll,
@@ -162,11 +163,13 @@ export default function Editor() {
 								type="button"
 								className="button-1 button-small"
 								onClick={ handleSave }
-								disabled={ isSaving }
+								disabled={ isSaving || ! hasUnsavedChanges }
 							>
 								{ isSaving
 									? __( 'Saving...', 'extrachill-artist-platform' )
-									: __( 'Save All', 'extrachill-artist-platform' ) }
+									: hasUnsavedChanges
+										? __( 'Save changes', 'extrachill-artist-platform' )
+										: __( 'Saved', 'extrachill-artist-platform' ) }
 							</button>
 						</ActionRow>
 					}

--- a/src/blocks/link-page-editor/context/EditorContext.js
+++ b/src/blocks/link-page-editor/context/EditorContext.js
@@ -93,34 +93,64 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 		setSaveError( null );
 
 		try {
-			const promises = [];
+			const tasks = [];
 
 			if ( dirtySections.has( 'artist' ) ) {
-				promises.push(
-					artistData.update( {
+				tasks.push( {
+					section: 'artist',
+					promise: artistData.update( {
 						name: artistData.artist?.name,
 						profile_image_id: artistData.artist?.profile_image_id,
-					} )
-				);
+					} ),
+				} );
 			}
 
 			if ( dirtySections.has( 'links' ) ) {
-				promises.push(
-					linksData.update( {
+				tasks.push( {
+					section: 'links',
+					promise: linksData.update( {
 						links: linksData.links,
 						settings: { ...linksData.settings, bio: linksData.bio },
 						css_vars: linksData.cssVars,
 						background_image_id: linksData.backgroundImageId,
-					} )
-				);
+					} ),
+				} );
 			}
 
 			if ( dirtySections.has( 'socials' ) ) {
-				promises.push( socialsData.update( socialsData.socials ) );
+				tasks.push( {
+					section: 'socials',
+					promise: socialsData.update( socialsData.socials ),
+				} );
 			}
 
-			if ( promises.length > 0 ) {
-				await Promise.all( promises );
+			if ( tasks.length === 0 ) {
+				setHasUnsavedChanges( false );
+				setDirtySections( new Set() );
+				return true;
+			}
+
+			const results = await Promise.allSettled(
+				tasks.map( ( task ) => task.promise )
+			);
+
+			const failedSections = new Set();
+			const failedMessages = [];
+			results.forEach( ( result, idx ) => {
+				if ( result.status === 'rejected' ) {
+					const section = tasks[ idx ].section;
+					failedSections.add( section );
+					failedMessages.push(
+						`${ section }: ${ result.reason?.message || 'unknown error' }`
+					);
+				}
+			} );
+
+			if ( failedSections.size > 0 ) {
+				setSaveError( failedMessages.join( '; ' ) );
+				setDirtySections( failedSections );
+				setHasUnsavedChanges( true );
+				return false;
 			}
 
 			setHasUnsavedChanges( false );

--- a/src/blocks/link-page-editor/context/EditorContext.js
+++ b/src/blocks/link-page-editor/context/EditorContext.js
@@ -23,6 +23,29 @@ import {
 	DEFAULT_TITLE_FONT,
 	DEFAULT_BODY_FONT,
 } from '../utils/fonts';
+import { readDirty, clearDirty } from '../utils/dirtyStorage';
+
+/**
+ * Resolve the sessionStorage dirty buffer for an artist on initial load /
+ * artist switch. Prompts the user exactly once when a buffer exists so we
+ * never silently restore stale work or silently discard real edits.
+ *
+ * Returns the buffer when kept, or null when missing / discarded / declined.
+ */
+const resolveRestoredBuffer = ( artistId ) => {
+	const stored = readDirty( artistId );
+	if ( ! stored ) {
+		return null;
+	}
+	const keep = window.confirm(
+		'You have unsaved changes from a previous session for this artist. Keep them? (Cancel to discard.)'
+	);
+	if ( keep ) {
+		return stored;
+	}
+	clearDirty( artistId );
+	return null;
+};
 
 const EditorContext = createContext( null );
 
@@ -64,12 +87,29 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 	const [ activeTab, setActiveTab ] = useState( 'info' );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ saveError, setSaveError ] = useState( null );
-	const [ hasUnsavedChanges, setHasUnsavedChanges ] = useState( false );
-	const [ dirtySections, setDirtySections ] = useState( new Set() );
 
-	const artistData = useArtist( artistId );
-	const linksData = useLinks( artistId );
-	const socialsData = useSocials( artistId );
+	// Resolve the dirty buffer for the initial artist exactly once at mount.
+	// `useState` lazy initializer guarantees synchronous resolution and a
+	// single prompt before any child hook runs.
+	const [ restoredBuffer, setRestoredBuffer ] = useState( () =>
+		resolveRestoredBuffer( initialArtistId )
+	);
+
+	const [ hasUnsavedChanges, setHasUnsavedChanges ] = useState(
+		() => !! restoredBuffer
+	);
+	const [ dirtySections, setDirtySections ] = useState(
+		() =>
+			new Set(
+				restoredBuffer && Array.isArray( restoredBuffer.dirtySections )
+					? restoredBuffer.dirtySections
+					: []
+			)
+	);
+
+	const artistData = useArtist( artistId, restoredBuffer );
+	const linksData = useLinks( artistId, restoredBuffer );
+	const socialsData = useSocials( artistId, restoredBuffer );
 	const mediaUpload = useMediaUpload();
 
 	const isLoading =
@@ -127,6 +167,8 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 			if ( tasks.length === 0 ) {
 				setHasUnsavedChanges( false );
 				setDirtySections( new Set() );
+				clearDirty( artistId );
+				setRestoredBuffer( null );
 				return true;
 			}
 
@@ -155,6 +197,8 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 
 			setHasUnsavedChanges( false );
 			setDirtySections( new Set() );
+			clearDirty( artistId );
+			setRestoredBuffer( null );
 			return true;
 		} catch ( err ) {
 			setSaveError( err.message || 'Failed to save changes' );
@@ -163,6 +207,7 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 			setIsSaving( false );
 		}
 	}, [
+		artistId,
 		artistData,
 		linksData,
 		socialsData,
@@ -178,11 +223,26 @@ export function EditorProvider( { artistId: initialArtistId, children } ) {
 				if ( ! confirmed ) {
 					return;
 				}
+				// User confirmed discard of in-flight edits for the current artist.
+				clearDirty( artistId );
 			}
+
+			// Resolve buffer for the artist we're switching to. If a buffer
+			// exists, prompt the user once; on keep, hydrate state from it.
+			const nextBuffer = resolveRestoredBuffer( newArtistId );
+			setRestoredBuffer( nextBuffer );
 			setArtistId( newArtistId );
-			setHasUnsavedChanges( false );
+			setHasUnsavedChanges( !! nextBuffer );
+			setDirtySections(
+				new Set(
+					nextBuffer && Array.isArray( nextBuffer.dirtySections )
+						? nextBuffer.dirtySections
+						: []
+				)
+			);
+			setSaveError( null );
 		},
-		[ hasUnsavedChanges ]
+		[ hasUnsavedChanges, artistId ]
 	);
 
 	/**

--- a/src/blocks/link-page-editor/hooks/useArtist.js
+++ b/src/blocks/link-page-editor/hooks/useArtist.js
@@ -2,18 +2,38 @@
  * useArtist Hook
  *
  * Manages artist core data (name and profile image).
+ *
+ * Accepts an optional `restoredBuffer` (resolved by EditorProvider from
+ * sessionStorage). When the buffer has an `artist` section for the current
+ * artist, initial state is hydrated from the buffer and the server fetch
+ * is skipped — the user's unsaved edits win over a fresh server snapshot.
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { getArtist, updateArtist, getConfig } from '../../shared/api/client';
+import { writeDirty } from '../utils/dirtyStorage';
 
-export default function useArtist( artistId ) {
-	const [ artist, setArtist ] = useState( null );
-	const [ isLoading, setIsLoading ] = useState( true );
+const bufferArtist = ( restoredBuffer ) =>
+	restoredBuffer && restoredBuffer.artist ? restoredBuffer.artist : null;
+
+export default function useArtist( artistId, restoredBuffer = null ) {
+	const initialBuffer = bufferArtist( restoredBuffer );
+
+	const [ artist, setArtist ] = useState( () =>
+		initialBuffer ? { ...initialBuffer } : null
+	);
+	const [ isLoading, setIsLoading ] = useState( ! initialBuffer );
 	const [ error, setError ] = useState( null );
 
 	const fetchArtist = useCallback( async () => {
 		if ( ! artistId ) {
+			setIsLoading( false );
+			return;
+		}
+
+		const buffered = bufferArtist( restoredBuffer );
+		if ( buffered ) {
+			setArtist( { ...buffered } );
 			setIsLoading( false );
 			return;
 		}
@@ -37,7 +57,7 @@ export default function useArtist( artistId ) {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ artistId ] );
+	}, [ artistId, restoredBuffer ] );
 
 	useEffect( () => {
 		fetchArtist();
@@ -67,19 +87,39 @@ export default function useArtist( artistId ) {
 		[ artistId ]
 	);
 
-	const setName = useCallback( ( name ) => {
-		setArtist( ( prev ) => ( { ...prev, name } ) );
-	}, [] );
+	const setName = useCallback(
+		( name ) => {
+			setArtist( ( prev ) => {
+				const next = { ...prev, name };
+				writeDirty( artistId, {
+					section: 'artist',
+					artist: { name },
+				} );
+				return next;
+			} );
+		},
+		[ artistId ]
+	);
 
 	const setProfileImage = useCallback(
 		( profileImageId, profileImageUrl ) => {
-			setArtist( ( prev ) => ( {
-				...prev,
-				profile_image_id: profileImageId,
-				profile_image_url: profileImageUrl,
-			} ) );
+			setArtist( ( prev ) => {
+				const next = {
+					...prev,
+					profile_image_id: profileImageId,
+					profile_image_url: profileImageUrl,
+				};
+				writeDirty( artistId, {
+					section: 'artist',
+					artist: {
+						profile_image_id: profileImageId,
+						profile_image_url: profileImageUrl,
+					},
+				} );
+				return next;
+			} );
 		},
-		[]
+		[ artistId ]
 	);
 
 	return {

--- a/src/blocks/link-page-editor/hooks/useLinks.js
+++ b/src/blocks/link-page-editor/hooks/useLinks.js
@@ -2,27 +2,69 @@
  * useLinks Hook
  *
  * Manages link page data (bio, links, settings, cssVars, rawFontValues).
+ *
+ * Accepts an optional `restoredBuffer` (resolved by EditorProvider from
+ * sessionStorage). When the buffer has a `links` section for the current
+ * artist, initial state is hydrated from the buffer and the server fetch
+ * is skipped — the user's unsaved edits win over a fresh server snapshot.
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { getLinks, updateLinks, getConfig } from '../../shared/api/client';
+import { writeDirty } from '../utils/dirtyStorage';
 
-export default function useLinks( artistId ) {
-	const [ links, setLinks ] = useState( [] );
-	const [ bio, setBio ] = useState( '' );
-	const [ settings, setSettings ] = useState( {} );
-	const [ cssVars, setCssVars ] = useState( {} );
-	const [ rawFontValues, setRawFontValues ] = useState( {
-		title_font: '',
-		body_font: '',
-	} );
-	const [ backgroundImageId, setBackgroundImageId ] = useState( null );
-	const [ backgroundImageUrl, setBackgroundImageUrl ] = useState( null );
-	const [ isLoading, setIsLoading ] = useState( true );
+const DEFAULT_RAW_FONTS = { title_font: '', body_font: '' };
+
+const bufferLinks = ( restoredBuffer ) =>
+	restoredBuffer && restoredBuffer.links ? restoredBuffer.links : null;
+
+export default function useLinks( artistId, restoredBuffer = null ) {
+	const initialBuffer = bufferLinks( restoredBuffer );
+
+	const [ links, setLinks ] = useState( () =>
+		initialBuffer?.links ? initialBuffer.links : []
+	);
+	const [ bio, setBio ] = useState( () =>
+		typeof initialBuffer?.bio === 'string' ? initialBuffer.bio : ''
+	);
+	const [ settings, setSettings ] = useState( () =>
+		initialBuffer?.settings ? initialBuffer.settings : {}
+	);
+	const [ cssVars, setCssVars ] = useState( () =>
+		initialBuffer?.css_vars ? initialBuffer.css_vars : {}
+	);
+	const [ rawFontValues, setRawFontValues ] = useState( () =>
+		initialBuffer?.raw_font_values
+			? initialBuffer.raw_font_values
+			: { ...DEFAULT_RAW_FONTS }
+	);
+	const [ backgroundImageId, setBackgroundImageId ] = useState(
+		() => initialBuffer?.background_image_id ?? null
+	);
+	const [ backgroundImageUrl, setBackgroundImageUrl ] = useState(
+		() => initialBuffer?.background_image_url ?? null
+	);
+	const [ isLoading, setIsLoading ] = useState( ! initialBuffer );
 	const [ error, setError ] = useState( null );
 
 	const fetchLinks = useCallback( async () => {
 		if ( ! artistId ) {
+			setIsLoading( false );
+			return;
+		}
+
+		const buffered = bufferLinks( restoredBuffer );
+		if ( buffered ) {
+			// Rehydrate from buffer — user's unsaved edits win for this artist.
+			setLinks( buffered.links || [] );
+			setBio( typeof buffered.bio === 'string' ? buffered.bio : '' );
+			setSettings( buffered.settings || {} );
+			setCssVars( buffered.css_vars || {} );
+			setRawFontValues(
+				buffered.raw_font_values || { ...DEFAULT_RAW_FONTS }
+			);
+			setBackgroundImageId( buffered.background_image_id ?? null );
+			setBackgroundImageUrl( buffered.background_image_url ?? null );
 			setIsLoading( false );
 			return;
 		}
@@ -44,7 +86,7 @@ export default function useLinks( artistId ) {
 			setSettings( data.settings || {} );
 			setCssVars( data.css_vars || {} );
 			setRawFontValues(
-				data.raw_font_values || { title_font: '', body_font: '' }
+				data.raw_font_values || { ...DEFAULT_RAW_FONTS }
 			);
 			setBackgroundImageId( data.background_image_id || null );
 			setBackgroundImageUrl( data.background_image_url || null );
@@ -53,7 +95,7 @@ export default function useLinks( artistId ) {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ artistId ] );
+	}, [ artistId, restoredBuffer ] );
 
 	useEffect( () => {
 		fetchLinks();
@@ -78,7 +120,7 @@ export default function useLinks( artistId ) {
 				setSettings( updated.settings || {} );
 				setCssVars( updated.css_vars || {} );
 				setRawFontValues(
-					updated.raw_font_values || { title_font: '', body_font: '' }
+					updated.raw_font_values || { ...DEFAULT_RAW_FONTS }
 				);
 				setBackgroundImageId( updated.background_image_id || null );
 				setBackgroundImageUrl( updated.background_image_url || null );
@@ -91,30 +133,75 @@ export default function useLinks( artistId ) {
 		[ artistId ]
 	);
 
-	const updateLocalLinks = useCallback( ( newLinks ) => {
-		setLinks( newLinks );
-	}, [] );
+	const updateLocalLinks = useCallback(
+		( newLinks ) => {
+			setLinks( newLinks );
+			writeDirty( artistId, { section: 'links', links: { links: newLinks } } );
+		},
+		[ artistId ]
+	);
 
-	const updateLocalBio = useCallback( ( newBio ) => {
-		setBio( newBio );
-	}, [] );
+	const updateLocalBio = useCallback(
+		( newBio ) => {
+			setBio( newBio );
+			writeDirty( artistId, { section: 'links', links: { bio: newBio } } );
+		},
+		[ artistId ]
+	);
 
-	const updateLocalSettings = useCallback( ( newSettings ) => {
-		setSettings( ( prev ) => ( { ...prev, ...newSettings } ) );
-	}, [] );
+	const updateLocalSettings = useCallback(
+		( newSettings ) => {
+			setSettings( ( prev ) => {
+				const merged = { ...prev, ...newSettings };
+				writeDirty( artistId, {
+					section: 'links',
+					links: { settings: merged },
+				} );
+				return merged;
+			} );
+		},
+		[ artistId ]
+	);
 
-	const updateLocalCssVars = useCallback( ( newCssVars ) => {
-		setCssVars( ( prev ) => ( { ...prev, ...newCssVars } ) );
-	}, [] );
+	const updateLocalCssVars = useCallback(
+		( newCssVars ) => {
+			setCssVars( ( prev ) => {
+				const merged = { ...prev, ...newCssVars };
+				writeDirty( artistId, {
+					section: 'links',
+					links: { css_vars: merged },
+				} );
+				return merged;
+			} );
+		},
+		[ artistId ]
+	);
 
-	const updateLocalRawFontValues = useCallback( ( newRawFontValues ) => {
-		setRawFontValues( ( prev ) => ( { ...prev, ...newRawFontValues } ) );
-	}, [] );
+	const updateLocalRawFontValues = useCallback(
+		( newRawFontValues ) => {
+			setRawFontValues( ( prev ) => {
+				const merged = { ...prev, ...newRawFontValues };
+				writeDirty( artistId, {
+					section: 'links',
+					links: { raw_font_values: merged },
+				} );
+				return merged;
+			} );
+		},
+		[ artistId ]
+	);
 
-	const updateBackgroundImage = useCallback( ( id, url ) => {
-		setBackgroundImageId( id );
-		setBackgroundImageUrl( url );
-	}, [] );
+	const updateBackgroundImage = useCallback(
+		( id, url ) => {
+			setBackgroundImageId( id );
+			setBackgroundImageUrl( url );
+			writeDirty( artistId, {
+				section: 'links',
+				links: { background_image_id: id, background_image_url: url },
+			} );
+		},
+		[ artistId ]
+	);
 
 	return {
 		links,

--- a/src/blocks/link-page-editor/hooks/useSocials.js
+++ b/src/blocks/link-page-editor/hooks/useSocials.js
@@ -2,10 +2,16 @@
  * useSocials Hook
  *
  * Manages social links data.
+ *
+ * Accepts an optional `restoredBuffer` (resolved by EditorProvider from
+ * sessionStorage). When the buffer has a `socials` section for the current
+ * artist, initial state is hydrated from the buffer and the server fetch
+ * is skipped — the user's unsaved edits win over a fresh server snapshot.
  */
 
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { getSocials, updateSocials, getConfig } from '../../shared/api/client';
+import { writeDirty } from '../utils/dirtyStorage';
 
 const normalizeSocials = ( socialLinks ) =>
 	( socialLinks || [] )
@@ -17,13 +23,29 @@ const normalizeSocials = ( socialLinks ) =>
 			icon_class: social.icon_class,
 		} ) );
 
-export default function useSocials( artistId ) {
-	const [ socials, setSocials ] = useState( [] );
-	const [ isLoading, setIsLoading ] = useState( true );
+const bufferSocials = ( restoredBuffer ) =>
+	restoredBuffer && Array.isArray( restoredBuffer.socials )
+		? restoredBuffer.socials
+		: null;
+
+export default function useSocials( artistId, restoredBuffer = null ) {
+	const initialBuffer = bufferSocials( restoredBuffer );
+
+	const [ socials, setSocials ] = useState( () =>
+		initialBuffer ? normalizeSocials( initialBuffer ) : []
+	);
+	const [ isLoading, setIsLoading ] = useState( ! initialBuffer );
 	const [ error, setError ] = useState( null );
 
 	const fetchSocials = useCallback( async () => {
 		if ( ! artistId ) {
+			setIsLoading( false );
+			return;
+		}
+
+		const buffered = bufferSocials( restoredBuffer );
+		if ( buffered ) {
+			setSocials( normalizeSocials( buffered ) );
 			setIsLoading( false );
 			return;
 		}
@@ -46,7 +68,7 @@ export default function useSocials( artistId ) {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ artistId ] );
+	}, [ artistId, restoredBuffer ] );
 
 	useEffect( () => {
 		fetchSocials();
@@ -78,9 +100,17 @@ export default function useSocials( artistId ) {
 		[ artistId ]
 	);
 
-	const updateLocalSocials = useCallback( ( newSocials ) => {
-		setSocials( normalizeSocials( newSocials ) );
-	}, [] );
+	const updateLocalSocials = useCallback(
+		( newSocials ) => {
+			const normalized = normalizeSocials( newSocials );
+			setSocials( normalized );
+			writeDirty( artistId, {
+				section: 'socials',
+				socials: normalized,
+			} );
+		},
+		[ artistId ]
+	);
 
 	return {
 		socials,

--- a/src/blocks/link-page-editor/utils/dirtyStorage.js
+++ b/src/blocks/link-page-editor/utils/dirtyStorage.js
@@ -1,0 +1,159 @@
+/**
+ * dirtyStorage
+ *
+ * Per-artist unsaved-edit buffer backed by sessionStorage. Lets the link-page
+ * editor rehydrate in-progress work after a tab close / reopen without
+ * relying on beforeunload guards.
+ *
+ * Storage shape (per artist):
+ *
+ *   {
+ *     version: 1,
+ *     savedAt: '<ISO>',
+ *     artist:   { name, profile_image_id, profile_image_url } | undefined,
+ *     links:    { links, settings, bio, css_vars, raw_font_values,
+ *                 background_image_id, background_image_url } | undefined,
+ *     socials:  [ { id, type, url, icon_class }, ... ] | undefined,
+ *     dirtySections: [ 'artist' | 'links' | 'socials', ... ]
+ *   }
+ *
+ * All reads/writes are wrapped in try/catch and degrade to null / no-op so a
+ * disabled / full / private-mode sessionStorage never crashes the editor.
+ */
+
+const KEY_PREFIX = 'ec-link-page-editor:dirty:';
+const SCHEMA_VERSION = 1;
+
+const buildKey = ( artistId ) => `${ KEY_PREFIX }${ artistId }`;
+
+const getStorage = () => {
+	try {
+		if ( typeof window === 'undefined' || ! window.sessionStorage ) {
+			return null;
+		}
+		return window.sessionStorage;
+	} catch ( e ) {
+		return null;
+	}
+};
+
+/**
+ * Read the stored dirty buffer for an artist.
+ *
+ * @param {number|string} artistId
+ * @return {object|null} Parsed buffer or null when missing / malformed / version-mismatched.
+ */
+export function readDirty( artistId ) {
+	if ( ! artistId ) {
+		return null;
+	}
+	const storage = getStorage();
+	if ( ! storage ) {
+		return null;
+	}
+
+	try {
+		const raw = storage.getItem( buildKey( artistId ) );
+		if ( ! raw ) {
+			return null;
+		}
+		const parsed = JSON.parse( raw );
+		if ( ! parsed || parsed.version !== SCHEMA_VERSION ) {
+			return null;
+		}
+		return parsed;
+	} catch ( e ) {
+		return null;
+	}
+}
+
+/**
+ * Read-modify-write merge of a partial snapshot into the stored buffer.
+ *
+ * `partial` is shaped like a subset of the storage shape:
+ *
+ *   writeDirty( artistId, { section: 'links', links: { bio: 'new bio' } } );
+ *   writeDirty( artistId, { section: 'socials', socials: [ ... ] } );
+ *
+ * When `section` is provided it is added to `dirtySections`.
+ *
+ * @param {number|string} artistId
+ * @param {object}        partial  Partial buffer to merge.
+ * @return {void}
+ */
+export function writeDirty( artistId, partial ) {
+	if ( ! artistId || ! partial ) {
+		return;
+	}
+	const storage = getStorage();
+	if ( ! storage ) {
+		return;
+	}
+
+	try {
+		const existing = readDirty( artistId ) || {
+			version: SCHEMA_VERSION,
+			dirtySections: [],
+		};
+
+		const next = {
+			...existing,
+			version: SCHEMA_VERSION,
+			savedAt: new Date().toISOString(),
+		};
+
+		const { section, ...sectionData } = partial;
+
+		if ( sectionData.artist !== undefined ) {
+			next.artist = { ...( existing.artist || {} ), ...sectionData.artist };
+		}
+		if ( sectionData.links !== undefined ) {
+			next.links = { ...( existing.links || {} ), ...sectionData.links };
+		}
+		if ( sectionData.socials !== undefined ) {
+			next.socials = sectionData.socials;
+		}
+
+		if ( section ) {
+			const dirty = new Set( existing.dirtySections || [] );
+			dirty.add( section );
+			next.dirtySections = Array.from( dirty );
+		}
+
+		storage.setItem( buildKey( artistId ), JSON.stringify( next ) );
+	} catch ( e ) {
+		// Quota exceeded, storage disabled, JSON failure — silently drop.
+	}
+}
+
+/**
+ * Remove the stored dirty buffer for an artist.
+ *
+ * @param {number|string} artistId
+ * @return {void}
+ */
+export function clearDirty( artistId ) {
+	if ( ! artistId ) {
+		return;
+	}
+	const storage = getStorage();
+	if ( ! storage ) {
+		return;
+	}
+
+	try {
+		storage.removeItem( buildKey( artistId ) );
+	} catch ( e ) {
+		// no-op
+	}
+}
+
+/**
+ * Quick existence check without parsing.
+ *
+ * @param {number|string} artistId
+ * @return {boolean}
+ */
+export function hasDirty( artistId ) {
+	return readDirty( artistId ) !== null;
+}


### PR DESCRIPTION
Closes #35

## Summary

Three reinforcing fixes to the link-page editor save behavior, one commit each.

### 1. Save button reflects dirty state (`fix:`)

`Editor.js` now consumes `hasUnsavedChanges` from `EditorContext`. The Save button label flips between **Saving... / Save changes / Saved**, and is **disabled when no edits are pending** so accidental clicks no longer fire no-op PUTs.

### 2. `Promise.allSettled` in `saveAll()` (`fix:`)

`EditorContext.saveAll()` previously used `Promise.all`, which short-circuited on the first rejection and left the editor in a half-saved + full-retry state. Replaced with `Promise.allSettled` plus per-section tagging:

- Successful sections are cleared from `dirtySections` (no re-PUT on retry).
- Only failed sections remain marked dirty.
- `saveError` names the failed section(s) (`socials: <reason>; links: <reason>`).

### 3. `sessionStorage` persistence (`feat:`)

The actual user-reported lost-work fix. New `utils/dirtyStorage.js` provides a versioned, per-artist dirty buffer keyed `ec-link-page-editor:dirty:{artistId}`:

- `readDirty` / `writeDirty` (read-modify-write merge) / `clearDirty`.
- All storage access wrapped in try/catch — quota / disabled / private-mode degrade to no-op.
- Schema version 1; mismatched versions bail to `null`.

Wiring:

- `useArtist` / `useLinks` / `useSocials` accept an optional `restoredBuffer`. Their `useState` lazy initializers hydrate from it synchronously, and their existing fetch effect short-circuits when the buffer has data for that section.
- Every `updateLocal*` setter writes its section into storage so each keystroke is captured.
- `EditorProvider` resolves the buffer for the active artist via a `useState` lazy initializer (and again synchronously inside `switchArtist`). When a buffer exists the user is prompted **exactly once per artist load** via `window.confirm`:

  > "You have unsaved changes from a previous session for this artist. Keep them? (Cancel to discard.)"

  Cancel clears storage and falls back to a clean server fetch.
- `hasUnsavedChanges` and `dirtySections` are seeded from the buffer's `dirtySections` list so the Save button is correctly enabled on rehydration.
- `saveAll` clears the storage key (and the in-memory `restoredBuffer`) on full success so a clean save leaves nothing stale behind.

#### Open-question resolution

Issue #35 flagged the "buffer + server both present on mount" question. Implemented **option (b) — explicit prompt** as recommended, mirroring the existing artist-switcher `window.confirm` pattern at `EditorContext.js:144-147`. The prompt is hoisted into `EditorProvider` so the user sees it **once per artist load**, not three times (one per hook).

## Constraints honored

- **No new `useEffect`** in any touched file. All rehydration is via `useState` lazy initializers and synchronous setter callbacks. `grep useEffect` across the touched files shows only the pre-existing fetch effects in the three hooks plus the CSS-injection effect in `Editor.js`.
- No version bumps, no `CHANGELOG.md` edits, no edits to `/var/www/.../wp-content/plugins/`.
- Conventional commits, one per fix.

## Test plan

Manual, against a built editor on a multisite link-page:

1. **Dirty state on Save button**
   - Load the editor on a clean artist → button reads **Saved**, is disabled.
   - Edit the Bio → button flips to **Save changes**, enabled.
   - Click Save → button shows **Saving...**, then **Saved** + disabled.
2. **Partial-failure save**
   - Force a 500 on `/socials` (e.g. temporarily break the endpoint). Edit Bio + a social → Save.
   - Expect: backend has updated Bio, `saveError` reads `socials: <reason>`, `dirtySections` is `{ 'socials' }`, button still reads **Save changes**.
   - Restore the endpoint, click Save again → only the socials PUT fires, button settles to **Saved**.
3. **Tab-close persistence**
   - Edit Bio + add a social → close tab.
   - Reopen the editor for the same artist → confirm dialog appears.
   - Click **OK (Keep)** → form contains the unsaved Bio + social, button reads **Save changes**.
   - Click Save → `sessionStorage` key `ec-link-page-editor:dirty:{artistId}` is removed.
4. **Discard branch**
   - Same as (3), but click **Cancel** at the prompt → form loads server-clean, storage key removed.
5. **Per-artist scoping**
   - Have buffers for two artists → each prompt resolves independently; the other artist's buffer is untouched.
6. **Storage failure**
   - In DevTools, disable `sessionStorage` (private mode / quota error) → editor still loads and saves normally; no console crash.
7. **Build**: `npm run build` succeeds.