### PR TITLE
fix: stop prefilling artist name with user display_name

### DIFF
--- a/src/blocks/artist-creator/render.php
+++ b/src/blocks/artist-creator/render.php
@@ -80,11 +80,15 @@ if ( empty( $existing_artists ) && function_exists( 'ec_artist_platform_emit_fun
 	);
 }
 
-// Prefill data from user profile
+// Prefill data from user profile.
+// Intentionally do NOT prefill artist_name from the user's display_name: an
+// artist/act name is rarely the same as the person's name, and a confused user
+// who submits without changing it creates a profile literally named after
+// themselves. The field renders empty with a placeholder so the user must
+// consciously type the act's name.
 $prefill = array();
 $current_user = wp_get_current_user();
 if ( $current_user && $current_user->ID ) {
-    $prefill['artist_name'] = $current_user->display_name;
     $prefill['avatar_id']   = get_user_meta( $current_user->ID, 'custom_avatar_id', true );
     if ( $prefill['avatar_id'] ) {
         $prefill['avatar_thumb'] = wp_get_attachment_image_url( $prefill['avatar_id'], 'thumbnail' );


### PR DESCRIPTION
## Summary
- The artist-creator block pre-filled the artist-name field with the current user's WP `display_name` (`src/blocks/artist-creator/render.php:87`).
- An artist/act name is rarely the same as the person's name, so confused users submitted the form unchanged and created profiles literally named after themselves. Real incident (2026-06-22): a user "jamie" created a profile named **"jamie"** because the field came pre-filled with his display name.
- This drops the `display_name` prefill so the field renders **empty** with its existing placeholder ("Enter your artist or band name"), forcing the user to consciously type the act's name.

## Why this is the minimal fix
- The React app (`src/blocks/artist-creator/view.js`) already initializes `name` as `config.prefill?.artist_name || ''`, so removing the PHP prefill key makes the field render empty with no JS change needed.
- The input already has a helpful placeholder and `required`, and both client-side (`Artist name is required.`) and server-side empty-name validation still block empty submits.

## Build / verification
- Edited the **source** (`src/blocks/artist-creator/render.php`), not just build output.
- Ran `npm run build` (wp-scripts) — compiled successfully; confirmed `build/blocks/artist-creator/render.php` no longer references `display_name` and `view.js` resolves to `artist_name||""`.
- `php -l` passes on the edited file.
- `build/` is gitignored in this repo (produced at release/deploy time), so no build artifacts are committed — only the source change.
- Note: eslint/prettier reports pre-existing formatting issues in `view.js` (tabs/JSX wrapping) that are unrelated to this change and were left untouched per "fix only your changes" discipline.

Fixes #81