### PR TITLE
fix: bootstrap extrachill.link edit button with wp-native bearer token

### DIFF
--- a/inc/link-pages/live/assets/js/link-page-edit-button.js
+++ b/inc/link-pages/live/assets/js/link-page-edit-button.js
@@ -1,58 +1,205 @@
 /**
- * Edit Button Client-Side Permission System
+ * Edit Button Client-Side Permission System (bearer-token auth)
  *
- * Security model: Zero server-side HTML rendering. JavaScript performs CORS permission
- * check to artist.extrachill.com and renders edit button only if authorized. Unauthorized
- * users receive no HTML or DOM elements. Requires WordPress authentication cookies with
- * SameSite=None; Secure attributes (configured by extrachill-users plugin).
+ * Security model: zero server-side HTML. JavaScript checks whether the current
+ * visitor may manage this artist and renders the edit button only if authorized.
+ * Unauthorized/anonymous visitors get no button and no DOM elements.
+ *
+ * Why bearer tokens (not cookies): extrachill.link is a different registrable
+ * domain than *.extrachill.com, where the WordPress auth cookie lives. A cookie
+ * can never reach extrachill.link, and the legacy SameSite=None cross-site
+ * cookie hack is blocked by modern browser privacy (Safari ITP, Chrome
+ * third-party-cookie phase-out), so the button silently failed for many
+ * logged-in artists.
+ *
+ * Instead we use a wp-native bearer token. It rides in an Authorization header,
+ * which is immune to SameSite / third-party-cookie restrictions and resolves the
+ * user network-wide. The token is bootstrapped via a one-time redirect to the
+ * artist site (where the cookie IS first-party), which mints a short-lived token
+ * and hands it back in the URL fragment. We cache it in localStorage and attach
+ * it to the cross-origin permissions request.
+ *
+ * Related:
+ * - Mint endpoint: extrachill-api/inc/auth/extrachill-link-token-handoff.php
+ * - Permissions route: extrachill-api/inc/routes/artists/permissions.php
  */
