### PR TITLE
fix: gate shop manager block render with ec_can_manage_shop

### DIFF
--- a/src/blocks/artist-shop-manager/render.php
+++ b/src/blocks/artist-shop-manager/render.php
@@ -16,6 +16,16 @@ if ( ! is_user_logged_in() ) {
     return;
 }
 
+// Gate on shop management permission. Currently admin-only until the shop
+// system is ready for public use (see extrachill-users/inc/shop-permissions.php).
+// Keeps the page render consistent with the nav link and create-shop CTA gates.
+if ( ! function_exists( 'ec_can_manage_shop' ) || ! ec_can_manage_shop() ) {
+    echo '<div class="notice notice-info">';
+    echo '<p>' . esc_html__( 'Shop management is not available for your account.', 'extrachill-artist-platform' ) . '</p>';
+    echo '</div>';
+    return;
+}
+
 $current_user_id = get_current_user_id();
 
 if ( ! function_exists( 'ec_get_artists_for_user' ) ) {


### PR DESCRIPTION
## Summary

Fixes #39. The Artist Shop Manager block render did not enforce `ec_can_manage_shop()`. The admin-only gate was applied to the nav link (`inc/core/nav.php` ~L81) and the create-shop CTA (`artist-creator` render ~L80), but **not** to the page render itself — so any logged-in user with at least one artist who navigated directly to `/manage-shop/` got the full app shell.

## The inconsistency

| Surface | Gated on `ec_can_manage_shop()` before? |
|---|---|
| Nav link (`inc/core/nav.php`) | ✅ yes |
| Create-shop CTA (`artist-creator` render) | ✅ yes (`current_user_can('manage_options')`) |
| Shop manager page render | ❌ **no** — only checked `is_user_logged_in()` |

## The fix

In `src/blocks/artist-shop-manager/render.php`, after the login check, gate on `ec_can_manage_shop()`:

```php
if ( ! function_exists( 'ec_can_manage_shop' ) || ! ec_can_manage_shop() ) {
    echo '<div class="notice notice-info">';
    echo '<p>' . esc_html__( 'Shop management is not available for your account.', 'extrachill-artist-platform' ) . '</p>';
    echo '</div>';
    return;
}
```

Guarded with `function_exists` since `ec_can_manage_shop()` is defined in the network plugin `extrachill-users` (`inc/shop-permissions.php`), which is intentionally admin-only until the shop system is ready for public use. Nav, CTA, and render now all gate on the same check — no drift.

## Build note

This is a Gutenberg block. The block was rebuilt with `npm run build` and the gate was verified in the compiled `build/blocks/artist-shop-manager/render.php`. Note: `build/` is gitignored in this repo and regenerated by the deploy pipeline (homeboy), so only the `src/` change is committed here.

## Interim fix

This is the minimal direct-call fix. A larger standardized gate API is tracked separately in extrachill-users#60 but does not exist yet, so the direct `ec_can_manage_shop()` call is used now.

## Verification

- Admin with an artist: render still works (app shell appears).
- Non-admin logged-in user with an artist hitting `/manage-shop/` directly: gets the not-available notice, not the app shell.