### PR TITLE
fix: self-heal zero post_modified_gmt to prevent RSS feed fatals

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -237,3 +237,84 @@ function extrachill_artist_platform_maybe_create_pages() {
     }
 }
 add_action( 'admin_init', 'extrachill_artist_platform_maybe_create_pages' );
+
+/**
+ * Self-heal posts whose post_modified_gmt is the MySQL zero date.
+ *
+ * WordPress core's get_feed_build_date() (wp-includes/feed.php) collects
+ * post_modified_gmt values from the feed query, discards the zero date, then
+ * calls max() on the result. When a feed query returns ONLY posts with
+ * post_modified_gmt = '0000-00-00 00:00:00' the array is empty and max([])
+ * throws a ValueError on PHP 8, fataling the entire feed. Bots crawling
+ * CPT-scoped feeds on this site (e.g. /feed/?post_type=forum) triggered this
+ * thousands of times per day on artist.extrachill.com.
+ *
+ * The historical bad rows came from a retired per-artist forum auto-creation
+ * path that bypassed wp_insert_post()'s modified-date defaults. That path has
+ * been removed, but this idempotent, run-once-per-version sweep guarantees no
+ * post can keep a zero post_modified_gmt regardless of how it was inserted.
+ *
+ * DOCUMENTED GOTCHA: the naive backfill
+ *   SET post_modified_gmt = post_date_gmt WHERE post_modified_gmt = '0000-00-00 00:00:00'
+ * SILENTLY FAILS for imported rows whose post_date_gmt is ALSO the zero date.
+ * We therefore derive GMT from the always-valid LOCAL post_date via CONVERT_TZ
+ * using THIS blog's own UTC offset (resolved from wp_timezone(), which is
+ * correct per-site: e.g. UTC on artist.extrachill.com, America/New_York on the
+ * main site). A zero post_date_gmt is repaired in the same pass so future
+ * writes have a coherent GMT baseline.
+ *
+ * @return void
+ */
+function extrachill_artist_platform_heal_zero_modified_dates() {
+    global $wpdb;
+
+    $healed_version = '1.0.0';
+    $stored = get_option( 'extrachill_artist_platform_feed_date_heal', '0' );
+    if ( version_compare( $stored, $healed_version, '>=' ) ) {
+        return;
+    }
+
+    $zero = '0000-00-00 00:00:00';
+
+    // Resolve this blog's UTC offset as a MySQL CONVERT_TZ offset string.
+    // wp_timezone() is per-site and DST-aware; it yields '+00:00' on a site
+    // configured for UTC and e.g. '-04:00' on America/New_York during EDT.
+    $tz      = wp_timezone();
+    $seconds = $tz->getOffset( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
+    $sign    = $seconds < 0 ? '-' : '+';
+    $abs     = abs( (int) $seconds );
+    $offset  = sprintf( '%s%02d:%02d', $sign, intdiv( $abs, HOUR_IN_SECONDS ), intdiv( $abs % HOUR_IN_SECONDS, MINUTE_IN_SECONDS ) );
+
+    // Repair a zero post_date_gmt first, derived from the valid local post_date.
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$wpdb->posts}
+             SET post_date_gmt = CONVERT_TZ( post_date, %s, '+00:00' )
+             WHERE post_date_gmt = %s
+               AND post_date <> %s",
+            $offset,
+            $zero,
+            $zero
+        )
+    );
+
+    // Backfill modified dates. post_modified mirrors the local post_date;
+    // post_modified_gmt is derived from the LOCAL post_date (never trusted from
+    // post_date_gmt). Heals all statuses so a future status flip to publish
+    // cannot resurface the feed crash.
+    $wpdb->query(
+        $wpdb->prepare(
+            "UPDATE {$wpdb->posts}
+             SET post_modified     = post_date,
+                 post_modified_gmt = CONVERT_TZ( post_date, %s, '+00:00' )
+             WHERE post_modified_gmt = %s
+               AND post_date <> %s",
+            $offset,
+            $zero,
+            $zero
+        )
+    );
+
+    update_option( 'extrachill_artist_platform_feed_date_heal', $healed_version );
+}
+add_action( 'admin_init', 'extrachill_artist_platform_heal_zero_modified_dates' );


### PR DESCRIPTION
## Summary

Closes #55. Stops the sustained `feed.php:736` PHP fatal on `artist.extrachill.com` and hardens the site against it recurring.

Two axes, both addressed:

1. **Data (already corrected out of band)** — every publish-status post network-wide now has a valid `post_modified_gmt` (verified 0 across all 9 blogs).
2. **Code (this PR)** — an idempotent, run-once-per-version self-healing sweep so no post can keep a zero `post_modified_gmt` regardless of how it was inserted.

## Root cause (confirmed by code archaeology, not just the symptom)

WP core `get_feed_build_date()` (`wp-includes/feed.php:736`) collects `post_modified_gmt` from the feed query, discards the zero date, then calls `max()`. When a feed query returns **only** posts with `post_modified_gmt = '0000-00-00 00:00:00'`, the array is empty and `max([])` throws a `ValueError` on PHP 8 — fataling the whole feed. Bots crawling CPT-scoped feeds (e.g. `/feed/?post_type=forum`) hit this ~5–10k/day.

