### PR TITLE
chore: bump @extrachill/components to ^0.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "extrachill-artist-platform",
-  "version": "1.8.19",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extrachill-artist-platform",
-      "version": "1.8.19",
+      "version": "1.9.1",
       "license": "GPL-2.0+",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@extrachill/api-client": "^0.2.1",
-        "@extrachill/components": "^0.4.50",
+        "@extrachill/components": "^0.5.2",
         "@wordpress/api-fetch": "^7.0.0",
         "@wordpress/block-editor": "^14.0.0",
         "@wordpress/blocks": "^15.9.0",
@@ -2603,9 +2603,9 @@
       "license": "GPL-2.0+"
     },
     "node_modules/@extrachill/components": {
-      "version": "0.4.50",
-      "resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.4.50.tgz",
-      "integrity": "sha512-DCQOuurmUvPoX0QBPSgHumJlx+fvIKVQEEgkrsMTFYqXeHo66xLAGbRUAxmZjivugqFkKT7qknte1yV4lZcIKQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.5.2.tgz",
+      "integrity": "sha512-vBacRRqb72EXuZNjgmMMaOO9Ztl7BXMmOnA5idX3PuvLVdeDif1lRoqhtKnOZ+8JFLcajXXrI1N2kGocPnbE2Q==",
       "license": "GPL-2.0+",
       "peerDependencies": {
         "react": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@extrachill/api-client": "^0.2.1",
-    "@extrachill/components": "^0.4.50",
+    "@extrachill/components": "^0.5.2",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",
     "@wordpress/blocks": "^15.9.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.4.50` → `^0.5.2` and resolves the lockfile to `0.5.2`.

## What changed
- `package.json`: dependency range `^0.4.x → ^0.5.2`
- `package-lock.json`: resolved to `@extrachill/components@0.5.2`
- No tracked `build/` changes — build assets are gitignored and compiled at deploy time by homeboy. A full `npm run build` was still run locally to confirm `0.5.2` compiles cleanly (it did).

## Behavior changes riding along (smoke-test these)
`@extrachill/components@0.5.2` introduces three changes the reviewer should verify on artist-platform surfaces:
1. **BlockShellInner narrow/wide centering fix** (`margin-inline:auto`) — check block layout centering in editors.
2. **SearchBox canonical button classes** — check any SearchBox usage renders/behaves correctly.
3. **InlineStatus/Badge dark-mode token parity** — check status/badge rendering in dark mode.

## Build
- `npm run build` (`wp-scripts build`) completed successfully with no errors.

## Lint
- `homeboy lint extrachill-artist-platform` reports only **pre-existing** PHPStan debt in PHP source files.
- **No new findings** are introduced by this change — it touches only `package.json` and `package-lock.json`.

---
Per repo rules: no version bump or CHANGELOG edits (homeboy owns both). PR only — not merged/released/deployed.