### PR TITLE
fix: hard-stop artist creator when user already owns a profile (#82)

### DIFF
--- a/src/blocks/artist-creator/render.php
+++ b/src/blocks/artist-creator/render.php
@@ -38,25 +38,30 @@ if ( ! $can_create ) {
 	return;
 }
 
-// Check if user already has artist profiles
+// Hard stop: if the user already owns at least one artist profile, render ONLY
+// the notice + management actions and do NOT mount the React creation form.
+// Falling through here previously left the blank creation form fully usable
+// below the notice, allowing the same user to create duplicate profiles (#82).
 $existing_artists = array();
 if ( function_exists( 'ec_get_artists_for_user' ) ) {
 	$existing_artists = ec_get_artists_for_user( $current_user_id );
-	if ( ! empty( $existing_artists ) ) {
-		$artist_count = count( $existing_artists );
-		echo '<div class="notice notice-info">';
-		if ( $artist_count === 1 ) {
-			echo '<p>' . esc_html__( 'You already have an artist profile.', 'extrachill-artist-platform' ) . '</p>';
-		} else {
-			echo '<p>' . sprintf(
-				/* translators: %d: number of artist profiles */
-				esc_html__( 'You already have %d artist profiles.', 'extrachill-artist-platform' ),
-				$artist_count
-			) . '</p>';
-		}
-		echo '<a href="' . esc_url( home_url( '/manage-artist/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Manage Artist', 'extrachill-artist-platform' ) . '</a>';
-		echo '</div>';
+}
+
+if ( ! empty( $existing_artists ) ) {
+	$artist_count = count( $existing_artists );
+	echo '<div class="notice notice-info">';
+	if ( $artist_count === 1 ) {
+		echo '<p>' . esc_html__( 'You already have an artist profile.', 'extrachill-artist-platform' ) . '</p>';
+	} else {
+		echo '<p>' . sprintf(
+			/* translators: %d: number of artist profiles */
+			esc_html__( 'You already have %d artist profiles.', 'extrachill-artist-platform' ),
+			$artist_count
+		) . '</p>';
 	}
+	echo '<a href="' . esc_url( home_url( '/manage-artist/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Manage Artist', 'extrachill-artist-platform' ) . '</a>';
+	echo '</div>';
+	return;
 }
 
 // Emit the artist_signup_started funnel event: an eligible logged-in user is
@@ -70,9 +75,10 @@ if ( function_exists( 'ec_get_artists_for_user' ) ) {
 // member re-viewing the form collapses to one person and does not distort the
 // funnel. Do NOT read this funnel with the generic get-analytics-summary
 // COUNT(*), which counts rows and would over-count signup-flow entries.
-// Skipped for users who already have a profile (the notice above) since they
-// are past this step.
-if ( empty( $existing_artists ) && function_exists( 'ec_artist_platform_emit_funnel_event' )
+// Users who already have a profile never reach this point — the hard stop
+// above returns before the form (and this emit) renders, so they are correctly
+// excluded from the signup_started step.
+if ( function_exists( 'ec_artist_platform_emit_funnel_event' )
 	&& defined( 'EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED' ) ) {
 	ec_artist_platform_emit_funnel_event(
 		EC_ANALYTICS_EVENT_ARTIST_SIGNUP_STARTED,

--- a/src/blocks/artist-creator/view.js
+++ b/src/blocks/artist-creator/view.js
@@ -86,7 +86,24 @@ const App = () => {
 			}
 
 			if ( created?.id ) {
+				// Route to an unambiguous landing instead of leaving the user
+				// on the SPA with a re-submittable blank form (#82). The PHP
+				// hard stop in render.php already prevents the blank form from
+				// re-mounting on reload; this redirect closes the in-session
+				// gap where a successful create left the user staring at the
+				// SPA with no clear "it worked" signal. We redirect to a
+				// known-good URL from the localized config (manage-link-page is
+				// the natural next onboarding step) rather than guessing fields
+				// on the API response. The success panel below renders as the
+				// brief confirmation before navigation completes.
 				setCreatedArtist( created );
+
+				const landingUrl =
+					config.createLinkPageUrl || config.manageArtistUrl;
+
+				if ( landingUrl ) {
+					window.location.assign( landingUrl );
+				}
 			}
 		} catch ( err ) {
 			setError( err?.message || 'Failed to create artist profile.' );


### PR DESCRIPTION
## Summary

Fixes #82 — the "you already have an artist profile" guard in the artist-creator block was both **display-only** (no hard stop) and **reload-only** (PHP-only check the React SPA never re-ran), so a user with an existing profile saw a blank, fully-usable creation form and could create a duplicate. A real user (jamie, 2026-06-22) did exactly this.

## What changed

### 1. PHP hard stop (the load-bearing fix) — `src/blocks/artist-creator/render.php`
- When `ec_get_artists_for_user()` reports the current user already owns **any** artist profile, the block now renders **only** the notice + "Manage Artist" action and **`return`s** — it no longer falls through to enqueue the frontend script or output `#ec-artist-creator-root`. The blank creation form is no longer mounted for existing owners.
- The `empty( $existing_artists )` guard around the `artist_signup_started` funnel emit was simplified: the hard stop above already guarantees existing owners never reach that line, so they remain correctly excluded from the funnel step. Comment updated to reflect this.

### 2. React success landing — `src/blocks/artist-creator/view.js`
- On a successful create, the creator now routes to an unambiguous landing (`createLinkPageUrl` — the natural next onboarding step, falling back to `manageArtistUrl`) instead of leaving the user on the SPA with a re-submittable blank form.
- The redirect uses **known-good localized config URLs** rather than guessing fields on the API response (the `@extrachill/api-client` `create()` return shape isn't a guaranteed source of a permalink), and fires **after** the existing post-create image upload so that step still runs.

## Notes / decisions
- **`build/` is gitignored** in this repo and is produced at deploy time — no built assets are committed. `npm run build` was run locally and **compiled successfully** to verify the source.
- The React source (`src/blocks/artist-creator/view.js`) is present and not minified, so part 2 was implemented in full — no follow-up deferral was needed.
- Source already shipped a client-side success panel; the real incident root cause was the missing PHP hard stop on reload, which is now fixed. The added redirect closes the in-session "nothing happened" gap.

## Verification
- `npm run build` — compiles successfully.
- `php -l render.php` — no syntax errors.
- `wp-scripts lint-js view.js` — no **new** errors introduced (the file carries pre-existing baseline prettier tabs-vs-spaces debt on lines unrelated to this change; confirmed identical count before/after via `git stash`). Left baseline untouched per fix-only-yours discipline.

## Constraints respected
- Conventional commit (`fix:`). No CHANGELOG edits, no version bump (homeboy owns both). PR only — no deploy/release.