### PR TITLE
Resolve Cancel Invite #49 — feature already ships via React roster

### DIFF
--- a/inc/artist-profiles/roster/manage-roster-ui.php
+++ b/inc/artist-profiles/roster/manage-roster-ui.php
@@ -88,7 +88,15 @@ function ec_display_manage_members_section( $artist_id, $current_user_id ) {
                         <span class="member-email"><?php echo esc_html( $invite['email'] ); ?></span>
                         <span class="member-status-label">(<?php echo esc_html( $status_text ); ?>: <?php echo esc_html( $invited_on_formatted ); ?>)</span>
                         <span class="member-actions">
-                            <?php /* Future: Add Cancel Invite action */ ?>
+                            <?php
+                            /*
+                             * Cancel Invite is handled by the React `artist-manager` block,
+                             * which calls DELETE /extrachill/v1/artists/{id}/roster/invites/{invite_id}
+                             * (extrachill-api) -> ec_remove_pending_invitation(). No AJAX; capability
+                             * enforced via ec_can_manage_artist() in the REST handler. This legacy
+                             * server-rendered roster UI is not the active surface.
+                             */
+                            ?>
                         </span>
                     </li>
             <?php 


### PR DESCRIPTION
## Summary

Issue #49 asked to wire the "Cancel Invite" action on pending-invite roster rows to the existing backend remover `ec_remove_pending_invitation()`. **Investigation found the feature is already fully implemented end-to-end** — the placeholder in #49 is a stale comment in a dead, orphaned legacy file.

## What I found (full chain already wired)

```
React UI                  src/blocks/artist-manager/view.js
  └─ Cancel button ──► cancelRosterInvite(artistId, inv.id)
                          │
API client re-export      src/blocks/shared/api/client.js:69
  └─ client.artists.cancelRosterInvite
                          │
@extrachill/api-client    ArtistsResource.cancelRosterInvite()
  └─ DELETE extrachill/v1/artists/{id}/roster/invites/{invite_id}
                          │
extrachill-api            inc/routes/artists/roster.php
  └─ extrachill_api_artist_roster_cancel_invite_handler()
       ├─ post-type validation (artist_profile)
       ├─ ec_can_manage_artist() capability check  ◄── enforced
       └─ ec_remove_pending_invitation($artist_id, $invite_id)
```

- **No AJAX.** Submission is a REST `DELETE` via `@wordpress/api-fetch` → `@extrachill/api-client` transport. No `admin-ajax`.
- **Capability check enforced** in the REST handler: `ec_can_manage_artist( get_current_user_id(), $artist_id )` returns 403 otherwise.
- **Acceptance criteria already met**: pending invites can be cancelled from the roster UI; routes through the existing remover; no AJAX.

## The only remaining artifact

`inc/artist-profiles/roster/manage-roster-ui.php` is a **legacy server-rendered roster UI**. Its function `ec_display_manage_members_section()` is `require_once`'d (so defined) but **never invoked anywhere** in the codebase — it has been replaced by the React `artist-manager` block. The `/* Future: Add Cancel Invite action */` placeholder cited in #49 lives in that dead function.

Wiring a *second* cancel path into this orphaned PHP UI would resurrect a parallel server-rendered roster interface that no longer renders — inventing a duplicate submission path the platform doesn't use. That contradicts the no-duplication intent.

## Change in this PR

Replaced the misleading `/* Future: Add Cancel Invite action */` TODO with an accurate annotation pointing to the live React + REST implementation, so the legacy file no longer falsely advertises an unbuilt feature.

```diff
-                            <?php /* Future: Add Cancel Invite action */ ?>
+                            <?php
+                            /*
+                             * Cancel Invite is handled by the React `artist-manager` block,
+                             * which calls DELETE /extrachill/v1/artists/{id}/roster/invites/{invite_id}
+                             * (extrachill-api) -> ec_remove_pending_invitation(). No AJAX; capability
+                             * enforced via ec_can_manage_artist() in the REST handler. This legacy
+                             * server-rendered roster UI is not the active surface.
+                             */
+                            ?>
```

PHP lint: clean. No JS rebuild needed (comment-only PHP change).

## Note on commit message

Used `docs:` rather than the originally-suggested `feat:` because no feature is being added — the feature already ships. A `feat:` message here would drive an inaccurate changelog entry.

Closes #49.

cc <@532385681268408341>