### PR TITLE
refactor: extract roster invite-status constants

### DIFF
--- a/inc/artist-profiles/roster/artist-invitation-emails.php
+++ b/inc/artist-profiles/roster/artist-invitation-emails.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/roster-data-functions.php'; // For ec_get_pending_invit
  * @param string $member_display_name The display name for the member (as initially entered).
  * @param string $invitation_token The unique token for the invitation.
  * @param int    $artist_id The ID of the artist.
- * @param string $invitation_status Status of the invitation (e.g., 'invited_new_user', 'invited_existing_artist').
+ * @param string $invitation_status Status of the invitation; one of EC_INVITE_STATUS_NEW_USER or EC_INVITE_STATUS_EXISTING_ARTIST.
  * @return bool True if the email was sent successfully, false otherwise.
  */
 function ec_send_artist_invitation_email( $recipient_email, $artist_name, $member_display_name, $invitation_token, $artist_id, $invitation_status ) {
@@ -32,7 +32,7 @@ function ec_send_artist_invitation_email( $recipient_email, $artist_name, $membe
 
 	// Construct the invitation link
 	$invitation_base_url = home_url( '/' );
-	if ( 'invited_new_user' === $invitation_status ) {
+	if ( EC_INVITE_STATUS_NEW_USER === $invitation_status ) {
 		$invitation_link = add_query_arg( array(
 			'action'    => 'ec_accept_invite',
 			'token'     => $invitation_token,
@@ -63,7 +63,7 @@ function ec_send_artist_invitation_email( $recipient_email, $artist_name, $membe
 	}
 
 	// CTA copy varies based on whether the invitee already has an account.
-	if ( 'invited_new_user' === $invitation_status ) {
+	if ( EC_INVITE_STATUS_NEW_USER === $invitation_status ) {
 		$cta_label = __( 'Accept invitation & create account', 'extrachill-artist-platform' );
 	} else {
 		$cta_label = __( 'Accept invitation', 'extrachill-artist-platform' );
@@ -152,8 +152,8 @@ function ec_handle_invitation_acceptance() {
 		if ( ! empty( $pending_invitations ) ) {
 			foreach ( $pending_invitations as $key => $invite ) {
 				if ( isset( $invite['token'] ) && $invite['token'] === $token ) {
-					// Check invite status - only 'invited_existing_artist' is relevant here for now
-					if ( isset( $invite['status'] ) && 'invited_existing_artist' === $invite['status'] ) {
+					// Check invite status - only EC_INVITE_STATUS_EXISTING_ARTIST is relevant here for now
+					if ( isset( $invite['status'] ) && EC_INVITE_STATUS_EXISTING_ARTIST === $invite['status'] ) {
 						// Check email match
 						if ( isset( $invite['email'] ) && strtolower( $invite['email'] ) === strtolower( $current_user->user_email ) ) {
 							$valid_invite         = $invite;

--- a/inc/artist-profiles/roster/manage-roster-ui.php
+++ b/inc/artist-profiles/roster/manage-roster-ui.php
@@ -73,10 +73,10 @@ function ec_display_manage_members_section( $artist_id, $current_user_id ) {
                     $invited_on_formatted = date_i18n( get_option( 'date_format' ), $invite['invited_on'] );
                     $status_text = '';
                     switch ( $invite['status'] ) {
-                        case 'invited_existing_artist':
+                        case EC_INVITE_STATUS_EXISTING_ARTIST:
                             $status_text = __( 'Invited (Existing User)', 'extrachill-artist-platform' );
                             break;
-                        case 'invited_new_user':
+                        case EC_INVITE_STATUS_NEW_USER:
                             $status_text = __( 'Invited (New User)', 'extrachill-artist-platform' );
                             break;
                         default:

--- a/inc/artist-profiles/roster/roster-data-functions.php
+++ b/inc/artist-profiles/roster/roster-data-functions.php
@@ -6,6 +6,52 @@
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Roster invite-status contract.
+ *
+ * These named constants are the single source of truth for the invite-status
+ * enum produced by ec_add_pending_invitation() and consumed by the roster UI,
+ * invitation emails, and the cross-network registration/acceptance flows in
+ * extrachill-users.
+ *
+ * IMPORTANT: The string VALUES are a stable cross-plugin contract. They are
+ * persisted in post meta (`_pending_invitations`) and matched by string
+ * equality in extrachill-users. Do NOT change the values without a coordinated
+ * data migration and updates to every consumer.
+ *
+ * Pending-invitation array shape (stored in `_pending_invitations` post meta):
+ *   array(
+ *     'id'           => string,  // 'inv_' . 12 random chars — stable removal key
+ *     'display_name' => string,  // sanitized display name
+ *     'email'        => string,  // sanitized email
+ *     'token'        => string,  // 32-char acceptance token
+ *     'status'       => string,  // one of EC_INVITE_STATUS_* below
+ *     'invited_on'   => int,     // GMT Unix timestamp
+ *   )
+ *
+ * @see ec_add_pending_invitation()
+ */
+
+/**
+ * Invite status: the email belongs to an existing user account.
+ *
+ * Acceptance is handled in-place (the existing user clicks the link while
+ * logged in); acceptance verifies/adds the artist membership meta.
+ */
+if ( ! defined( 'EC_INVITE_STATUS_EXISTING_ARTIST' ) ) {
+	define( 'EC_INVITE_STATUS_EXISTING_ARTIST', 'invited_existing_artist' );
+}
+
+/**
+ * Invite status: the email has no account yet.
+ *
+ * Acceptance routes through the registration flow in extrachill-users, which
+ * creates the account and then links the artist membership.
+ */
+if ( ! defined( 'EC_INVITE_STATUS_NEW_USER' ) ) {
+	define( 'EC_INVITE_STATUS_NEW_USER', 'invited_new_user' );
+}
+
 // --- Pending Invitation Functions ---
 
 /**
@@ -58,10 +104,10 @@ function ec_add_pending_invitation( $artist_id, $display_name, $email ) { // Rem
     if ( $existing_user_id ) {
         // User exists. We will invite them. 
         // The acceptance process will handle adding 'user_is_artist' meta if needed.
-        $final_status = 'invited_existing_artist'; // Use this status; acceptance will verify/add meta.
+        $final_status = EC_INVITE_STATUS_EXISTING_ARTIST; // Use this status; acceptance will verify/add meta.
     } else {
         // New user
-        $final_status = 'invited_new_user';
+        $final_status = EC_INVITE_STATUS_NEW_USER;
     }
 
     $new_invite_entry = array(
@@ -70,7 +116,7 @@ function ec_add_pending_invitation( $artist_id, $display_name, $email ) { // Rem
         'email'         => sanitize_email( $email ),
         'token'         => $token,
         'status'        => sanitize_key( $final_status ), 
-        'invited_on'    => current_time( 'timestamp', true ) // GMT timestamp
+        'invited_on'    => time() // GMT Unix timestamp (replaces deprecated current_time( 'timestamp', true ))
     );
 
     $invitations[] = $new_invite_entry;


### PR DESCRIPTION
## Summary

Extracts the roster invite-status enum (`invited_existing_artist`, `invited_new_user`) into named constants in the **producer** (extrachill-artist-platform), eliminating bare magic-string equality across this repo's call sites. Fixes the deprecated `current_time('timestamp', true)` usage. Refs #47.

A producer-side rename of these values silently breaks acceptance flows in extrachill-users with no error — these constants make the contract explicit and grep-able.

## Where the constants live

Defined in the producer file `inc/artist-profiles/roster/roster-data-functions.php` (the source of truth that emits the status), guarded with `if ( ! defined() )`:

- `EC_INVITE_STATUS_EXISTING_ARTIST` = `'invited_existing_artist'`
- `EC_INVITE_STATUS_NEW_USER` = `'invited_new_user'`

This file is already `require_once`'d by both AP consumers (`manage-roster-ui.php`, `artist-invitation-emails.php`), so the constants are available wherever the enum is read in this repo. The pending-invitation **array shape** is now documented in a docblock alongside the constants.

> **Why the producer, not a shared location:** the cross-network consumers live in a different plugin/repo (extrachill-users). Cleanly sharing constants across that repo boundary requires coordinated edits to extrachill-users that belong in a separate PR (see follow-up below). The string VALUES are unchanged, so the on-disk/persisted contract is identical — this is a pure rename to named constants.

## Call sites migrated (this repo)

| File | Lines | Change |
|------|-------|--------|
| `roster-data-functions.php` | producer | `$final_status` now assigned from the constants |
| `artist-invitation-emails.php` | 35, 66, 156 | string equality → constants; docblock updated |
| `manage-roster-ui.php` | 76, 79 | `switch`/`case` labels → constants |

The only remaining literal occurrences of the values are the two `define()` calls themselves (the single source of truth).

## Deprecated current_time fix

`roster-data-functions.php` `invited_on` changed from the deprecated `current_time( 'timestamp', true )` to `time()` — the modern equivalent for a GMT Unix timestamp. Behavior is identical (both return a GMT Unix timestamp).

## Follow-up needed (extrachill-users — separate PR)

These cross-network consumers still string-match `'invited_new_user'` and should adopt the shared constants in a dedicated PR (out of scope here — wrong repo):

- `inc/auth/register.php:106`
- `inc/auth-tokens/service.php:600`
- `build/login-register/render.php:100`

Adopting the constants there requires either a coordinated load order (extrachill-artist-platform's producer file being available) or re-declaring the contract constants in extrachill-users. That's a deliberate cross-repo design decision tracked as the remaining work on #47.

## Verification

- No bare invite-status strings remain in this repo except the two `define()` definitions.
- `php -l` clean on all three changed files.
- String VALUES unchanged → invite/acceptance flow behavior is identical.