-(function() {
+(function () {
     'use strict';
 
+    var TOKEN_STORAGE_KEY = 'ecLinkEditToken';
+    // Marker so an anonymous visitor only round-trips through the mint handoff
+    // once per browser tab session instead of redirecting on every page view.
+    var HANDOFF_ATTEMPTED_KEY = 'ecLinkEditHandoffAttempted';
+
     /**
-     * Performs CORS permission check and renders edit button if authorized
+     * Read a non-expired cached token from localStorage.
      *
-     * Makes fetch request with credentials to artist.extrachill.com REST API endpoint.
-     * WordPress cookies with SameSite=None; Secure are sent via credentials: 'include'.
-     * Only renders button if server validates permission via ec_can_manage_artist().
-     *
-     * @return {void}
+     * @return {string|null} The token string, or null if absent/expired.
      */
-    function checkEditPermission() {
-        const body = document.body;
-        const apiUrl = body && body.dataset ? body.dataset.extrchPermissionsApiUrl : '';
-
-        if (!apiUrl) {
-            return;
-        }
-
-        fetch(apiUrl, {
-            method: 'GET',
-            credentials: 'include'
-        })
-        .then((response) => {
-            if (!response.ok) {
+    function getStoredToken() {
+        try {
+            var raw = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+            if (!raw) {
                 return null;
             }
-            return response.json();
-        })
-        .then((data) => {
-            if (!data || data.can_edit !== true || !data.manage_url) {
-                return;
+            var parsed = JSON.parse(raw);
+            if (!parsed || !parsed.token || !parsed.expiresAt) {
+                return null;
             }
-
-            renderEditButton(data.manage_url);
-        })
-        .catch(() => {});
+            // Treat as expired a little early to avoid using a token that dies
+            // mid-request. wp-native access tokens live ~15 minutes.
+            if (Date.now() >= (parsed.expiresAt - 5000)) {
+                window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+                return null;
+            }
+            return parsed.token;
+        } catch (e) {
+            return null;
+        }
     }
 
     /**
-     * Renders fixed-position edit button with management URL
+     * Persist a token with a client-side expiry (~15 min, matching wp-native).
      *
-     * Creates anchor element with Font Awesome icon and appends to body.
-     * Includes duplicate check to prevent multiple button instances.
+     * @param {string} token The plaintext access token.
+     * @return {void}
+     */
+    function storeToken(token) {
+        try {
+            window.localStorage.setItem(
+                TOKEN_STORAGE_KEY,
+                JSON.stringify({
+                    token: token,
+                    // 15 minutes; the server is the source of truth and a 401
+                    // will clear it early if it dies sooner.
+                    expiresAt: Date.now() + (15 * 60 * 1000)
+                })
+            );
+        } catch (e) {
+            // localStorage unavailable (private mode quotas etc.) — the button
+            // just won't render. Non-fatal.
+        }
+    }
+
+    /**
+     * Clear the cached token.
      *
-     * @param {string} manageUrl - URL to link page management interface
+     * @return {void}
+     */
+    function clearStoredToken() {
+        try {
+            window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+        } catch (e) {}
+    }
+
+    /**
+     * Parse the token (or the tokenless marker) out of the URL fragment left by
+     * the mint handoff redirect, then scrub the fragment from the address bar.
+     *
+     * @return {{token: (string|null), attempted: boolean}}
+     */
+    function consumeFragmentToken() {
+        var result = { token: null, attempted: false };
+        var hash = window.location.hash || '';
+        if (!hash || hash.length < 2) {
+            return result;
+        }
+
+        var fragment = hash.charAt(0) === '#' ? hash.substring(1) : hash;
+        var params = new URLSearchParams(fragment);
+
+        if (params.has('ec_link_token')) {
+            result.token = params.get('ec_link_token');
+            result.attempted = true;
+        } else if (params.has('ec_link_token_none')) {
+            // Handoff ran and the visitor was not logged in.
+            result.attempted = true;
+        } else {
+            return result;
+        }
+
+        // Scrub our keys from the fragment, preserving any unrelated fragment.
+        params.delete('ec_link_token');
+        params.delete('ec_link_token_none');
+        var remaining = params.toString();
+        var cleanUrl = window.location.pathname + window.location.search + (remaining ? '#' + remaining : '');
+        try {
+            window.history.replaceState(null, '', cleanUrl);
+        } catch (e) {
+            // history API unavailable — leave the URL as-is.
+        }
+
+        return result;
+    }
+
+    /**
+     * Redirect to the mint handoff endpoint on the artist site, which mints a
+     * short-lived token (if the visitor is logged in there) and 302s back with
+     * the token in the fragment. Guarded by a per-session marker so anonymous
+     * visitors only round-trip once.
+     *
+     * @param {string} handoffUrl Base handoff URL from the body data attribute.
+     * @return {void}
+     */
+    function attemptHandoff(handoffUrl) {
+        if (!handoffUrl) {
+            return;
+        }
+        try {
+            if (window.sessionStorage.getItem(HANDOFF_ATTEMPTED_KEY)) {
+                return;
+            }
+            window.sessionStorage.setItem(HANDOFF_ATTEMPTED_KEY, '1');
+        } catch (e) {
+            // sessionStorage unavailable — fall through; without the guard we'd
+            // risk a redirect loop, so bail rather than redirect.
+            return;
+        }
+
+        var returnUrl = window.location.href.split('#')[0];
+        var separator = handoffUrl.indexOf('?') === -1 ? '?' : '&';
+        var destination = handoffUrl + separator + 'return=' + encodeURIComponent(returnUrl);
+        window.location.assign(destination);
+    }
+
+    /**
+     * Call the permissions endpoint with a bearer token and render the button if
+     * authorized. On 401 (token expired/invalid) clears the cached token.
+     *
+     * @param {string} apiUrl The permissions endpoint URL.
+     * @param {string} token  The bearer access token.
+     * @return {void}
+     */
+    function checkPermission(apiUrl, token) {
+        fetch(apiUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + token
+            }
+        })
+            .then(function (response) {
+                if (response.status === 401) {
+                    clearStoredToken();
+                    return null;
+                }
+                if (!response.ok) {
+                    return null;
+                }
+                return response.json();
+            })
+            .then(function (data) {
+                if (!data || data.can_edit !== true || !data.manage_url) {
+                    return;
+                }
+                renderEditButton(data.manage_url);
+            })
+            .catch(function () {});
+    }
+
+    /**
+     * Render the fixed-position edit button.
+     *
+     * @param {string} manageUrl URL to the link page management interface.
      * @return {void}
      */
     function renderEditButton(manageUrl) {
@@ -60,7 +207,7 @@
             return;
         }
 
-        const editButton = document.createElement('a');
+        var editButton = document.createElement('a');
         editButton.href = manageUrl;
         editButton.className = 'extrch-link-page-edit-btn';
         editButton.setAttribute('aria-label', 'Edit link page');
@@ -69,10 +216,49 @@
         document.body.appendChild(editButton);
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', checkEditPermission);
-    } else {
-        checkEditPermission();
+    /**
+     * Orchestrate the edit-button auth flow.
+     *
+     * @return {void}
+     */
+    function init() {
+        var body = document.body;
+        if (!body || !body.dataset) {
+            return;
+        }
+
+        var apiUrl = body.dataset.extrchPermissionsApiUrl || '';
+        var handoffUrl = body.dataset.extrchTokenHandoffUrl || '';
+        if (!apiUrl) {
+            return;
+        }
+
+        // 1. If we just came back from the mint handoff, capture the token.
+        var fragment = consumeFragmentToken();
+        if (fragment.token) {
+            storeToken(fragment.token);
+        }
+
+        // 2. Use a cached/just-captured token if we have one.
+        var token = getStoredToken();
+        if (token) {
+            checkPermission(apiUrl, token);
+            return;
+        }
+
+        // 3. No token. If the handoff already ran this session (including the
+        //    tokenless "not logged in" return), stop — anonymous visitor.
+        if (fragment.attempted) {
+            return;
+        }
+
+        // 4. Bootstrap a token via the one-time handoff redirect.
+        attemptHandoff(handoffUrl);
     }
 
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
 })();

--- a/inc/link-pages/live/templates/single-artist_link_page.php
+++ b/inc/link-pages/live/templates/single-artist_link_page.php
@@ -81,13 +81,19 @@ $body_bg_style .= 'min-height:100vh;';
     ?>
 </head>
 <?php
-$api_base = ec_get_site_url( 'artist' ) . '/wp-json/extrachill/v1';
+$artist_site_url = ec_get_site_url( 'artist' );
+$api_base = $artist_site_url . '/wp-json/extrachill/v1';
 $permissions_api_url = $api_base . '/artists/' . $artist_id . '/permissions';
 $subscribe_api_url = $api_base . '/artists/' . $artist_id . '/subscribe';
 $tracking_click_url = $api_base . '/analytics/click';
 $tracking_view_url = $api_base . '/analytics/view';
+// Bearer-token mint handoff on the artist site, where the .extrachill.com auth
+// cookie is first-party. The edit-button JS redirects here once to obtain a
+// short-lived token, which comes back in the URL fragment (see
+// extrachill-api/inc/auth/extrachill-link-token-handoff.php).
+$token_handoff_url = $artist_site_url . '/wp-admin/admin-post.php?action=ec_link_token_handoff';
 ?>
-<body class="extrch-link-page"<?php if ($body_bg_style) echo ' style="' . esc_attr( $body_bg_style ) . '"'; ?> data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>" data-extrch-tracking-view-url="<?php echo esc_url( $tracking_view_url ); ?>">
+<body class="extrch-link-page"<?php if ($body_bg_style) echo ' style="' . esc_attr( $body_bg_style ) . '"'; ?> data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-token-handoff-url="<?php echo esc_url( $token_handoff_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>" data-extrch-tracking-view-url="<?php echo esc_url( $tracking_view_url ); ?>">
 <?php
 // Google Tag Manager (noscript)
 ?>
@@ -95,13 +101,18 @@ $tracking_view_url = $api_base . '/analytics/view';
             height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <?php
 /**
- * Edit button security model: Client-side only rendering with zero server-side HTML.
- * JavaScript performs a credentialed CORS permission check (extrachill.link → artist.extrachill.com)
- * and renders the button only if authorized.
+ * Edit button security model: client-side only rendering with zero server-side HTML.
+ * extrachill.link is a different registrable domain than *.extrachill.com, so the
+ * WordPress auth cookie can never reach it. The JS bootstraps a short-lived
+ * wp-native bearer token via a one-time redirect to the artist site (where the
+ * cookie is first-party), caches it, and performs the permission check with an
+ * Authorization: Bearer header — immune to SameSite / third-party-cookie blocking.
+ * The button renders only if the server authorizes the token-resolved user.
  *
  * Related:
  * - JS: inc/link-pages/live/assets/js/link-page-edit-button.js
- * - REST endpoint: extrachill-api/inc/routes/artist/permissions.php
+ * - Permissions endpoint: extrachill-api/inc/routes/artists/permissions.php
+ * - Token mint handoff: extrachill-api/inc/auth/extrachill-link-token-handoff.php
  */
 
     // Pass $data explicitly to the template so overlay and all settings are available


### PR DESCRIPTION
## Summary

Client-side half of the fix for the **extrachill.link edit button not appearing** for logged-in artists (owners and editors). See the companion PR Extra-Chill/extrachill-api#93 for the full root-cause writeup.

**Short version:** the button did a credentialed cross-site `fetch()` to `artist.extrachill.com` that depended on the WordPress auth cookie being sent across registrable domains via a `SameSite=None` hack. Modern browser privacy (Safari ITP, Chrome third-party-cookie phase-out) blocks that, so the button silently failed. This reworks the client flow to use a wp-native **bearer token**, which is immune to those restrictions.

## Changes

- **`inc/link-pages/live/assets/js/link-page-edit-button.js`:** rewritten to a bearer-token flow:
  1. Read a cached token from `localStorage` (with client-side expiry).
  2. If none, redirect **once per tab session** to the artist-site mint handoff; the token comes back in the URL fragment.
  3. Cache it, scrub the fragment from the address bar, and call the permissions endpoint with `Authorization: Bearer <token>`.
  4. A `401` clears the cached token; anonymous visitors round-trip at most once, then stop (no redirect loop, no button).
- **`inc/link-pages/live/templates/single-artist_link_page.php`:** emit `data-extrch-token-handoff-url` pointing at the artist-site `admin-post` mint endpoint, and update the stale security-model docblock (it incorrectly described the old credentialed-cookie model and attributed the SameSite config to the wrong plugin).

## Notes

- No server-side button HTML — the zero-server-render security model is preserved; only the auth transport changed (cookie → bearer header).
- The token is short-lived (15 min) and carried in the URL fragment, which is never transmitted to the server or written to access logs.

## Paired PR

Requires the mint endpoint + de-cookied permissions route in **extrachill-api**: Extra-Chill/extrachill-api#93. Merge/deploy together.