### PR TITLE
fix: guard ability category registration against double-fire _doing_it_wrong notice

### DIFF
--- a/inc/abilities/category.php
+++ b/inc/abilities/category.php
@@ -12,27 +12,37 @@ defined( 'ABSPATH' ) || exit;
  * Register artist platform ability categories.
  */
 function extrachill_artist_platform_register_category() {
-	wp_register_ability_category(
-		'extrachill-artist-platform',
-		array(
-			'label'       => __( 'Artist Platform', 'extrachill-artist-platform' ),
-			'description' => __( 'Artist profile and link page management for Extra Chill.', 'extrachill-artist-platform' ),
-		)
-	);
+	if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+		return;
+	}
 
-	wp_register_ability_category(
-		'extrachill-artists',
-		array(
-			'label'       => __( 'Artists', 'extrachill-artist-platform' ),
-			'description' => __( 'Artist-domain abilities: profiles, links, socials, subscribers, analytics.', 'extrachill-artist-platform' ),
-		)
-	);
+	if ( ! wp_has_ability_category( 'extrachill-artist-platform' ) ) {
+		wp_register_ability_category(
+			'extrachill-artist-platform',
+			array(
+				'label'       => __( 'Artist Platform', 'extrachill-artist-platform' ),
+				'description' => __( 'Artist profile and link page management for Extra Chill.', 'extrachill-artist-platform' ),
+			)
+		);
+	}
 
-	wp_register_ability_category(
-		'extrachill-admin-artist-relationships',
-		array(
-			'label'       => __( 'Admin: Artist Relationships', 'extrachill-artist-platform' ),
-			'description' => __( 'Network-admin abilities for managing artist-user relationships.', 'extrachill-artist-platform' ),
-		)
-	);
+	if ( ! wp_has_ability_category( 'extrachill-artists' ) ) {
+		wp_register_ability_category(
+			'extrachill-artists',
+			array(
+				'label'       => __( 'Artists', 'extrachill-artist-platform' ),
+				'description' => __( 'Artist-domain abilities: profiles, links, socials, subscribers, analytics.', 'extrachill-artist-platform' ),
+			)
+		);
+	}
+
+	if ( ! wp_has_ability_category( 'extrachill-admin-artist-relationships' ) ) {
+		wp_register_ability_category(
+			'extrachill-admin-artist-relationships',
+			array(
+				'label'       => __( 'Admin: Artist Relationships', 'extrachill-artist-platform' ),
+				'description' => __( 'Network-admin abilities for managing artist-user relationships.', 'extrachill-artist-platform' ),
+			)
+		);
+	}
 }


### PR DESCRIPTION
## The notice

```
PHP Notice: Function WP_Ability_Categories_Registry::register was called incorrectly.
Ability category "<slug>" is already registered.
in /var/www/extrachill.com/wp-includes/functions.php on line 6170
```

## Root cause

On this multisite, WordPress core's `wp_abilities_api_categories_init` action fires more than once per request. This plugin's `extrachill_artist_platform_register_category()` callback called `wp_register_ability_category()` **unconditionally** for three categories, so the second hook fire re-registered each one and tripped `_doing_it_wrong`.

## The fix

Guard every registration with core's idempotency check `wp_has_ability_category()` so a repeat fire is a clean no-op. Added a `function_exists()` guard for both `wp_register_ability_category` and `wp_has_ability_category` (same core API), then a per-slug `wp_has_ability_category()` guard around each of the three calls:

- `extrachill-artist-platform`
- `extrachill-artists`
- `extrachill-admin-artist-relationships`

No slug, label, description, or hook changes — only the idempotency guard.