### PR TITLE
fix: block duplicate same-user artist profiles in create-artist ability

### DIFF
--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -38,6 +38,42 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 		return new WP_Error( 'invalid_artist_name', 'Artist name is required.' );
 	}
 
+	// Duplicate guard: reject when this same user already owns an
+	// artist_profile with an identical case-insensitive, trimmed title.
+	// Enforced server-side regardless of client (Extra-Chill/extrachill-artist-platform#80).
+	// Mirrors the established one-per-artist link-page guard at
+	// inc/core/filters/create.php:128 (return WP_Error 'already_exists').
+	// ec_get_artists_for_user() (extrachill-users) is the single source of
+	// truth for a user's published profiles and handles its own blog switch,
+	// so call it before switching context here.
+	if ( $user_id && function_exists( 'ec_get_artists_for_user' ) ) {
+		$existing_artist_ids = ec_get_artists_for_user( $user_id );
+		if ( ! empty( $existing_artist_ids ) ) {
+			$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+			if ( $artist_blog_id ) {
+				switch_to_blog( $artist_blog_id );
+				$normalized_new = function_exists( 'mb_strtolower' ) ? mb_strtolower( $name ) : strtolower( $name );
+				foreach ( $existing_artist_ids as $existing_id ) {
+					$existing_title      = trim( (string) get_the_title( (int) $existing_id ) );
+					$normalized_existing = function_exists( 'mb_strtolower' ) ? mb_strtolower( $existing_title ) : strtolower( $existing_title );
+					if ( $normalized_existing === $normalized_new ) {
+						restore_current_blog();
+						return new WP_Error(
+							'duplicate_artist_name',
+							sprintf(
+								/* translators: %s: the duplicate artist profile name. */
+								__( 'You already have an artist profile named "%s". Open the existing profile instead of creating a duplicate.', 'extrachill-artist-platform' ),
+								$name
+							),
+							array( 'existing_artist_id' => (int) $existing_id )
+						);
+					}
+				}
+				restore_current_blog();
+			}
+		}
+	}
+
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 	if ( ! $artist_blog_id ) {
 		return new WP_Error( 'dependency_missing', 'Multisite not configured.' );
@@ -95,5 +131,8 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 		return $get_ability->execute( array( 'artist_id' => $artist_id ) );
 	}
 
-	return array( 'id' => (int) $artist_id, 'name' => $name );
+	return array(
+		'id'   => (int) $artist_id,
+		'name' => $name,
+	);
 }


### PR DESCRIPTION
## Summary

The `extrachill/create-artist` ability (`inc/abilities/handlers/create-artist.php`) validated only that the name was non-empty (`strlen($name) < 1`) before calling `wp_insert_post()` with `post_status=publish`. There was **no duplicate guard**, so a user could create unlimited profiles with the identical title. A real incident produced two identical "THE HIVE" profiles 10 minutes apart because nothing stopped the second submission.

This adds a **server-side** duplicate guard, enforced regardless of client.

Fixes #80

## What changed

Before the `wp_insert_post()` call, the handler now:

1. Enumerates the current user's published profiles via `ec_get_artists_for_user( $user_id )` (extrachill-users — the single source of truth for user→artist relationships; it handles its own blog switching).
2. Normalizes both the incoming name and each existing title by `trim()` + lowercase.
3. If any existing title matches the incoming title (case-insensitive, trimmed), returns a `WP_Error` and does **not** create the profile.

## Design choices

- **Block, not warn.** Mirrors the established one-per-artist link-page guard at `inc/core/filters/create.php:128`, which returns a hard `WP_Error( 'already_exists', ... )`. A hard rejection is the safer default for a publish-status write and matches the existing precedent in this codebase. The error includes `existing_artist_id` in its data array so a client can deep-link the user to their existing profile (enabling a future confirm/redirect UX without changing the contract).
- **Error shape.** Returns `new WP_Error( 'duplicate_artist_name', <message>, array( 'existing_artist_id' => <id> ) )`, matching exactly how the handler already returns rejections (`invalid_artist_name`, `dependency_missing`). No new contract surface.
- **Case-insensitivity + trim.** Comparison is `mb_strtolower`-normalized (ASCII `strtolower` fallback) and trimmed on both sides, so "THE HIVE", "the hive", and " The Hive " all collide for the same user. `$name` is already trimmed at the top of the handler.
- **Scope = same user only.** Only the creating user's own profiles are checked. Two different users may legitimately have same-named profiles, so cross-user titles are intentionally not blocked.
- **Defensive `function_exists` guards** match the rest of the handler's style (it already guards `ec_get_blog_id`, `ec_add_artist_membership`), so the ability degrades gracefully if extrachill-users isn't loaded.

## Verification

- `php -l` clean.
- `phpcs --standard=WordPress` on the changed file: the only remaining findings are **pre-existing baseline** (a param-comment full-stop and two Yoda-condition errors that exist on `main`); the new code introduces **zero** new findings. (WPCS is not a committed dev-dependency of this repo, so it was installed locally only for linting and reverted — no `composer.json`/`composer.lock` changes are included.)
- Happy path preserved: first profile → `ec_get_artists_for_user()` returns empty → guard skipped → insert proceeds. Different title → no normalized match → proceeds. Only true same-user same-title duplicates are blocked.