### PR TITLE
feat: artist profile hub foundation — term binding + section registry

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -75,10 +75,14 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/templates.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/page-title.php';
 
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
+
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/permissions.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/artist-grid.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/breadcrumbs.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/section-registry.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/default-sections.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/subscribe-data-functions.php';
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/create-link-page.php';

--- a/inc/artist-profiles/frontend/default-sections.php
+++ b/inc/artist-profiles/frontend/default-sections.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Default Artist Profile Sections (registered by AP core)
+ *
+ * Re-homes the blocks that single-artist_profile.php used to hardcode into the
+ * section registry (see section-registry.php). Output is intentionally
+ * byte-equivalent to the previous template so there is NO visual regression for
+ * this foundation PR — only the wiring changes (template loop instead of inline
+ * markup).
+ *
+ * Sections registered here:
+ *   - hero       (priority 10): header image, manage button, profile image,
+ *                title + genre/local-scene meta, social icons, and the link-page
+ *                URL card. This is where the link page becomes "one tool" — a
+ *                card inside the profile, not the destination the profile links
+ *                out to.
+ *   - overview   (priority 20): the .entry-content block — the About bio.
+ *
+ * The cross-site Coverage block is NO LONGER rendered here. It moved to a
+ * foreign-registered section owned by extrachill-multisite (priority 30, id
+ * `coverage`) via the same `ec_artist_profile_sections` filter — the layer-pure
+ * proof that a foreign plugin self-registers a term-scoped hub section. AP core
+ * does not name it.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register AP core's default profile sections.
+ *
+ * @param array[] $sections       Registered sections.
+ * @param int     $artist_id      Artist profile post ID.
+ * @param int     $artist_term_id Bound main-blog `artist` term_id.
+ * @return array[]
+ */
+function ec_register_default_artist_profile_sections( $sections, $artist_id, $artist_term_id ) {
+    $sections[] = array(
+        'id'       => 'hero',
+        'label'    => __( 'Overview', 'extrachill-artist-platform' ),
+        'priority' => 10,
+        'as_tab'   => false,
+        'render'   => 'ec_render_artist_profile_hero_section',
+    );
+
+    $sections[] = array(
+        'id'       => 'overview',
+        'label'    => __( 'About', 'extrachill-artist-platform' ),
+        'priority' => 20,
+        'as_tab'   => false,
+        'render'   => 'ec_render_artist_profile_overview_section',
+    );
+
+    return $sections;
+}
+add_filter( 'ec_artist_profile_sections', 'ec_register_default_artist_profile_sections', 10, 3 );
+
+/**
+ * Render the hero section.
+ *
+ * Byte-equivalent to the hero block previously inlined in
+ * single-artist_profile.php.
+ *
+ * @param int $artist_profile_id Artist profile post ID.
+ * @param int $artist_term_id    Bound main-blog `artist` term_id (unused here).
+ * @return void
+ */
+function ec_render_artist_profile_hero_section( $artist_profile_id, $artist_term_id = 0 ) {
+    $genre      = get_post_meta( $artist_profile_id, '_genre', true );
+    $local_city = get_post_meta( $artist_profile_id, '_local_city', true );
+
+    // Prepare for Hero Section
+    $hero_background_style = '';
+    $header_image_id = get_post_meta( $artist_profile_id, '_artist_profile_header_image_id', true );
+
+    if ( $header_image_id ) {
+        $image_url = wp_get_attachment_image_url( $header_image_id, 'full' ); // Or 'large', depending on desired size
+        if ( $image_url ) {
+            $hero_background_style = 'style="background-image: url(\'' . esc_url( $image_url ) . '\');"';
+        }
+    } else {
+        // Fallback for no specific header image; class-based styling can apply
+        $hero_background_style = '';
+    }
+    ?>
+
+                        <div class="artist-profile-header artist-hero" <?php echo $hero_background_style; ?>>
+                            <div class="artist-hero-overlay"></div>
+                            <div class="artist-hero-content">
+                                <?php
+                                // --- Manage Artist Button (Moved to top of hero content) ---
+                                if ( is_user_logged_in() ) :
+                                    // Display "Manage Artist Profile" button if the current user can manage members for this artist profile.
+                                    // This uses the custom capability 'manage_artist_members'.
+                                    if ( ec_can_manage_artist( get_current_user_id(), $artist_profile_id ) ) :
+                                        $manage_artist_url = get_permalink( get_page_by_path( 'manage-artist' ) );
+                                        if ( $manage_artist_url ) {
+                                            echo '<div class="artist-profile-actions">';
+                                            echo '<a href="' . esc_url( $manage_artist_url ) . '" class="button-2 button-medium artist-manage-button">Manage Artist</a>';
+                                            echo '</div>';
+                                        }
+                                    endif;
+                                endif;
+                                // --- End Manage Artist Button (Moved) ---
+                                ?>
+                                <?php // Display Profile Picture and then Title/Meta in a flex row
+                                // The artist-hero-top-row container helps to align the image and the text content side-by-side.
+                                ?>
+                                <div class="artist-hero-top-row">
+                                    <?php if ( has_post_thumbnail( $artist_profile_id ) ) : ?>
+                                        <div class="artist-profile-featured-image">
+                                            <?php echo get_the_post_thumbnail( $artist_profile_id, 'medium' ); // This is the actual profile picture ?>
+                                        </div>
+                                    <?php endif; ?>
+                                    <div class="artist-hero-text-content">
+                                        <h1 class="artist-hero-title" itemprop="headline"><?php echo esc_html( get_the_title( $artist_profile_id ) ); ?></h1>
+
+                                        <?php if ( ! empty( $genre ) || ! empty( $local_city ) ) : ?>
+                                            <p class="artist-meta-info">
+                                                <?php if ( ! empty( $genre ) ) : ?>
+                                                    <span class="artist-genre"><strong><?php esc_html_e( 'Genre:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $genre ); ?></span>
+                                                <?php endif; ?>
+                                                <?php if ( ! empty( $genre ) && ! empty( $local_city ) ) : ?>
+                                                    <span class="artist-meta-separator">|</span>
+                                                <?php endif; ?>
+                                                <?php if ( ! empty( $local_city ) ) : ?>
+                                                    <span class="artist-local-scene"><strong><?php esc_html_e( 'Local Scene:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $local_city ); ?></span>
+                                                <?php endif; ?>
+                                            </p>
+                                        <?php endif; ?>
+                                    </div>
+                                </div>
+
+                                <?php
+                                // Use centralized social links rendering
+                                $social_manager = extrachill_artist_platform_social_links();
+                                echo $social_manager->render_social_icons( $artist_profile_id, array(
+                                    'container_class' => 'artist-social-links',
+                                    'icon_class' => 'extrch-social-icon'
+                                ) );
+                                ?>
+
+                                <?php
+                                // --- Display Artist Link Page URL (New) ---
+                                $link_page_id_for_url_display = apply_filters('ec_get_link_page_id', $artist_profile_id);
+                                if ( $link_page_id_for_url_display && get_post_type( $link_page_id_for_url_display ) === 'artist_link_page' ) {
+                                    global $post; // Ensure $post is the artist_profile CPT object
+                                    if ( isset( $post ) && $post->post_type === 'artist_profile' ) {
+                                        $artist_slug_for_url = $post->post_name;
+                                        $public_url_href = '';
+                                        $public_url_display_text = '';
+
+                                        if ( defined('EXTRCH_LINKPAGE_DEV') && EXTRCH_LINKPAGE_DEV ) {
+                                            $public_url_href = get_permalink( $link_page_id_for_url_display );
+                                        } else {
+                                            // Use canonical extrachill.link URL
+                                            $public_url_href = 'https://extrachill.link/' . $artist_slug_for_url;
+                                        }
+
+                                        if ( ! empty( $public_url_href ) ) {
+                                            $public_url_display_text = preg_replace( '#^https?://#', '', $public_url_href );
+
+                                            echo '<div class="artist-public-link-display">';
+                                            echo '<a href="' . esc_url( $public_url_href ) . '" class="button-3 button-medium" rel="ugc noopener">' . esc_html( $public_url_display_text ) . '</a>';
+                                            echo '</div>';
+                                        }
+                                    }
+                                }
+                                // --- End Display Artist Link Page URL (New) ---
+                                ?>
+
+                            </div>
+                        </div>
+
+                        <?php
+                        /**
+                         * generate_after_entry_title hook.
+                         *
+                         * @since 0.1
+                         * @hooked generate_post_meta - 10
+                         */
+                        // do_action( 'generate_after_entry_title' ); // Maybe hide default meta?
+                        ?>
+<?php
+}
+
+/**
+ * Render the overview (entry-content) section: the About bio.
+ *
+ * The cross-site Coverage block that previously rendered here is now a
+ * foreign-registered section owned by extrachill-multisite (see this file's
+ * docblock). The bio block itself is byte-equivalent to the previous template.
+ *
+ * @param int $artist_profile_id Artist profile post ID.
+ * @param int $artist_term_id    Bound main-blog `artist` term_id (unused here).
+ * @return void
+ */
+function ec_render_artist_profile_overview_section( $artist_profile_id, $artist_term_id = 0 ) {
+    ?>
+                        <div class="entry-content" itemprop="text">
+                            <?php
+                            // --- Artist Bio Section ---
+                            $artist_name = get_the_title( $artist_profile_id );
+                            $artist_bio = get_post_field( 'post_content', $artist_profile_id );
+
+                            echo '<div class="artist-bio-section">';
+                            echo '<h2 class="section-title">' . esc_html( sprintf( __( 'About %s', 'extrachill-artist-platform' ), $artist_name ) ) . '</h2>';
+                            if ( ! empty( $artist_bio ) ) {
+                                echo '<div class="artist-bio">';
+                                echo wpautop( $artist_bio );
+                                echo '</div>';
+                            } else {
+                                echo '<p>' . __( 'No biography available yet.', 'extrachill-artist-platform' ) . '</p>';
+                            }
+                            echo '</div>'; // .artist-bio-section
+                            ?>
+                        </div><!-- .entry-content -->
+<?php
+}

--- a/inc/artist-profiles/frontend/section-registry.php
+++ b/inc/artist-profiles/frontend/section-registry.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Artist Profile Section/Tab Registry ("the hub")
+ *
+ * The single-artist_profile template no longer hardcodes its rendered blocks.
+ * Instead each block is a registered section, and the template loops over the
+ * registered sections ordered by priority. This is the seam every future
+ * profile surface (Shows, Community, Instagram, ...) plugs into: a section
+ * self-registers from its OWNING plugin (layer purity — AP core never names a
+ * foreign plugin), declaring how it renders.
+ *
+ * Filter contract (long-lived; treat as a public API):
+ *
+ *   apply_filters( 'ec_artist_profile_sections', array $sections, int $artist_id, int $artist_term_id )
+ *
+ * Each section is an associative array:
+ *
+ *   [
+ *     'id'       => (string)   unique section id, e.g. 'overview', 'coverage'
+ *     'label'    => (string)   human label (used as the tab title when tabbed)
+ *     'priority' => (int)      sort order (lower renders first); default 10
+ *     'render'   => (callable) receives ( int $artist_id, int $artist_term_id )
+ *                              and ECHOES its markup server-side (no AJAX)
+ *     'visible'  => (callable) optional; receives ( int $artist_id, int $artist_term_id )
+ *                              and returns bool — falsey hides the section
+ *     'as_tab'   => (bool)     optional; reserved for tabbed layout. The
+ *                              template decides layout from priority/as_tab;
+ *                              the registry never imposes tabs-vs-stacked.
+ *   ]
+ *
+ * The third filter arg, $artist_term_id, is the bound main-blog `artist` term
+ * (Primitive 1). Term-scoped sections (Shows/Coverage/Community) use it to query
+ * other network surfaces via ec_cross_site_rest_request().
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Get the registered, ordered, visible sections for an artist profile.
+ *
+ * @param int      $artist_id      Artist profile post ID.
+ * @param int|null $artist_term_id Bound main-blog `artist` term_id. Resolved
+ *                                 from the binding when null.
+ * @return array[] Ordered list of normalized section arrays.
+ */
+function ec_get_artist_profile_sections( $artist_id, $artist_term_id = null ) {
+    $artist_id = (int) $artist_id;
+    if ( $artist_id <= 0 ) {
+        return array();
+    }
+
+    if ( null === $artist_term_id ) {
+        $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
+    }
+    $artist_term_id = (int) $artist_term_id;
+
+    /**
+     * Filter the artist profile sections.
+     *
+     * @param array[] $sections       Registered sections.
+     * @param int     $artist_id      Artist profile post ID.
+     * @param int     $artist_term_id Bound main-blog `artist` term_id (0 if unbound).
+     */
+    $sections = apply_filters( 'ec_artist_profile_sections', array(), $artist_id, $artist_term_id );
+
+    if ( ! is_array( $sections ) ) {
+        return array();
+    }
+
+    // Normalize, drop invalid entries, apply visibility gating.
+    $normalized = array();
+    foreach ( $sections as $section ) {
+        if ( ! is_array( $section ) || empty( $section['id'] ) || empty( $section['render'] ) || ! is_callable( $section['render'] ) ) {
+            continue;
+        }
+
+        $section['id']       = (string) $section['id'];
+        $section['label']    = isset( $section['label'] ) ? (string) $section['label'] : '';
+        $section['priority'] = isset( $section['priority'] ) ? (int) $section['priority'] : 10;
+        $section['as_tab']   = ! empty( $section['as_tab'] );
+
+        if ( isset( $section['visible'] ) && is_callable( $section['visible'] ) ) {
+            if ( ! call_user_func( $section['visible'], $artist_id, $artist_term_id ) ) {
+                continue;
+            }
+        }
+
+        $normalized[] = $section;
+    }
+
+    // Stable sort by priority.
+    usort( $normalized, function ( $a, $b ) {
+        if ( $a['priority'] === $b['priority'] ) {
+            return 0;
+        }
+        return ( $a['priority'] < $b['priority'] ) ? -1 : 1;
+    } );
+
+    return $normalized;
+}
+
+/**
+ * Render all registered sections for an artist profile, in priority order.
+ *
+ * Each section's render callable echoes server-side. For THIS foundation the
+ * template keeps the existing stacked layout (no tabs), so every section is
+ * rendered in sequence. Tabbed rendering (using the theme shared-tabs primitive
+ * or @extrachill/components Tabs) is a later layer that consumes `as_tab`.
+ *
+ * @param int      $artist_id      Artist profile post ID.
+ * @param int|null $artist_term_id Bound main-blog `artist` term_id.
+ * @return void
+ */
+function ec_render_artist_profile_sections( $artist_id, $artist_term_id = null ) {
+    $artist_id = (int) $artist_id;
+    if ( $artist_id <= 0 ) {
+        return;
+    }
+
+    if ( null === $artist_term_id ) {
+        $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
+    }
+    $artist_term_id = (int) $artist_term_id;
+
+    $sections = ec_get_artist_profile_sections( $artist_id, $artist_term_id );
+    foreach ( $sections as $section ) {
+        call_user_func( $section['render'], $artist_id, $artist_term_id );
+    }
+}

--- a/inc/artist-profiles/frontend/templates/single-artist_profile.php
+++ b/inc/artist-profiles/frontend/templates/single-artist_profile.php
@@ -1,6 +1,12 @@
 <?php
 /**
  * The Template for displaying all single Artist Profiles.
+ *
+ * The profile body is no longer hardcoded here. Each block is a section
+ * registered via the `ec_artist_profile_sections` filter and rendered in
+ * priority order by ec_render_artist_profile_sections(). AP core registers the
+ * default sections (hero, overview) in inc/artist-profiles/frontend/default-sections.php;
+ * foreign plugins register their own term-scoped sections from their own code.
  */
 
 get_header(); ?>
@@ -21,167 +27,27 @@ get_header(); ?>
             // --- End Breadcrumbs ---
 
             // --- Main Post Loop ---
-            while ( have_posts() ) : the_post(); 
+            while ( have_posts() ) : the_post();
 
                 $artist_profile_id = get_the_ID();
 
-                // Get additional artist meta
-                $genre = get_post_meta( $artist_profile_id, '_genre', true );
-                $local_city = get_post_meta( $artist_profile_id, '_local_city', true );
-                $website_url = get_post_meta( $artist_profile_id, '_website_url', true );
-                $spotify_url = get_post_meta( $artist_profile_id, '_spotify_url', true );
-                $apple_music_url = get_post_meta( $artist_profile_id, '_apple_music_url', true );
-                $bandcamp_url = get_post_meta( $artist_profile_id, '_bandcamp_url', true );
-
-                $artist_profile_social_links = get_post_meta( $artist_profile_id, '_artist_profile_social_links', true );
-                if ( ! is_array( $artist_profile_social_links ) ) {
-                    $artist_profile_social_links = array();
-                }
+                // Resolve the bound main-blog `artist` term (Primitive 1) so
+                // term-scoped sections (Shows/Coverage/Community) can query the
+                // network. 0 when the profile has no term yet.
+                $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_profile_id ) : 0;
 
             ?>
 
                 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> >
                     <div class="ec-edge-gutter">
-                        <?php 
-                        // Prepare for Hero Section
-                        $hero_background_style = '';
-                        $header_image_id = get_post_meta( $artist_profile_id, '_artist_profile_header_image_id', true );
-
-                        if ( $header_image_id ) {
-                            $image_url = wp_get_attachment_image_url( $header_image_id, 'full' ); // Or 'large', depending on desired size
-                            if ( $image_url ) {
-                                $hero_background_style = 'style="background-image: url(\'' . esc_url( $image_url ) . '\');"';
-                            }
-                        } else {
-                            // Fallback for no specific header image; class-based styling can apply
-                            $hero_background_style = ''; 
+                        <?php
+                        // Render every registered section in priority order.
+                        // The default sections reproduce the previous hardcoded
+                        // hero + entry-content blocks (no visual change).
+                        if ( function_exists( 'ec_render_artist_profile_sections' ) ) {
+                            ec_render_artist_profile_sections( $artist_profile_id, $artist_term_id );
                         }
                         ?>
-
-                        <div class="artist-profile-header artist-hero" <?php echo $hero_background_style; ?>>
-                            <div class="artist-hero-overlay"></div>
-                            <div class="artist-hero-content">
-                                <?php
-                                // --- Manage Artist Button (Moved to top of hero content) ---
-                                if ( is_user_logged_in() ) :
-                                    // Display "Manage Artist Profile" button if the current user can manage members for this artist profile.
-                                    // This uses the custom capability 'manage_artist_members'.
-                                    if ( ec_can_manage_artist( get_current_user_id(), $artist_profile_id ) ) :
-                                        $manage_artist_url = get_permalink( get_page_by_path( 'manage-artist' ) );
-                                        if ( $manage_artist_url ) {
-                                            echo '<div class="artist-profile-actions">';
-                                            echo '<a href="' . esc_url( $manage_artist_url ) . '" class="button-2 button-medium artist-manage-button">Manage Artist</a>';
-                                            echo '</div>';
-                                        }
-                                    endif;
-                                endif;
-                                // --- End Manage Artist Button (Moved) ---
-                                ?>
-                                <?php // Display Profile Picture and then Title/Meta in a flex row
-                                // The artist-hero-top-row container helps to align the image and the text content side-by-side.
-                                ?>
-                                <div class="artist-hero-top-row">
-                                    <?php if ( has_post_thumbnail( $artist_profile_id ) ) : ?>
-                                        <div class="artist-profile-featured-image">
-                                            <?php echo get_the_post_thumbnail( $artist_profile_id, 'medium' ); // This is the actual profile picture ?>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="artist-hero-text-content">
-                                        <h1 class="artist-hero-title" itemprop="headline"><?php echo esc_html( get_the_title( $artist_profile_id ) ); ?></h1>
-
-                                        <?php if ( ! empty( $genre ) || ! empty( $local_city ) ) : ?>
-                                            <p class="artist-meta-info">
-                                                <?php if ( ! empty( $genre ) ) : ?>
-                                                    <span class="artist-genre"><strong><?php esc_html_e( 'Genre:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $genre ); ?></span>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $genre ) && ! empty( $local_city ) ) : ?>
-                                                    <span class="artist-meta-separator">|</span>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $local_city ) ) : ?>
-                                                    <span class="artist-local-scene"><strong><?php esc_html_e( 'Local Scene:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $local_city ); ?></span>
-                                                <?php endif; ?>
-                                            </p>
-                                        <?php endif; ?>
-                                    </div>
-                                </div>
-
-                                <?php 
-                                // Use centralized social links rendering
-                                $social_manager = extrachill_artist_platform_social_links();
-                                echo $social_manager->render_social_icons( $artist_profile_id, array(
-                                    'container_class' => 'artist-social-links',
-                                    'icon_class' => 'extrch-social-icon'
-                                ) );
-                                ?>
-
-                                <?php
-                                // --- Display Artist Link Page URL (New) ---
-                                $link_page_id_for_url_display = apply_filters('ec_get_link_page_id', $artist_profile_id);
-                                if ( $link_page_id_for_url_display && get_post_type( $link_page_id_for_url_display ) === 'artist_link_page' ) {
-                                    global $post; // Ensure $post is the artist_profile CPT object
-                                    if ( isset( $post ) && $post->post_type === 'artist_profile' ) {
-                                        $artist_slug_for_url = $post->post_name;
-                                        $public_url_href = ''; 
-                                        $public_url_display_text = '';
-
-                                        if ( defined('EXTRCH_LINKPAGE_DEV') && EXTRCH_LINKPAGE_DEV ) {
-                                            $public_url_href = get_permalink( $link_page_id_for_url_display );
-                                        } else {
-                                            // Use canonical extrachill.link URL
-                                            $public_url_href = 'https://extrachill.link/' . $artist_slug_for_url;
-                                        }
-
-                                        if ( ! empty( $public_url_href ) ) {
-                                            $public_url_display_text = preg_replace( '#^https?://#', '', $public_url_href );
-
-                                            echo '<div class="artist-public-link-display">';
-                                            echo '<a href="' . esc_url( $public_url_href ) . '" class="button-3 button-medium" rel="ugc noopener">' . esc_html( $public_url_display_text ) . '</a>';
-                                            echo '</div>';
-                                        }
-                                    }
-                                }
-                                // --- End Display Artist Link Page URL (New) ---
-                                ?>
-
-                            </div>
-                        </div>
-
-                        <?php
-                        /**
-                         * generate_after_entry_title hook.
-                         *
-                         * @since 0.1
-                         * @hooked generate_post_meta - 10
-                         */
-                        // do_action( 'generate_after_entry_title' ); // Maybe hide default meta?
-                        ?>
-
-                        <div class="entry-content" itemprop="text">
-                            <?php
-                            // --- Artist Bio Section ---
-                            $artist_name = get_the_title( $artist_profile_id );
-                            $artist_bio = get_post_field( 'post_content', $artist_profile_id );
-                            
-                            echo '<div class="artist-bio-section">';
-                            echo '<h2 class="section-title">' . esc_html( sprintf( __( 'About %s', 'extrachill-artist-platform' ), $artist_name ) ) . '</h2>';
-                            if ( ! empty( $artist_bio ) ) {
-                                echo '<div class="artist-bio">';
-                                echo wpautop( $artist_bio );
-                                echo '</div>';
-                            } else {
-                                echo '<p>' . __( 'No biography available yet.', 'extrachill-artist-platform' ) . '</p>';
-                            }
-                            echo '</div>'; // .artist-bio-section
-
-                            // Cross-site link to blog coverage (provided by extrachill-multisite)
-                            if ( function_exists( 'extrachill_render_cross_site_artist_profile_links' ) ) {
-                                global $post;
-                                if ( isset( $post ) && $post->post_type === 'artist_profile' && ! empty( $post->post_name ) ) {
-                                    extrachill_render_cross_site_artist_profile_links( $post->post_name );
-                                }
-                            }
-                            ?>
-                        </div><!-- .entry-content -->
 
                         <?php
                         /**
@@ -215,4 +81,4 @@ get_header(); ?>
  */
 do_action( 'extra_chill_after_primary_content_area' );
 
-get_footer(); 
+get_footer();

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * Artist Profile <-> Artist Term Binding ("the hub join")
+ *
+ * An artist exists as BOTH an `artist_profile` CPT (on the artist blog) AND an
+ * `artist` taxonomy term (on the MAIN blog, attached to `post`). Historically
+ * the two were joined ONLY by matching slug (see extrachill-artist-platform#60),
+ * which silently breaks when either side is renamed.
+ *
+ * This module establishes a stored, bidirectional, ID-based binding plus
+ * resolvers that prefer the stored binding and fall back to slug-matching,
+ * self-healing the stored binding on a successful fallback so the next call is
+ * O(1).
+ *
+ *   - `_artist_term_id`    POST meta on the artist_profile  -> main-blog term_id
+ *   - `_artist_profile_id` TERM meta on the artist term      -> artist-blog post ID
+ *
+ * The `artist` term lives on the MAIN blog; the profile lives on the ARTIST
+ * blog. Every cross-blog hop pairs switch_to_blog() with restore_current_blog()
+ * in a try/finally so the blog context can never leak.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve the main-blog `artist` term_id bound to an artist_profile.
+ *
+ * Reads the stored `_artist_term_id` binding first. If absent, falls back to
+ * matching the profile's slug against an `artist` term on the MAIN blog and,
+ * on success, writes BOTH meta sides so the next lookup is O(1).
+ *
+ * @param int $profile_id Artist profile post ID (on the artist blog).
+ * @return int Main-blog `artist` term_id, or 0 if none can be resolved.
+ */
+function ec_get_artist_term_id( $profile_id ) {
+    $profile_id = (int) $profile_id;
+    if ( $profile_id <= 0 ) {
+        return 0;
+    }
+
+    // 1. Stored binding wins.
+    $stored = (int) get_post_meta( $profile_id, '_artist_term_id', true );
+    if ( $stored > 0 ) {
+        return $stored;
+    }
+
+    // 2. Slug fallback. The profile lives on the artist blog; resolve its slug
+    //    there, then look the term up on the main blog.
+    $slug = get_post_field( 'post_name', $profile_id );
+    if ( empty( $slug ) ) {
+        return 0;
+    }
+
+    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+    if ( ! $main_blog_id ) {
+        return 0;
+    }
+
+    $term_id   = 0;
+    $term_slug = '';
+    switch_to_blog( $main_blog_id );
+    try {
+        $term = get_term_by( 'slug', $slug, 'artist' );
+        if ( $term && ! is_wp_error( $term ) ) {
+            $term_id   = (int) $term->term_id;
+            $term_slug = $term->slug;
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    if ( $term_id <= 0 ) {
+        return 0;
+    }
+
+    // 3. Self-heal: persist both sides of the binding.
+    ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
+
+    return $term_id;
+}
+
+/**
+ * Resolve the artist-blog artist_profile post ID bound to an `artist` term.
+ *
+ * Reads the stored `_artist_profile_id` term meta first. If absent, falls back
+ * to matching the term's slug against an `artist_profile` post on the ARTIST
+ * blog and, on success, writes BOTH meta sides so the next lookup is O(1).
+ *
+ * @param int $term_id Main-blog `artist` term_id.
+ * @return int Artist profile post ID (on the artist blog), or 0 if none.
+ */
+function ec_get_artist_profile_id( $term_id ) {
+    $term_id = (int) $term_id;
+    if ( $term_id <= 0 ) {
+        return 0;
+    }
+
+    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+    if ( ! $main_blog_id ) {
+        return 0;
+    }
+
+    // 1. Stored binding wins. Term meta lives on the MAIN blog alongside the term.
+    $stored    = 0;
+    $term_slug = '';
+    switch_to_blog( $main_blog_id );
+    try {
+        $stored = (int) get_term_meta( $term_id, '_artist_profile_id', true );
+        if ( $stored <= 0 ) {
+            $term = get_term( $term_id, 'artist' );
+            if ( $term && ! is_wp_error( $term ) ) {
+                $term_slug = $term->slug;
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    if ( $stored > 0 ) {
+        return $stored;
+    }
+
+    if ( empty( $term_slug ) ) {
+        return 0;
+    }
+
+    // 2. Slug fallback. Look the profile up on the artist blog by slug.
+    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+    if ( ! $artist_blog_id ) {
+        return 0;
+    }
+
+    $profile_id = 0;
+    switch_to_blog( $artist_blog_id );
+    try {
+        $found = get_posts( array(
+            'post_type'        => 'artist_profile',
+            'name'             => $term_slug,
+            'post_status'      => 'publish',
+            'posts_per_page'   => 1,
+            'fields'           => 'ids',
+            'suppress_filters' => false,
+        ) );
+        if ( ! empty( $found ) ) {
+            $profile_id = (int) $found[0];
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    if ( $profile_id <= 0 ) {
+        return 0;
+    }
+
+    // 3. Self-heal: persist both sides of the binding.
+    ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
+
+    return $profile_id;
+}
+
+/**
+ * Persist both sides of the profile <-> term binding.
+ *
+ * Writes `_artist_term_id` on the profile (artist blog) and `_artist_profile_id`
+ * on the term (main blog). The term meta write is performed inside a
+ * switch_to_blog()/restore_current_blog() pair so it always lands on the main
+ * blog regardless of the caller's current context.
+ *
+ * @param int      $profile_id   Artist profile post ID (artist blog).
+ * @param int      $term_id      Main-blog `artist` term_id.
+ * @param int|null $main_blog_id Optional resolved main blog ID (avoids a lookup).
+ * @return void
+ */
+function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = null ) {
+    $profile_id = (int) $profile_id;
+    $term_id    = (int) $term_id;
+    if ( $profile_id <= 0 || $term_id <= 0 ) {
+        return;
+    }
+
+    // Profile-side meta. update_post_meta targets the post on whichever blog it
+    // lives on; this binding is only ever resolved from the artist blog where
+    // the profile is the current post, so write it directly.
+    update_post_meta( $profile_id, '_artist_term_id', $term_id );
+
+    // Term-side meta lives on the main blog.
+    if ( null === $main_blog_id ) {
+        $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+    }
+    if ( ! $main_blog_id ) {
+        return;
+    }
+
+    switch_to_blog( $main_blog_id );
+    try {
+        update_term_meta( $term_id, '_artist_profile_id', $profile_id );
+    } finally {
+        restore_current_blog();
+    }
+}
+
+/**
+ * Ensure an artist_profile is bound to a matching `artist` term on save.
+ *
+ * Runs on the artist blog when a profile is created or updated. If no stored
+ * binding exists, resolves (or creates) the matching main-blog `artist` term by
+ * slug and persists both meta sides. A term without a profile is fine (most of
+ * the 1,182 terms have none); this only guarantees that a profile always has a
+ * term.
+ *
+ * @param int $profile_id Artist profile post ID.
+ * @return void
+ */
+function ec_sync_artist_profile_term_binding( $profile_id ) {
+    $profile_id = (int) $profile_id;
+    if ( $profile_id <= 0 || get_post_type( $profile_id ) !== 'artist_profile' ) {
+        return;
+    }
+
+    // Already bound? Nothing to do.
+    if ( (int) get_post_meta( $profile_id, '_artist_term_id', true ) > 0 ) {
+        return;
+    }
+
+    // Try the slug-fallback resolver first (it self-heals on success).
+    $term_id = ec_get_artist_term_id( $profile_id );
+    if ( $term_id > 0 ) {
+        return;
+    }
+
+    // No matching term exists yet — create one on the main blog so the profile
+    // is always represented in the network join key.
+    $title = get_the_title( $profile_id );
+    $slug  = get_post_field( 'post_name', $profile_id );
+    if ( empty( $title ) || empty( $slug ) ) {
+        return;
+    }
+
+    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+    if ( ! $main_blog_id ) {
+        return;
+    }
+
+    $new_term_id = 0;
+    switch_to_blog( $main_blog_id );
+    try {
+        $existing = get_term_by( 'slug', $slug, 'artist' );
+        if ( $existing && ! is_wp_error( $existing ) ) {
+            $new_term_id = (int) $existing->term_id;
+        } else {
+            $inserted = wp_insert_term( $title, 'artist', array( 'slug' => $slug ) );
+            if ( ! is_wp_error( $inserted ) && ! empty( $inserted['term_id'] ) ) {
+                $new_term_id = (int) $inserted['term_id'];
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    if ( $new_term_id > 0 ) {
+        ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $main_blog_id );
+    }
+}
+add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 1 );
+
+/**
+ * Idempotent, run-once-per-version backfill of profile <-> term bindings.
+ *
+ * Mirrors the version-gated option pattern used by
+ * extrachill_artist_platform_heal_zero_modified_dates(): an option stores the
+ * backfill version; the walk only runs when the stored version is behind.
+ *
+ * Walks every artist_profile on the artist blog, resolves each one's `artist`
+ * term by slug on the main blog, and writes both meta sides. Profiles that
+ * already carry a stored `_artist_term_id` are skipped. Terms without a profile
+ * are left untouched (a term without a profile is just an untagged artist).
+ *
+ * @return void
+ */
+function ec_backfill_artist_term_bindings() {
+    $backfill_version = '1.0.0';
+    $stored = get_option( 'extrachill_artist_platform_term_binding_backfill', '0' );
+    if ( version_compare( $stored, $backfill_version, '>=' ) ) {
+        return;
+    }
+
+    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+    $main_blog_id   = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+    if ( ! $artist_blog_id || ! $main_blog_id ) {
+        // Network helpers unavailable; do not burn the version gate. Retry next load.
+        return;
+    }
+
+    // Collect candidate profiles (id + slug) from the artist blog.
+    $profiles = array();
+    switch_to_blog( $artist_blog_id );
+    try {
+        $found = get_posts( array(
+            'post_type'        => 'artist_profile',
+            'post_status'      => 'any',
+            'posts_per_page'   => -1,
+            'fields'           => 'ids',
+            'suppress_filters' => false,
+        ) );
+        foreach ( (array) $found as $pid ) {
+            $pid = (int) $pid;
+            if ( (int) get_post_meta( $pid, '_artist_term_id', true ) > 0 ) {
+                continue; // already bound
+            }
+            $slug = get_post_field( 'post_name', $pid );
+            if ( ! empty( $slug ) ) {
+                $profiles[ $pid ] = $slug;
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    if ( empty( $profiles ) ) {
+        update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
+        return;
+    }
+
+    // Resolve each slug to a term on the main blog (single switch for the batch).
+    $resolved = array();
+    switch_to_blog( $main_blog_id );
+    try {
+        foreach ( $profiles as $pid => $slug ) {
+            $term = get_term_by( 'slug', $slug, 'artist' );
+            if ( $term && ! is_wp_error( $term ) ) {
+                $term_id = (int) $term->term_id;
+                $resolved[ $pid ] = $term_id;
+                // Write the term-side meta while we are already on the main blog.
+                update_term_meta( $term_id, '_artist_profile_id', $pid );
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    // Write the profile-side meta on the artist blog.
+    if ( ! empty( $resolved ) ) {
+        switch_to_blog( $artist_blog_id );
+        try {
+            foreach ( $resolved as $pid => $term_id ) {
+                update_post_meta( $pid, '_artist_term_id', $term_id );
+            }
+        } finally {
+            restore_current_blog();
+        }
+    }
+
+    update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
+}
+add_action( 'admin_init', 'ec_backfill_artist_term_bindings' );


### PR DESCRIPTION
## Summary

Foundation for the artist-profile-hub epic (#61). Builds the **two primitives** the hub plugs into — **no feature/tab content** beyond the byte-equivalent re-home of the existing blocks plus the one foreign-plugin proof section. PR-only.

This is a coordinated 2-PR change. The foreign-plugin proof section ships in the companion PR:
- **extrachill-multisite** → `hub-coverage-section` (registers the cross-site **Coverage** section). Both must land together.

## Primitive 1 — `artist_profile` ↔ `artist` term binding ("the hub join")

`inc/core/artist-term-binding.php` — a stored, bidirectional, ID-based binding that replaces the fragile slug-only join (#60):

- `_artist_term_id` **post** meta on the profile (artist blog) ↔ `_artist_profile_id` **term** meta on the `artist` term (main blog).
- Resolver pair `ec_get_artist_term_id( $profile_id )` / `ec_get_artist_profile_id( $term_id )` — each reads the stored binding **first**, then falls back to cross-blog slug-match (`ec_get_blog_id('main')` / `ec_get_blog_id('artist')` + `switch_to_blog` + `get_term_by('slug',…,'artist')` / `get_posts(name=…)`). On a successful fallback both meta sides **self-heal** so the next call is O(1).
- `ec_sync_artist_profile_term_binding()` on `ec_artist_profile_save` (priority 5) guarantees every profile has a matching main-blog term (creates one if missing — a term without a profile is fine; most of the 1,182 terms have none).
- **Idempotent, run-once-per-version backfill** on `admin_init`, gated by the `extrachill_artist_platform_term_binding_backfill` option — mirrors the exact pattern of `extrachill_artist_platform_heal_zero_modified_dates()` + the subscriber-db version gate.
- Every `switch_to_blog()` is paired with `restore_current_blog()` in `try/finally`.

## Primitive 2 — profile section/tab registry

`inc/artist-profiles/frontend/section-registry.php`:

```php
apply_filters( 'ec_artist_profile_sections', array(), int $artist_id, int $artist_term_id );
// each section: [ 'id', 'label', 'priority', 'render' (callable), 'visible' (callable), 'as_tab' (bool) ]
```

- `render` callables receive `( $artist_id, $artist_term_id )` and **echo server-side** (no AJAX).
- `ec_render_artist_profile_sections()` iterates registered sections ordered by `priority`, applying the optional `visible` gate.
- The registry does **not** impose tabs-vs-stacked — it exposes `priority`/`as_tab` and lets the template decide. For this PR the **stacked layout is retained** (no visual change, no new tab JS/CSS).
- `single-artist_profile.php` now loops over the registry instead of hardcoding blocks. The existing `do_action` hooks (`extrachill_before_body_content`, `extra_chill_after_content`, `extrachill_after_body_content`, `extra_chill_after_primary_content_area`) are preserved.

### How the existing blocks were re-homed (no visual regression)

`inc/artist-profiles/frontend/default-sections.php` registers AP-core defaults via the new filter, with output **byte-equivalent** to the old template:
- **hero** (priority 10): header image, manage button, profile image, title + genre/local-scene meta, social icons, link-page URL card.
- **overview** (priority 20): the `.entry-content` About bio block.

The cross-site **Coverage** block previously inlined inside `.entry-content` is **moved out** to a foreign-registered section owned by extrachill-multisite (companion PR, priority 30). This is the one acceptance-required end-to-end foreign-plugin proof. Net effect: Coverage now renders as its own first-class hub section directly after the About block (a minor, intentional DOM-placement shift — it leaves `.entry-content` and stacks immediately below it), preserving visual order.

## RULES.md "prove it doesn't already exist" findings

- **`extrachill_get_artist_profile_by_slug()`** (extrachill-multisite entity-links.php:243) resolves profile-by-slug only — no stored ID, no reverse term lookup. It does **not** encode the binding; it's exactly the fragile slug round-trip #60 flags. Not reused as the binding source of truth (kept as a fallback-style path).
- **`_associated_artist_profile_id`** (AP `inc/core/filters/ids.php`) binds `artist_link_page` → `artist_profile` (link page ↔ profile). It is a **different** relationship and does **not** encode the profile ↔ `artist`-term join. New, non-overlapping meta keys (`_artist_term_id` / `_artist_profile_id`) were used to avoid colliding with it.
- The `artist` taxonomy is already `show_in_rest => true` on the main blog (theme `inc/core/custom-taxonomies.php`) — no taxonomy registration change needed.

## Tab primitive note

No tab UI ships here (stacked layout retained). When tabs render later they will reuse `@extrachill/components` `Tabs`/`ResponsiveTabs` or the theme `shared-tabs` — never a third system. No new tab JS/CSS introduced.

## Constraints honored

- No AJAX — all sections render server-side.
- No theme edits. No `CHANGELOG.md` edits. No version bumps (homeboy owns those).
- `php -l` clean on every changed/new file.
- Existing `do_action` hooks preserved.

Refs #61.
Closes #62.
Closes #60.