### PR TITLE
refactor: drop dead bp_ follow-system default for subscriber source

### DIFF
--- a/inc/database/subscriber-db.php
+++ b/inc/database/subscriber-db.php
@@ -21,7 +21,7 @@ function extrachill_artist_create_subscribers_table() {
         artist_profile_id BIGINT(20) UNSIGNED NOT NULL,
         subscriber_email VARCHAR(255) NOT NULL,
         username VARCHAR(60) NULL DEFAULT NULL,
-        source VARCHAR(50) NOT NULL DEFAULT 'platform_follow_consent',
+        source VARCHAR(50) NOT NULL DEFAULT 'artist_subscribe_form',
         subscribed_at DATETIME NOT NULL,
         exported TINYINT(1) NOT NULL DEFAULT 0,
         PRIMARY KEY (subscriber_id),


### PR DESCRIPTION
## Summary

The `artist_subscribers` table's `source` column defaulted to `'platform_follow_consent'` — a magic string left over from the removed BuddyPress-style `bp_*` follow system. This changes the schema default to an accurate value reflecting how subscribers are actually added today.

## Investigation

- The only real subscriber write path is the artist-subscribe ability handler (`inc/abilities/handlers/artist-subscribe.php`), which already defaults `source` to `'artist_subscribe_form'` when the caller omits it.
- No live PHP path writes `'platform_follow_consent'` as a *default* — the only remaining references are: (a) this schema default, and (b) the users-plugin email-consent ability, which sets that value *explicitly* on its own consent rows (untouched here). The string also appears in `docs/subscription/` describing the old system.
- So the `'platform_follow_consent'` DB default was purely a dead-system leftover.

## Change

- `source VARCHAR(50) NOT NULL DEFAULT 'platform_follow_consent'` -> `DEFAULT 'artist_subscribe_form'`

Any future caller that omits `source` now records the real acquisition path (the subscribe form) instead of a defunct source.

## Schema / data note

This is a **schema-default change for new inserts only**. It does **not** require a migration of existing rows (existing `source` values are untouched; `dbDelta` will only adjust the column default on the next schema sync). Coordinates with the subscriber-db lifecycle work in artist-platform#54.

## Verification
- Sweep test `git grep -nE '\bbp_[a-z]' -- '*.php' | grep -v bbp_` -> no matches.
- `php -l inc/database/subscriber-db.php` -> No syntax errors detected.

Refs Extra-Chill/extrachill-users#103