### PR TITLE
fix: forum setting never saves via centralized save

### DIFF
--- a/inc/artist-profiles/admin/meta-boxes.php
+++ b/inc/artist-profiles/admin/meta-boxes.php
@@ -53,13 +53,38 @@ function ec_render_artist_settings_meta_box( $post ) {
 }
 
 /**
- * Saves the meta box data for artist settings.
+ * Persist the forum settings meta from the submitted request payload.
+ *
+ * Shared writer for both the wp-admin metabox path and the centralized
+ * front-end save path. Authorization (nonce verification and/or capability
+ * checks) is the responsibility of each caller — by the time this runs the
+ * request has already been authorized.
+ *
+ * @param int $post_id The ID of the artist profile being saved.
+ */
+function ec_write_artist_settings_meta( $post_id ) {
+    // Checkbox: present in $_POST means checked, absent means unchecked.
+    $new_value = isset( $_POST['ec_allow_public_topic_creation'] ) ? '1' : '0';
+
+    update_post_meta( $post_id, '_allow_public_topic_creation', $new_value );
+}
+
+/**
+ * Saves the meta box data for artist settings (wp-admin metabox path).
+ *
+ * This path carries its own nonce (rendered by ec_render_artist_settings_meta_box)
+ * and is authorized by verifying that nonce plus the edit_post capability.
  *
  * @param int $post_id The ID of the post being saved.
  */
 function ec_save_artist_settings_meta( $post_id ) {
     // Check if nonce is set and valid.
     if ( ! isset( $_POST['ec_artist_settings_nonce'] ) || ! wp_verify_nonce( $_POST['ec_artist_settings_nonce'], 'ec_save_artist_settings_meta' ) ) {
+        return;
+    }
+
+    // Only act on artist profiles.
+    if ( get_post_type( $post_id ) !== 'artist_profile' ) {
         return;
     }
 
@@ -79,14 +104,18 @@ function ec_save_artist_settings_meta( $post_id ) {
         return;
     }
 
-    // Check if the checkbox was checked
-    $new_value = isset( $_POST['ec_allow_public_topic_creation'] ) ? '1' : '0';
-
-    // Update the post meta
-    update_post_meta( $post_id, '_allow_public_topic_creation', $new_value );
+    ec_write_artist_settings_meta( $post_id );
 }
+// Wire the metabox handler to the classic wp-admin save_post flow.
+add_action( 'save_post_artist_profile', 'ec_save_artist_settings_meta', 10, 1 );
+
 /**
- * Centralized wrapper for artist settings meta when using the centralized save system.
+ * Centralized save handler for artist settings meta.
+ *
+ * Runs on the front-end centralized save flow (ec_artist_profile_save). That
+ * flow has already authorized the request, so there is no metabox nonce here;
+ * instead we enforce the manage-artist capability before writing. The value is
+ * read directly from the submitted payload (same field name the metabox uses).
  *
  * @param int $artist_id The ID of the artist profile being saved.
  */
@@ -95,14 +124,18 @@ function ec_save_artist_settings_meta_centralized( $artist_id ) {
         return;
     }
 
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
+    // Enforce capability — the centralized save already validated its own nonce,
+    // but the writer itself must still confirm the current user can manage this artist.
+    $can_manage = function_exists( 'ec_can_manage_artist' )
+        ? ec_can_manage_artist( get_current_user_id(), $artist_id )
+        : current_user_can( 'edit_post', $artist_id );
+
+    if ( ! $can_manage ) {
         return;
     }
 
-    // Call the existing meta save function with the post object and update flag
-    ec_save_artist_settings_meta( $artist_id, $artist_post, true );
+    ec_write_artist_settings_meta( $artist_id );
 }
 
-// Hook into centralized save system only - no legacy save_post hook needed
+// Hook into the centralized front-end save system.
 add_action( 'ec_artist_profile_save', 'ec_save_artist_settings_meta_centralized', 10, 1 );


### PR DESCRIPTION
## Summary

Fixes #40 — the artist "Allow public topic creation" forum setting (`_allow_public_topic_creation`) never persisted because the save path short-circuited on a nonce that doesn't exist on that path.

## Root cause

`inc/artist-profiles/admin/meta-boxes.php` had a single handler, `ec_save_artist_settings_meta()`, whose **first line** bailed if `$_POST['ec_artist_settings_nonce']` was absent:

- The centralized front-end flow (`ec_artist_profile_save`) called it via `ec_save_artist_settings_meta_centralized()`, but that flow carries **no** `ec_artist_settings_nonce`, so the function returned immediately and the meta was never written.
- The wrapper passed extra args (`$artist_post, true`) that were silently ignored — the signature only accepts `$post_id`.
- Worse, the metabox handler was hooked to **nothing** (no `save_post`), so the wp-admin path didn't persist either. The "no legacy save_post hook needed" comment was wrong.

## The fix

Split the two save paths cleanly around a shared writer:

- **`ec_write_artist_settings_meta( $post_id )`** — new shared writer. Reads `ec_allow_public_topic_creation` from the request payload and calls `update_post_meta()`. No auth of its own (callers authorize).
- **`ec_save_artist_settings_meta()`** (wp-admin metabox path) — keeps its nonce verification + `edit_post` capability check, and is now correctly wired to `save_post_artist_profile`. This path legitimately carries the metabox nonce.
- **`ec_save_artist_settings_meta_centralized()`** (centralized front-end path) — no longer delegates to the nonce-gated handler. It enforces a **capability check** (`ec_can_manage_artist()`, falling back to `current_user_can('edit_post')`) since the centralized save already validated its own nonce, then writes directly via the shared writer.
- Corrected the misleading "no legacy save_post hook needed" comment.

## Where the value comes from

The checkbox is named `ec_allow_public_topic_creation` (rendered in `ec_render_artist_settings_meta_box`). Both paths read it from `$_POST` in the same request that processes the form submission — the centralized writer reads the identical field name, so no payload renaming is needed. The meta key `_allow_public_topic_creation` is referenced only in this file across the active plugin tree, so this is the sole writer.

## Verification

- `php -l` clean on the edited file.
- Centralized path: `ec_artist_profile_save` → `ec_save_artist_settings_meta_centralized()` → capability check → `ec_write_artist_settings_meta()` → `update_post_meta()`. The nonce short-circuit is gone, so the value now persists.
- wp-admin path: nonce + `edit_post` checks intact, now actually hooked to `save_post_artist_profile`.
- Capability enforcement preserved on both paths (nonce+cap for admin, `ec_can_manage_artist` for centralized).

Note: there is currently no front-end artist-manager block field for this setting in this repo (the meta key is only wired through the wp-admin metabox today), but the centralized writer is now ready to persist it the moment a front-end field submitting `ec_allow_public_topic_creation` reaches the `ec_artist_profile_save` flow.

cc <@532385681268408341> — open and ready for review.