### PR TITLE
fix: map block.json version targets to artifact paths for deploy verification

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -16,28 +16,29 @@
       "pattern": "EXTRACHILL_ARTIST_PLATFORM_VERSION',\\s*'([0-9.]+)'"
     },
     {
-      "file": "package.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
-    },
-    {
       "file": "src/blocks/artist-manager/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/blocks/artist-manager/block.json"
     },
     {
       "file": "src/blocks/artist-shop-manager/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/blocks/artist-shop-manager/block.json"
     },
     {
       "file": "src/blocks/artist-creator/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/blocks/artist-creator/block.json"
     },
     {
       "file": "src/blocks/artist-analytics/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/blocks/artist-analytics/block.json"
     },
     {
       "file": "src/blocks/link-page-editor/block.json",
-      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+      "pattern": "\"version\":\\s*\"([0-9.]+)\"",
+      "artifact_path": "build/blocks/link-page-editor/block.json"
     }
   ]
 }


### PR DESCRIPTION
## Problem

`homeboy deploy extrachill-artist-platform` fails verification:

```
Artifact '...extrachill-artist-platform.zip' does not contain version target 'package.json'
for component 'extrachill-artist-platform'. Refusing to deploy unverified content.
```

## Root cause

`homeboy.json` `version_targets` listed `package.json` and `src/blocks/*/block.json`. Those are **dev-tree** paths that the production build artifact strips/transforms:

- `package.json` is excluded from the artifact entirely.
- `src/blocks/<name>/block.json` is compiled by wp-scripts to `build/blocks/<name>/block.json` in the artifact.

homeboy uses `version_targets` both to bump versions at release (source paths, fine) and to verify the artifact at deploy (needs artifact-present paths). The missing `artifact_path` mapping made deploy verification look for source-only files that don't exist in the zip.

## Fix

Match the canonical pattern already used by `extrachill-events`:

- Add `artifact_path` to each `src/blocks/*/block.json` target mapping it to the compiled `build/blocks/*/block.json` in the artifact.
- Drop the `package.json` target (not in the artifact, not version-critical — the plugin header + `EXTRACHILL_ARTIST_PLATFORM_VERSION` constant remain the authoritative version sources).

No code changes; deploy-config only.