### PR TITLE
chore: remove debug error_log spew from subscriber CSV export

### DIFF
--- a/inc/artist-profiles/subscribe-data-functions.php
+++ b/inc/artist-profiles/subscribe-data-functions.php
@@ -76,71 +76,55 @@ function extrachill_artist_get_artist_subscribers( $artist_id, $args = array() )
  * Hooked to admin_post and admin_post_nopriv.
  */
 function extrachill_artist_export_artist_subscribers_csv() {
-    error_log('extrachill_artist_export_artist_subscribers_csv: Function started.');
-
     // Check for required parameters (artist_id and nonce) - accept GET or POST
     // Using $_REQUEST to get parameters from either GET or POST
     if ( ! isset( $_REQUEST['artist_id'], $_REQUEST['_wpnonce'] ) ) {
-        error_log('extrachill_artist_export_artist_subscribers_csv: Missing required parameters (GET/POST).');
         exit;
     }
-    error_log('extrachill_artist_export_artist_subscribers_csv: Required parameters found (GET/POST).');
 
     $artist_id = apply_filters('ec_get_artist_id', $_REQUEST);
     $nonce = sanitize_text_field( $_REQUEST['_wpnonce'] );
-    error_log('extrachill_artist_export_artist_subscribers_csv: Artist ID: ' . $artist_id . ', Nonce: ' . $nonce);
 
     // Verify nonce (using the nonce action defined in the subscribers tab template)
     if ( ! wp_verify_nonce( $nonce, 'export_artist_subscribers_csv_' . $artist_id ) ) {
-        error_log('extrachill_artist_export_artist_subscribers_csv: Nonce verification failed.');
         exit;
     }
-    error_log('extrachill_artist_export_artist_subscribers_csv: Nonce verified.');
 
     // Permission check: Does the current user have the capability to manage this artist's members?
     if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-         error_log('extrachill_artist_export_artist_subscribers_csv: Permission denied for artist ID: ' . $artist_id);
          exit;
     }
-    error_log('extrachill_artist_export_artist_subscribers_csv: Permission granted.');
 
     // Determine if we should include already exported subscribers - accept GET or POST
     $include_exported = isset($_REQUEST['include_exported']) && $_REQUEST['include_exported'] == '1';
     $exported_filter = $include_exported ? null : 0;
-    error_log('extrachill_artist_export_artist_subscribers_csv: Include exported: ' . ($include_exported ? 'Yes' : 'No'));
 
     // Fetch subscriber data
     $subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array( 'limit' => -1, 'exported' => $exported_filter ) );
-    error_log('extrachill_artist_export_artist_subscribers_csv: Fetched ' . count($subscribers) . ' subscribers.');
 
     // Get artist name for filename
     $artist_name = get_the_title( $artist_id );
     $filename = sanitize_title( $artist_name ) . '-subscribers-' . date( 'Y-m-d' ) . '.csv';
-    error_log('extrachill_artist_export_artist_subscribers_csv: Filename: ' . $filename);
 
     // Clean any output buffer before setting headers
     if (ob_get_contents()) {
         ob_clean();
     }
-    error_log('extrachill_artist_export_artist_subscribers_csv: Output buffer cleaned (if active).');
 
     // Set headers for CSV download
     header( 'Content-Type: text/csv; charset=' . get_option( 'blog_charset' ) );
     header( 'Content-Disposition: attachment; filename="' . $filename . '"');
     header( 'Pragma: no-cache' );
     header( 'Expires: 0' );
-    error_log('extrachill_artist_export_artist_subscribers_csv: Headers set.');
 
     // Output CSV content
     $output = fopen( 'php://output', 'w' );
-    error_log('extrachill_artist_export_artist_subscribers_csv: Output stream opened.');
 
     // Add BOM for UTF-8 support in some spreadsheet programs
     fputs( $output, chr(0xEF) . chr(0xBB) . chr(0xBF) );
 
     // Add CSV headers
     fputcsv( $output, array( __( 'Email', 'extrachill-artist-platform' ), __( 'Username', 'extrachill-artist-platform' ), __( 'Subscribed At (UTC)', 'extrachill-artist-platform' ), __( 'Exported', 'extrachill-artist-platform' ) ) );
-    error_log('extrachill_artist_export_artist_subscribers_csv: CSV headers written.');
 
     // Add data rows and collect IDs to mark as exported if needed
     $subscriber_ids_to_mark_exported = array();
@@ -157,14 +141,11 @@ function extrachill_artist_export_artist_subscribers_csv() {
             $subscriber_ids_to_mark_exported[] = $subscriber->subscriber_id;
         }
     }
-    error_log('extrachill_artist_export_artist_subscribers_csv: Data rows written.');
 
     fclose( $output );
-    error_log('extrachill_artist_export_artist_subscribers_csv: Output stream closed.');
 
     // Mark exported subscribers as exported in the database (only if not including all)
     if ( !$include_exported && ! empty( $subscriber_ids_to_mark_exported ) ) {
-         error_log('extrachill_artist_export_artist_subscribers_csv: Marking ' . count($subscriber_ids_to_mark_exported) . ' subscribers as exported.');
          global $wpdb;
          $table_name = $wpdb->prefix . 'artist_subscribers';
          $ids_string = implode( ', ', array_map( 'absint', $subscriber_ids_to_mark_exported ) );


### PR DESCRIPTION
## Summary

Removes ~20 `error_log('extrachill_artist_export_artist_subscribers_csv: ...')` step-trace statements left from hotfix-style debugging in the shipping subscriber CSV export function (`inc/artist-profiles/subscribe-data-functions.php`). These logged on **every** export in production ("Function started / Headers set / Output stream opened / ...").

Closes #48.

## What changed

- Deleted all step-trace `error_log()` lines from `extrachill_artist_export_artist_subscribers_csv()` (19 deletions).
- No `error_log()` remains in the export path. None of the removed lines logged an actual error — they were pure step traces. The early-exit branches (missing params, nonce failure, permission denied) are silent-by-design `exit;` guards, so nothing error-level needed retaining.
- **Export logic and output are completely unchanged** — only logging was removed.

## Verification

- `php -l` passes (no syntax errors).
- Grep confirms zero `error_log` references remain in the file.
- CSV output (headers, BOM, rows, exported-marking DB update) is byte-for-byte identical to before.

## Acceptance criteria

- [x] Step-trace `error_log()` statements removed from the CSV export path
- [x] Any retained logging is error-only and WP_DEBUG-gated (n/a — no logging worth retaining)