### PR TITLE
feat: instrument artist-signup activation funnel

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -114,6 +114,8 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/nav.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-artist-provisioning.php';
 
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/analytics/activation-funnel.php';
+
         ExtraChillArtistPlatform_PageTemplates::instance();
         ExtraChillArtistPlatform_Assets::instance();
         ExtraChillArtistPlatform_SocialLinks::instance();

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -72,19 +72,17 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	// event row is stamped with the artist site's blog_id. The existing
 	// extrachill/get-analytics-summary reader aggregates this with no new
 	// read surface. user_id is carried in the payload (and stamped on the
-	// row when the request runs as the creating user) for cohort joins.
-	$analytics_ability = wp_get_ability( 'extrachill/track-analytics-event' );
-	if ( $analytics_ability ) {
-		$analytics_ability->execute(
-			array(
-				'event_type' => EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
-				'event_data' => array(
-					'user_id'   => $user_id,
-					'artist_id' => (int) $artist_id,
-				),
-			)
-		);
-	}
+	// row when the request runs as the creating user) for cohort joins, and
+	// the anonymous first-party visitor_id is passed so this completion step
+	// stitches to the upstream artist_signup_started / user_registration rows
+	// for the same member (Extra-Chill/extrachill-users#145 stitching).
+	ec_artist_platform_emit_funnel_event(
+		EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
+		array(
+			'user_id'   => $user_id,
+			'artist_id' => (int) $artist_id,
+		)
+	);
 
 	restore_current_blog();
 

