### PR TITLE
feat: instrument artist funnel as analytics events + add platform stats ability

### DIFF
--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -37,6 +37,7 @@ require_once __DIR__ . '/handlers/artist-subscribe.php';
 require_once __DIR__ . '/handlers/artist-list-subscribers.php';
 require_once __DIR__ . '/handlers/artist-export-subscribers.php';
 require_once __DIR__ . '/handlers/artist-get-analytics.php';
+require_once __DIR__ . '/handlers/get-artist-platform-stats.php';
 
 // Admin artist-relationships ability handlers.
 require_once __DIR__ . '/handlers/admin-list-artist-relationships.php';

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -55,6 +55,24 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 		update_post_meta( $artist_id, '_genre', $genre );
 	}
 
+	// Emit the funnel event while still in the artist blog context so the
+	// event row is stamped with the artist site's blog_id. The existing
+	// extrachill/get-analytics-summary reader aggregates this with no new
+	// read surface. user_id is carried in the payload (and stamped on the
+	// row when the request runs as the creating user) for cohort joins.
+	$analytics_ability = wp_get_ability( 'extrachill/track-analytics-event' );
+	if ( $analytics_ability ) {
+		$analytics_ability->execute(
+			array(
+				'event_type' => 'artist_profile_created',
+				'event_data' => array(
+					'user_id'   => $user_id,
+					'artist_id' => (int) $artist_id,
+				),
+			)
+		);
+	}
+
 	restore_current_blog();
 
 	if ( function_exists( 'ec_add_artist_membership' ) ) {

--- a/inc/abilities/handlers/get-artist-platform-stats.php
+++ b/inc/abilities/handlers/get-artist-platform-stats.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+/**
+ * Handler: extrachill/get-artist-platform-stats
+ *
+ * Point-in-time platform aggregates the event stream can't reconstruct:
+ * total published artist profiles, total published link pages, profiles
+ * created in the last N days, and link pages with at least one view or
+ * click in the last N days.
+ *
+ * Funnel conversion-over-time (created/requested/approved counts) is NOT
+ * served here — those are analytics events read via
+ * extrachill/get-analytics-summary. This ability only covers the
+ * point-in-time aggregates that the event stream cannot derive.
+ *
+ * @package ExtraChillArtistPlatform
+ * @since   1.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return point-in-time artist platform aggregates.
+ *
+ * @param array $input {
+ *     @type int $days Window (in days) for the "recent" aggregates. Default 28.
+ * }
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_get_artist_platform_stats( array $input ): array|WP_Error {
+	$days = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 28;
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'dependency_missing', 'Multisite not configured.' );
+	}
+
+	$did_switch = false;
+	if ( get_current_blog_id() !== $artist_blog_id ) {
+		switch_to_blog( $artist_blog_id );
+		$did_switch = true;
+	}
+
+	global $wpdb;
+
+	// Total published artist profiles (reuse the artists-list ability so the
+	// count stays canonical and is never duplicated here). Fall back to a
+	// direct found_posts count only if the ability is unavailable, so the
+	// metric is never silently zero.
+	$total_artist_profiles = null;
+	$list_ability          = wp_get_ability( 'extrachill/artists-list' );
+	if ( $list_ability ) {
+		$list_result = $list_ability->execute(
+			array(
+				'per_page' => 1,
+				'page'     => 1,
+			)
+		);
+		if ( ! is_wp_error( $list_result ) && isset( $list_result['total'] ) ) {
+			$total_artist_profiles = (int) $list_result['total'];
+		}
+	}
+	if ( null === $total_artist_profiles ) {
+		$profile_query         = new WP_Query(
+			array(
+				'post_type'      => 'artist_profile',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
+			)
+		);
+		$total_artist_profiles = (int) $profile_query->found_posts;
+	}
+
+	// Total published link pages.
+	$link_page_query  = new WP_Query(
+		array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'no_found_rows'  => false,
+		)
+	);
+	$total_link_pages = (int) $link_page_query->found_posts;
+
+	// Artist profiles created in the last N days.
+	$profiles_created_recent = 0;
+	if ( $days > 0 ) {
+		$created_query           = new WP_Query(
+			array(
+				'post_type'      => 'artist_profile',
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => false,
+				'date_query'     => array(
+					array(
+						'after'     => gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) ),
+						'column'    => 'post_date_gmt',
+						'inclusive' => true,
+					),
+				),
+			)
+		);
+		$profiles_created_recent = (int) $created_query->found_posts;
+	}
+
+	// Link pages with at least one view or click in the last N days.
+	$views_table  = $wpdb->prefix . 'extrch_link_page_daily_views';
+	$clicks_table = $wpdb->prefix . 'extrch_link_page_daily_link_clicks';
+	$since        = $days > 0 ? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) : '1970-01-01';
+
+	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$active_link_page_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT link_page_id FROM {$views_table} WHERE stat_date >= %s AND view_count > 0
+			 UNION
+			 SELECT link_page_id FROM {$clicks_table} WHERE stat_date >= %s AND click_count > 0",
+			$since,
+			$since
+		)
+	);
+	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	$active_link_pages_recent = is_array( $active_link_page_ids ) ? count( $active_link_page_ids ) : 0;
+
+	if ( $did_switch ) {
+		restore_current_blog();
+	}
+
+	return array(
+		'total_artist_profiles'    => $total_artist_profiles,
+		'total_link_pages'         => $total_link_pages,
+		'profiles_created_recent'  => $profiles_created_recent,
+		'active_link_pages_recent' => $active_link_pages_recent,
+		'days'                     => $days,
+	);
+}

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -397,6 +397,45 @@ function extrachill_artist_platform_register_abilities() {
 	);
 
 	wp_register_ability(
+		'extrachill/get-artist-platform-stats',
+		array(
+			'label'               => __( 'Get artist platform stats', 'extrachill-artist-platform' ),
+			'description'         => __( 'Point-in-time platform aggregates: total published artist profiles, total published link pages, profiles created in last N days, and link pages with at least one view/click in last N days. Funnel conversion-over-time is read separately via extrachill/get-analytics-summary.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array(),
+				'properties'           => array(
+					'days' => array( 'type' => 'integer', 'minimum' => 0, 'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total_artist_profiles'    => array( 'type' => 'integer' ),
+					'total_link_pages'         => array( 'type' => 'integer' ),
+					'profiles_created_recent'  => array( 'type' => 'integer' ),
+					'active_link_pages_recent' => array( 'type' => 'integer' ),
+					'days'                     => array( 'type' => 'integer' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_get_artist_platform_stats',
+			'permission_callback' => function () {
+				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
 		'extrachill/artist-get',
 		array(
 			'label'               => __( 'Get artist by ID', 'extrachill-artist-platform' ),


### PR DESCRIPTION
## Summary
Makes the artist platform's signup/creation funnel measurable over time by **instrumenting at source** — emitting analytics events at lifecycle points and reading them through the **existing** `extrachill/get-analytics-summary` ability. No parallel read abstraction for funnel counts was built.

Implements Extra-Chill/extrachill-artist-platform#72 (the parts owned by this plugin).

## What changed (this repo)
- **`artist_profile_created` event** — emitted in the `extrachill/create-artist` handler via the existing `extrachill/track-analytics-event` ability. Emitted inside the artist-blog context so the row is stamped with the artist site's `blog_id`; payload carries `user_id` (+ `artist_id`) for cohort joins.
- **`extrachill/get-artist-platform-stats` ability** (new read ability for point-in-time aggregates the event stream can't reconstruct):
  - `total_artist_profiles` — reuses `extrachill/artists-list` `total` (with a direct `found_posts` fallback so the metric is never silently zero if the ability isn't registered yet)
  - `total_link_pages` — published `artist_link_page` count
  - `profiles_created_recent` — profiles created in last N days
  - `active_link_pages_recent` — distinct link pages with ≥1 view/click in last N days (UNION over `extrch_link_page_daily_views` + `extrch_link_page_daily_link_clicks`)
  - Logic lives entirely in the ability; permission gated to `manage_options`/WP-CLI; `show_in_rest => true`.

## Event ownership (read this — coordination note for #72)
This PR owns the **`artist_profile_created`** emit and the **stats ability** — those are squarely in extrachill-artist-platform.

The other two funnel events — **`artist_access_requested`** and **`artist_access_approved`** (the conversion event) — must be emitted from **extrachill-users**, because that is where the lifecycle code lives:
- `extrachill/request-artist-access` (stores `artist_access_request` user-meta) — `extrachill-users/inc/core/abilities/artist-access.php`
- `extrachill/approve-artist-access` (deletes the request meta, sets `user_is_artist`/`user_is_professional`) — same file.

extrachill-users is being worked by a sibling minion (issue #127, branch `team-experience-events`), so this PR deliberately does **not** touch it to avoid collision. Those two emits should land there. Once they do, all three funnel events are readable via `wp extrachill analytics summary --days=N` with zero additional read surface.

## CLI wrapper
The `wp extrachill artists stats` thin wrapper is in a companion PR on extrachill-cli (branch `measurability-cli`).

## Verification (run against the live worktree handler)
```
STATS: {"total_artist_profiles":97,"total_link_pages":189,"profiles_created_recent":4,"active_link_pages_recent":93,"days":28}
EMITTED event id 763365 on blog 4 (artist site)
SUMMARY (artist_profile_created, 1d): {"event_types":[{"event_type":"artist_profile_created","count":1,"daily_avg":1}],"total":1,...}
```
- The new event lands in `c8c_extrachill_analytics_events` and the **existing summary reader sees it** — proof the instrument-at-source approach works with no new read path. (Smoke-test event was deleted after verification.)
- `php -l` clean on all changed files. `phpcs --standard=WordPress` clean except the 3 baseline house-style findings shared verbatim with the existing sibling handler `artists-list.php` (missing file-doc / declare-before-docblock / param full-stop) — intentionally matched to the established repo convention.

## Constraints honored
- No release, no deploy — PR only.
- Conventional commit; no CHANGELOG / version edits.
- Business logic in the ability; no parallel read abstraction for funnel counts.

Refs #72