### PR TITLE
feat: link roster members to their community profiles

### DIFF
--- a/inc/artist-profiles/roster/manage-roster-ui.php
+++ b/inc/artist-profiles/roster/manage-roster-ui.php
@@ -46,9 +46,20 @@ function ec_display_manage_members_section( $artist_id, $current_user_id ) {
                         $linked_user_ids[] = $user_info->ID;
                         $processed_emails[] = strtolower($user_info->user_email);
             ?>
+                        <?php
+                        $community_profile_url = function_exists( 'extrachill_get_user_community_profile_url' )
+                            ? extrachill_get_user_community_profile_url( $user_info->ID )
+                            : '';
+                        ?>
                         <li data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" class="ec-member-linked">
                             <?php echo get_avatar( $user_info->ID, 32 ); ?>
-                            <span class="member-name"><?php echo esc_html( $user_info->display_name ); ?> (<?php echo esc_html( $user_info->user_login ); ?>)</span>
+                            <span class="member-name"><?php
+                                if ( ! empty( $community_profile_url ) ) :
+                                    ?><a href="<?php echo esc_url( $community_profile_url ); ?>"><?php echo esc_html( $user_info->display_name ); ?></a><?php
+                                else :
+                                    echo esc_html( $user_info->display_name );
+                                endif;
+                            ?> (<?php echo esc_html( $user_info->user_login ); ?>)</span>
                             <span class="member-status-label">(Linked Account)</span>
                             <?php if ( $user_info->ID !== $current_user_id ) : ?>
                                 <button type="button" class="button-2 button-small ec-remove-member-button" data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" title="<?php esc_attr_e( 'Remove this member from artist', 'extrachill-artist-platform' ); ?>">&times; <?php esc_html_e('Remove', 'extrachill-artist-platform'); ?></button>


### PR DESCRIPTION
Closes #59

## What changed
The artist roster's linked-member rows now link each member's display name to their community profile. Previously the roster rendered the member name as plain text even though a canonical cross-site resolver already existed.

Single render site touched: `inc/artist-profiles/roster/manage-roster-ui.php`, the linked-member `<li>` loop. The member display name is now wrapped in an `<a>` pointing at the member's community `/u/{nicename}` URL; the `(user_login)` suffix and all other markup are unchanged.

## Resolver reused (no new resolver added)
- `extrachill_get_user_community_profile_url( $user_info->ID )` — defined in `extrachill-multisite/inc/cross-site-links/entity-links.php` (network-active). Returns the community `/u/{nicename}` URL, or `''` when the user has no community profile.
- Guarded with `function_exists( 'extrachill_get_user_community_profile_url' )` per the codebase's cross-plugin convention.

## Graceful omission
When the resolver returns `''` (no community profile), the name renders as plain `esc_html()` text with **no** broken/empty `href`.

## Escaping
- `esc_url()` on the profile URL
- `esc_html()` on the display name

## Scope / safety
- Minimal change — only the linked-member row; the pending-invitations branch is untouched and the loop was not refactored.
- No theme edits.
- No `CHANGELOG.md` edits.
- No version bumps.