### PR TITLE
refactor: replace hardcoded extrachill.com domain with ec_get_site_url

### DIFF
--- a/inc/home/templates/hero.php
+++ b/inc/home/templates/hero.php
@@ -35,7 +35,7 @@ $user_artist_ids    = isset( $user_artist_ids ) ? $user_artist_ids : array();
             <a href="<?php echo esc_url( home_url( '/login/#tab-register' ) ); ?>" class="button-2 button-medium">
                 <?php esc_html_e( 'Sign Up', 'extrachill-artist-platform' ); ?>
             </a>
-            <a href="https://docs.extrachill.com/artist-platform/" class="button-3 button-medium">
+            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
                 <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
             </a>
         </div>
@@ -50,7 +50,7 @@ $user_artist_ids    = isset( $user_artist_ids ) ? $user_artist_ids : array();
             <a href="<?php echo esc_url( home_url( '/create-artist/' ) ); ?>" class="button-1 button-medium">
                 <?php esc_html_e( 'Create Artist Profile', 'extrachill-artist-platform' ); ?>
             </a>
-            <a href="https://docs.extrachill.com/artist-platform/" class="button-3 button-medium">
+            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
                 <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
             </a>
         </div>
@@ -65,7 +65,7 @@ $user_artist_ids    = isset( $user_artist_ids ) ? $user_artist_ids : array();
             <a href="<?php echo esc_url( ec_get_site_url( 'community' ) . '/settings/#tab-artist-platform' ); ?>" class="button-1 button-medium">
                 <?php esc_html_e( 'Request Artist Access', 'extrachill-artist-platform' ); ?>
             </a>
-            <a href="https://docs.extrachill.com/artist-platform/" class="button-3 button-medium">
+            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
                 <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
             </a>
         </div>


### PR DESCRIPTION
## Summary
Replaces three hardcoded `https://docs.extrachill.com/artist-platform/` "Learn More" links in the home hero template with `ec_get_site_url( 'docs' ) . '/artist-platform/'` (wrapped in `esc_url()`).

On staging/dev clones the `ec_site_url_override` filter rewrites domains; the hardcoded URLs leaked the production domain and weren't using the domain map at all.

## Changes
- `inc/home/templates/hero.php:38,53,68` — derive the docs URL from `ec_get_site_url( 'docs' )`

## Verification
- Site key `docs` → blog ID 10 → `docs.extrachill.com` (matches the replaced literal); no behavior change on production, clones now resolve correctly.

refs Extra-Chill/extrachill-multisite#36