### PR TITLE
refactor: remove dead virtual-cap shim from permissions.php

### DIFF
--- a/inc/core/filters/permissions.php
+++ b/inc/core/filters/permissions.php
@@ -68,40 +68,16 @@ function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
     $user_id = $user->ID;
     $cap     = $args[0];
     $object_id = isset( $args[2] ) ? $args[2] : null;
-    
-    if ( $cap === 'create_artist_profiles' ) {
-        if ( ec_can_create_artist_profiles( $user_id ) ) {
-            $allcaps[$cap] = true;
-        }
-        return $allcaps;
-    }
-    
-    if ( $cap === 'manage_artist_members' && $object_id ) {
-        if ( ec_can_manage_artist( $user_id, $object_id ) ) {
-            $allcaps[$cap] = true;
-        }
-        return $allcaps;
-    }
-    
-    if ( $cap === 'view_artist_link_page_analytics' && $object_id ) {
-        if ( get_post_type( $object_id ) === 'artist_link_page' ) {
-            $artist_id = apply_filters('ec_get_artist_id', $object_id);
-            if ( $artist_id && ec_can_manage_artist( $user_id, $artist_id ) ) {
-                $allcaps[$cap] = true;
-            }
-        }
-        return $allcaps;
-    }
-    
+
     if ( $object_id && get_post_type( $object_id ) === 'artist_profile' ) {
         if ( ec_can_manage_artist( $user_id, $object_id ) ) {
-            $post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post', 'manage_artist_members' );
+            $post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post' );
             if ( in_array( $cap, $post_caps ) ) {
                 $allcaps[$cap] = true;
             }
         }
     }
-    
+
     return $allcaps;
 }
 


### PR DESCRIPTION
## Summary

Removes a dead `user_has_cap` shim in `inc/core/filters/permissions.php` that fabricated three custom WordPress capabilities that **nothing consumes**. Closes #41.

## Removed (verified zero consumers)

Three branches in `ec_filter_user_capabilities()` that fabricated custom caps:

- `create_artist_profiles` (early-return branch)
- `manage_artist_members` (early-return branch)
- `view_artist_link_page_analytics` (early-return branch)

Also dropped the now-orphaned `manage_artist_members` string from the kept `$post_caps` array (nothing reads it).

## Preserved (load-bearing)

The final branch that maps **WP-native post caps** on `artist_profile` objects:

```php
if ( $object_id && get_post_type( $object_id ) === 'artist_profile' ) {
    if ( ec_can_manage_artist( $user_id, $object_id ) ) {
        $post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post' );
        ...
    }
}
```

`edit_post` / `delete_post` / `read_post` / `publish_post` feed WordPress `map_meta_cap` for the CPT (registered with `map_meta_cap => true`). **This branch is preserved** so editing/deleting artist profiles still works. The helper functions (`ec_get_permission_artist_id`, `ec_get_permission_link_page_id`, `ec_get_permission_is_admin`, `ec_get_permission_can_create_artists`) are also untouched — they are consumed by extrachill-api/abilities.

## Verification

Grepped the entire plugin tree plus `extrachill-community`, `extrachill-users`, and `extrachill-api` for `current_user_can(` / `user_can(` paired with any of the three fabricated cap strings:

- **Zero matches.** Nothing consumes the fabricated caps via the cap-check API.
- Every real caller invokes `ec_can_create_artist_profiles()` / `ec_can_manage_artist()` directly.
- One stale comment reference exists in `single-artist_profile.php` ("This uses the custom capability 'manage_artist_members'") but the actual check there calls `ec_can_manage_artist()` directly — not a cap check. Left untouched (out of scope).

`php -l` passes on the modified file.