### PR TITLE
refactor: reference canonical analytics event-name constant (users#129)

### DIFF
--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -9,18 +9,17 @@
 defined( 'ABSPATH' ) || exit;
 
 /*
- * Event-name contract constant (Extra-Chill/extrachill-users#129).
- * ----------------------------------------------------------------
- * The artist-funnel analytics event_type string is defined ONCE here and
- * referenced at the emit site below, so a rename is mechanical and a
- * stray-literal typo can't silently desync this emit from the shared
- * contract (the "permanently-zero metric, no error" failure mode).
- *
- * Scope: extrachill-artist-platform owns and emits only this one funnel
- * event. The read-side aggregation lives in the analytics summary reader;
- * no load-time cross-plugin dependency is introduced in either direction.
+ * Event-name contract (Extra-Chill/extrachill-users#129).
+ * -------------------------------------------------------
+ * The canonical artist-funnel event_type name is defined ONCE in
+ * extrachill-analytics (inc/core/event-types.php) as
+ * `EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED`. extrachill-analytics owns
+ * the analytics substrate and the `extrachill/track-analytics-event`
+ * ability this handler already calls at runtime, and is network-active,
+ * so the constant is guaranteed present here — referencing it adds no new
+ * coupling. The emit site below references the analytics constant directly
+ * (no local copy of the literal), so a rename happens in exactly one place.
  */
-const EC_ARTIST_PLATFORM_EVENT_PROFILE_CREATED = 'artist_profile_created';
 
 /**
  * Create a new artist profile.
@@ -78,7 +77,7 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	if ( $analytics_ability ) {
 		$analytics_ability->execute(
 			array(
-				'event_type' => EC_ARTIST_PLATFORM_EVENT_PROFILE_CREATED,
+				'event_type' => EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
 				'event_data' => array(
 					'user_id'   => $user_id,
 					'artist_id' => (int) $artist_id,

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -8,6 +8,20 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/*
+ * Event-name contract constant (Extra-Chill/extrachill-users#129).
+ * ----------------------------------------------------------------
+ * The artist-funnel analytics event_type string is defined ONCE here and
+ * referenced at the emit site below, so a rename is mechanical and a
+ * stray-literal typo can't silently desync this emit from the shared
+ * contract (the "permanently-zero metric, no error" failure mode).
+ *
+ * Scope: extrachill-artist-platform owns and emits only this one funnel
+ * event. The read-side aggregation lives in the analytics summary reader;
+ * no load-time cross-plugin dependency is introduced in either direction.
+ */
+const EC_ARTIST_PLATFORM_EVENT_PROFILE_CREATED = 'artist_profile_created';
+
 /**
  * Create a new artist profile.
  *
@@ -64,7 +78,7 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	if ( $analytics_ability ) {
 		$analytics_ability->execute(
 			array(
-				'event_type' => 'artist_profile_created',
+				'event_type' => EC_ARTIST_PLATFORM_EVENT_PROFILE_CREATED,
 				'event_data' => array(
 					'user_id'   => $user_id,
 					'artist_id' => (int) $artist_id,


### PR DESCRIPTION
## Summary
Repoints the artist-funnel emit site at the **canonical event-name constant owned by extrachill-analytics** (Extra-Chill/extrachill-analytics#32). Part of a 5-PR set on branch `event-name-contract` resolving extrachill-users#129.

> **Revised approach:** the first pass used a per-plugin `EC_ARTIST_PLATFORM_EVENT_PROFILE_CREATED` constant, which still duplicated the literal across plugins. This revision collapses every event-name literal to a single cross-plugin source in extrachill-analytics.

## Why extrachill-analytics is the home (zero new coupling)
The create-artist handler already calls `wp_get_ability('extrachill/track-analytics-event')` at runtime — an ability owned by extrachill-analytics — so a hard runtime dependency on analytics already exists; referencing its constant adds none. extrachill-analytics is `Network: true`, so the constant is always defined. Full rationale: Extra-Chill/extrachill-analytics#32.

## Changes
- `inc/abilities/handlers/create-artist.php` — dropped the per-plugin constant; the emit site references `EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED`.

## Single-source proof
No bare `artist_profile_created` literal remains in this repo — the emit references the analytics constant.

## No behavior change
The constant resolves to the byte-identical `artist_profile_created` string used before.

## Verification
- `php -l` clean; phpcs (WordPress): zero new findings in changed hunks (the Yoda / param-comment / array-alignment findings are pre-existing house-style, confirmed against `main`).

## Related PRs (branch `event-name-contract`)
- **Keystone (constants home):** Extra-Chill/extrachill-analytics#32
- extrachill-users: Extra-Chill/extrachill-users#130
- extrachill-studio: Extra-Chill/extrachill-studio#98
- extrachill-roadie: Extra-Chill/extrachill-roadie#52

Refs Extra-Chill/extrachill-users#129. Review all 5 together; do not merge standalone.