The bad rows were the **52 published `forum` posts** created by a retired **per-artist forum auto-creation** path that bypassed `wp_insert_post`'s modified-date defaults. That path is **already gone**:
- #56/#57 (`e7fb4ed`) removed the per-artist forum admin UI; the `publish_artist_profile` forum auto-creation hook is commented out, no `bbp_insert_forum`.
- The remaining `wp_insert_post` calls in this repo create only `artist_profile` / `artist_link_page` / `page` via vanilla `wp_insert_post`, which backfills modified dates correctly.

So there is **no live insert path in this plugin that bypasses `post_modified_gmt`**. This PR is defense-in-depth against the WP-core `max([])` fragility, not a fix to an active insert bug.

> The `forum` post type is owned by **bbPress**; the only forum *creation* in the active tree is `bbp_insert_forum()` in **extrachill-community** activation (community forums, which set dates correctly). Confirmed — not editing another repo.

## The fix

`extrachill-artist-platform.php` — new `extrachill_artist_platform_heal_zero_modified_dates()` on `admin_init`, gated by a `extrachill_artist_platform_feed_date_heal` version option (mirrors the existing `extrachill_artist_platform_maybe_create_pages` upgrade scaffold). Runs once, idempotent.

- **Derives GMT from the always-valid local `post_date`** via `CONVERT_TZ(post_date, <offset>, '+00:00')`.
- **Per-blog offset from `wp_timezone()`** — correct per-site: `+00:00` on `artist.extrachill.com` (which runs UTC: `gmt_offset=0`, empty `timezone_string`), `-04:00` on the main site (`America/New_York`, EDT). A hardcoded `-05:00` would have **corrupted** blog 4's dates by 5h; this avoids that.
- **Documented gotcha handled:** the naive `SET post_modified_gmt = post_date_gmt` silently fails on imported rows whose `post_date_gmt` is *also* the zero date. We never trust `post_date_gmt` — we derive from local `post_date`, and repair a zero `post_date_gmt` in the same pass.
- Heals **all statuses** (not just publish) so a future status flip can't resurface the bug.

### Why a one-time sweep, not a per-request guard
Scanning the posts table on every request would be wasteful, and the live insert path is already gone. A versioned, run-once backfill mirrors the plugin's existing upgrade pattern and self-heals any stray bad row introduced before deploy.

## Backfill SQL (the equivalent of what the new code runs)

```sql
-- repair zero GMT date from valid local date (per-blog offset; +00:00 on blog 4)
UPDATE c8c_4_posts
SET post_date_gmt = CONVERT_TZ(post_date, '+00:00', '+00:00')
WHERE post_date_gmt = '0000-00-00 00:00:00' AND post_date <> '0000-00-00 00:00:00';

-- backfill modified dates (derive GMT from LOCAL post_date, not post_date_gmt)
UPDATE c8c_4_posts
SET post_modified = post_date,
    post_modified_gmt = CONVERT_TZ(post_date, '+00:00', '+00:00')
WHERE post_modified_gmt = '0000-00-00 00:00:00' AND post_date <> '0000-00-00 00:00:00';
```

`CONVERT_TZ` with a **numeric** offset needs no `mysql.time_zone` tables. (Verified separately for the EDT case on the main site: `2025-05-19 19:17:53` @ `-04:00` → `2025-05-19 23:17:53` GMT.)

## Row counts (publish-status — the crash-relevant set)

| Blog | publish posts with zero `post_modified_gmt` (after) |
|------|------|
| 1 (extrachill) | 0 |
| 2 (community) | 0 |
| 3 (shop) | 0 |
| 4 (artist) | 0 |
| 7 (events) | 0 |
| 9 (newsletter) | 0 |
| 10 (docs) | 0 |
| 11 (wire) | 0 |
| 12 (studio) | 0 |

The 52 forum posts named in the issue (IDs 12116/12153/12190…) no longer exist as zero-modified — repaired/removed during the orphaned-forum cleanup. Blog 4's only remaining zero-modified rows are **non-publish** (72 `attachment`/`inherit`, 1 `artist_link_page`/`draft`) which feeds never query, so they don't trigger the crash; the new sweep heals them too as hygiene.

> **Important data note for review:** `artist.extrachill.com` (blog 4) runs on **UTC** (`gmt_offset=0`, empty `timezone_string`) — every `post_date` equals its `post_date_gmt`. The MEMORY/issue guidance to use `CONVERT_TZ(post_date,'-05:00','+00:00')` was for the **main site** (`America/New_York`); applying a -5h shift on blog 4 would have corrupted dates. The code resolves the offset per-blog via `wp_timezone()`, so it's correct on every site.

## Verification

- `php -l extrachill-artist-platform.php` → no syntax errors ✅
- `wp_timezone()->getOffset(now)` on blog 4 → `+00:00` (correct, blog 4 is UTC) ✅
- Numeric `CONVERT_TZ` confirmed (no time_zone tables needed) ✅
- Network rescan: **0** publish zero-modified posts on all 9 blogs ✅
- `https://artist.extrachill.com/feed/` and `/feed/?post_type=forum` → 301 (production canonical redirect, not a fatal) ✅
- `grep "feed.php on line 736" wp-content/debug.log` per day: **27–31 May = 0** new fatals (bleed stopped) ✅