--- a/inc/analytics/activation-funnel.php
+++ b/inc/analytics/activation-funnel.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Artist-signup activation funnel instrumentation.
+ *
+ * Emits the ordered activation-funnel analytics events a new member walks
+ * while building/claiming an artist page:
+ *
+ *   user_registration                (emitted by extrachill-users)
+ *     -> artist_signup_started        entered the create-artist flow
+ *       -> artist_profile_created     profile row inserted (create-artist handler)
+ *         -> artist_profile_first_publish   link page created/published
+ *
+ * Every emit carries the anonymous first-party `visitor_id` (top-level ability
+ * arg) AND the `user_id` (in event_data), so a single member's pre/post-login
+ * path stitches into one queryable sequence and the step-to-step drop-off
+ * (and the specific abandon step) is computable. This is the same
+ * visitor_id<->user_id stitching the registration referrer/UTM work keys on
+ * (Extra-Chill/extrachill-users#145) — built once, shared.
+ *
+ * Event-name contract: the funnel event_type strings are defined ONCE in
+ * extrachill-analytics (inc/core/event-types.php) as
+ * EC_ANALYTICS_EVENT_ARTIST_* constants. extrachill-analytics owns the
+ * analytics substrate and the `extrachill/track-analytics-event` ability this
+ * file calls at runtime, and is network-active, so the constants are
+ * guaranteed present here — referencing them adds no new coupling and lets a
+ * rename happen in exactly one place.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Emit a single artist-funnel analytics event with visitor_id stitching.
+ *
+ * Thin wrapper over the extrachill/track-analytics-event ability that:
+ *   - no-ops cleanly when the analytics plugin (and its ability) is absent,
+ *   - resolves the anonymous first-party visitor_id from the analytics cookie
+ *     helper (empty string when the visitor opted out via GPC/DNT, which the
+ *     ability stores as NULL),
+ *   - always carries user_id in the payload for cohort joins.
+ *
+ * The events table also auto-stamps user_id (from the current user) and
+ * blog_id (from the current context) on the row itself.
+ *
+ * @param string $event_type One of the EC_ANALYTICS_EVENT_ARTIST_* constants.
+ * @param array  $event_data Payload; user_id should be included by the caller.
+ * @return void
+ */
+function ec_artist_platform_emit_funnel_event( $event_type, array $event_data ) {
+	if ( ! function_exists( 'wp_get_ability' ) ) {
+		return;
+	}
+
+	$ability = wp_get_ability( 'extrachill/track-analytics-event' );
+	if ( ! $ability ) {
+		return;
+	}
+
+	$visitor_id = function_exists( 'extrachill_analytics_get_or_mint_visitor_id' )
+		? (string) extrachill_analytics_get_or_mint_visitor_id()
+		: '';
+
+	$ability->execute(
+		array(
+			'event_type' => $event_type,
+			'event_data' => $event_data,
+			'visitor_id' => $visitor_id,
+		)
+	);
+}
+
+/**
+ * Emit artist_profile_first_publish when a link page is created/published.
+ *
+ * Hooks the decoupled `ec_link_page_created` action fired by
+ * ec_create_link_page() (inc/core/filters/create.php), so this fires exactly
+ * once when an artist's link page is actually created — the "finished, not
+ * just registered a bare profile" activation signal — regardless of which
+ * code path triggered creation. Skips forced/programmatic re-creation.
+ *
+ * @param int  $link_page_id Newly created link page ID.
+ * @param int  $artist_id    Associated artist profile ID.
+ * @param bool $force        Whether creation was forced (programmatic re-create).
+ * @return void
+ */
+function ec_artist_platform_emit_first_publish( $link_page_id, $artist_id, $force = false ) {
+	if ( $force ) {
+		return;
+	}
+
+	if ( ! defined( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH' ) ) {
+		return;
+	}
+
+	ec_artist_platform_emit_funnel_event(
+		EC_ANALYTICS_EVENT_ARTIST_PROFILE_FIRST_PUBLISH,
+		array(
+			'user_id'      => get_current_user_id(),
+			'artist_id'    => (int) $artist_id,
+			'link_page_id' => (int) $link_page_id,
+		)
+	);
+}
+add_action( 'ec_link_page_created', 'ec_artist_platform_emit_first_publish', 10, 3 );

--- a/src/blocks/artist-creator/render.php
+++ b/src/blocks/artist-creator/render.php
@@ -63,10 +63,15 @@ if ( function_exists( 'ec_get_artists_for_user' ) ) {
 // viewing the create-artist form (entered the activation flow). Carries the
 // anonymous visitor_id + user_id so this step stitches to the upstream
 // user_registration row and the downstream artist_profile_created /
-// _first_publish rows for the same member. Readers dedupe per visitor_id +
-// user_id, so a re-view of the form does not distort the funnel. Skipped for
-// users who already have a profile (the notice above) since they are past
-// this step.
+// _first_publish rows for the same member. This emit is intentionally dumb —
+// one row per form render. Per-person dedup is the READER's job: the funnel
+// is read via the extrachill/get-activation-funnel ability, which counts each
+// step as COUNT(DISTINCT COALESCE(NULLIF(user_id,0), visitor_id)), so a
+// member re-viewing the form collapses to one person and does not distort the
+// funnel. Do NOT read this funnel with the generic get-analytics-summary
+// COUNT(*), which counts rows and would over-count signup-flow entries.
+// Skipped for users who already have a profile (the notice above) since they
+// are past this step.
 if ( empty( $existing_artists ) && function_exists( 'ec_artist_platform_emit_funnel_event' )
 	&& defined( 'EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED' ) ) {
 	ec_artist_platform_emit_funnel_event(

--- a/src/blocks/artist-creator/render.php
+++ b/src/blocks/artist-creator/render.php
@@ -39,6 +39,7 @@ if ( ! $can_create ) {
 }
 
 // Check if user already has artist profiles
+$existing_artists = array();
 if ( function_exists( 'ec_get_artists_for_user' ) ) {
 	$existing_artists = ec_get_artists_for_user( $current_user_id );
 	if ( ! empty( $existing_artists ) ) {
@@ -56,6 +57,22 @@ if ( function_exists( 'ec_get_artists_for_user' ) ) {
 		echo '<a href="' . esc_url( home_url( '/manage-artist/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Manage Artist', 'extrachill-artist-platform' ) . '</a>';
 		echo '</div>';
 	}
+}
+
+// Emit the artist_signup_started funnel event: an eligible logged-in user is
+// viewing the create-artist form (entered the activation flow). Carries the
+// anonymous visitor_id + user_id so this step stitches to the upstream
+// user_registration row and the downstream artist_profile_created /
+// _first_publish rows for the same member. Readers dedupe per visitor_id +
+// user_id, so a re-view of the form does not distort the funnel. Skipped for
+// users who already have a profile (the notice above) since they are past
+// this step.
+if ( empty( $existing_artists ) && function_exists( 'ec_artist_platform_emit_funnel_event' )
+	&& defined( 'EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED' ) ) {
+	ec_artist_platform_emit_funnel_event(
+		EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,
+		array( 'user_id' => $current_user_id )
+	);
 }
 
 // Prefill data from user profile


### PR DESCRIPTION
## Summary

Instruments the artist-signup **activation funnel** so we can measure where new members drop off between registering and finishing an artist page. Today only ~33% of recent signups completed a profile and we can see the *end* states (profile exists / doesn't) but not **where** in the create flow the other two-thirds abandon.

Closes #77. **Depends on** Extra-Chill/extrachill-analytics#43 (defines the event-type constants this PR references).

## The funnel

```
user_registration                (extrachill-users)
  -> artist_signup_started        entered the create flow      [NEW]
    -> artist_profile_created     profile inserted              [existing, now carries visitor_id]
      -> artist_profile_first_publish   link page created       [NEW]
```

## What changed

- **`artist_signup_started`** — emitted from `src/blocks/artist-creator/render.php` when an eligible logged-in user **without** a profile views the create form (entered the flow). Skipped for users who already have a profile (they're past this step).
- **`artist_profile_created`** — the existing emit in `inc/abilities/handlers/create-artist.php`, refactored to go through the shared helper so it now **also carries `visitor_id`** for stitching (previously it only carried `user_id`/`artist_id`). Still emitted inside the artist-blog context so the row keeps the artist-site `blog_id`.
- **`artist_profile_first_publish`** — emitted on the decoupled `ec_link_page_created` action (fired by `ec_create_link_page()`), so it fires exactly once when a link page is actually created/published — the "finished, not just a bare profile" signal — regardless of which path triggered creation. Skips forced/programmatic re-creation (`$force`).

## Shared helper

New `inc/analytics/activation-funnel.php` holds `ec_artist_platform_emit_funnel_event()`: a thin wrapper over the `extrachill/track-analytics-event` ability that

- no-ops cleanly when analytics (or the ability) is absent,
- resolves the anonymous first-party `visitor_id` from the analytics cookie helper (`extrachill_analytics_get_or_mint_visitor_id()`, empty/NULL when opted out via GPC/DNT),
- always carries `user_id` in the payload.

So **every** funnel step carries `visitor_id` + `user_id` and a single member's pre/post-login path stitches into one queryable sequence — the same plumbing the registration referrer/UTM work keys on (Extra-Chill/extrachill-users#145).

Event_type strings reference the canonical `EC_ANALYTICS_EVENT_ARTIST_*` constants owned by `extrachill-analytics` — no local literals, so a rename happens in one place.

## Acceptance criteria (from #77)

- [x] Each funnel step emits an analytics event carrying `visitor_id` + `user_id` so `register -> start -> create -> publish` is queryable and the abandon step computable.
- [x] `artist_profile_created` continues to fire (unchanged behavior, now also stamped with `visitor_id`).
- [x] Existing signups unaffected; no schema migration (new event_type strings only).
- [x] No new PII beyond what the analytics events already capture.
- [x] Works on artist.extrachill.com (blog 4) — create-artist runs there; first-publish hook fires there.

## Notes

- `build/` is gitignored and regenerated by `wp-scripts build` on deploy, so only the `src/` render change is committed.
- `php -l` clean on all changed files.

## Companion PR

- Event-type constants: Extra-Chill/extrachill-analytics#43

Closes #77
Refs Extra-Chill/extrachill-users#145