### PR TITLE
feat: existing-account awareness at join registration to prevent duplicate accounts

### DIFF
--- a/inc/join/join-flow.php
+++ b/inc/join/join-flow.php
@@ -5,11 +5,13 @@
  * Handles join flow operations:
  * - Modal rendering via template action hook
  * - Redirect logic for login/registration via from_join parameter
+ * - Returning-user nudge: existing email at registration → login tab
  *
  * Flow:
  * - New users registering via join flow → /create-artist/
  * - Existing users with no artists → /create-artist/
  * - Existing users with artists → /manage-link-page/
+ * - Registering with an email that already has an account → /login/ (login tab)
  *
  * @package ExtraChillArtistPlatform
  */
@@ -124,6 +126,78 @@ function ec_join_flow_login_redirect( $redirect_to, $requested_redirect_to, $use
 	return $dest['url'];
 }
 add_filter( 'login_redirect', 'ec_join_flow_login_redirect', 10, 3 );
+
+/**
+ * Nudge returning users toward login before a duplicate account is created.
+ *
+ * The join flow drops confused returning users straight onto the registration
+ * tab. A real incident (2026-06-22) had a user who couldn't tell his first
+ * registration had succeeded create a SECOND, empty account rather than logging
+ * back in — the path of least resistance with nothing stopping it.
+ *
+ * This runs on the registration submission BEFORE the user-creation handler
+ * (extrachill-users hooks the same action at the default priority 10; this fires
+ * at priority 5). For join-flow submissions only, if the submitted email already
+ * belongs to an account, we send the user back to the login tab with an explicit
+ * "you already have an account — log in" nudge instead of letting the generic
+ * anti-enumeration error fire and silently inviting a clean-slate duplicate.
+ *
+ * Scope is deliberately narrow: it only acts on verified join-flow registration
+ * submissions, so it cannot be used as an email-enumeration oracle outside a
+ * legitimate, nonce-verified registration attempt (which already reveals the same
+ * "exists" signal today via the duplicate-email error path).
+ */
+function ec_join_flow_existing_account_nudge() {
+	// Only intervene on join-flow registration submissions. ec_is_join_flow_request()
+	// inspects $_REQUEST['from_join'] / redirect_to, matching how the rest of this
+	// flow detects its own requests.
+	if ( ! ec_is_join_flow_request() ) {
+		return;
+	}
+
+	if ( ! class_exists( 'EC_Redirect_Handler' ) || ! function_exists( 'email_exists' ) ) {
+		return;
+	}
+
+	// Verify the registration nonce before reading the email, mirroring the
+	// canonical handler in extrachill-users. This guarantees we only act on a
+	// genuine form submission, not an arbitrary crafted request.
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified immediately below.
+	if (
+		! isset( $_POST['extrachill_register_nonce'] )
+		|| ! wp_verify_nonce(
+			sanitize_text_field( wp_unslash( $_POST['extrachill_register_nonce'] ) ),
+			'extrachill_register_nonce_field'
+		)
+	) {
+		return;
+	}
+
+	$email = isset( $_POST['extrachill_email'] )
+		? sanitize_email( wp_unslash( $_POST['extrachill_email'] ) )
+		: '';
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	if ( empty( $email ) || ! email_exists( $email ) ) {
+		// Brand-new email (or no email): let the normal registration handler run.
+		return;
+	}
+
+	// Existing account detected. Route the user to the login tab with a nudge,
+	// preserving the join-flow context so the experience stays coherent.
+	$redirect = EC_Redirect_Handler::from_post( 'ec_registration' );
+
+	$login_url = add_query_arg( 'from_join', 'true', home_url( '/login/' ) ) . '#tab-login';
+
+	extrachill_set_notice(
+		__( 'Looks like you already have an Extra Chill account with that email. Log in below to continue — no need to create a new one.', 'extrachill-artist-platform' ),
+		'info'
+	);
+
+	$redirect->redirect_to( $login_url );
+}
+add_action( 'admin_post_nopriv_extrachill_register_user', 'ec_join_flow_existing_account_nudge', 5 );
+add_action( 'admin_post_extrachill_register_user', 'ec_join_flow_existing_account_nudge', 5 );
 
 /**
  * Handle post-registration redirect for join flow users


### PR DESCRIPTION
## Summary

Closes the duplicate-account failure mode described in #83. A confused returning user who couldn't tell his first registration had succeeded created a **second, empty account** because the join flow dropped him straight onto the registration tab with nothing nudging him toward login.

This adds a returning-user / duplicate heuristic at the **join-flow registration entry point** so an existing email gets steered to login instead of silently spawning a clean-slate account.

Fixes #83

## The heuristic & where it hooks

- New function `ec_join_flow_existing_account_nudge()` in `inc/join/join-flow.php`.
- Hooked to `admin_post_nopriv_extrachill_register_user` **and** `admin_post_extrachill_register_user` at **priority 5**, so it runs *before* the canonical user-creation handler in `extrachill-users` (which hooks the same action at the default priority 10).
- Flow:
  1. Bail unless this is a join-flow request (`ec_is_join_flow_request()` — the same detector the rest of this file already uses).
  2. **Verify the registration nonce** (`extrachill_register_nonce` / `extrachill_register_nonce_field`) before touching the email — mirrors the canonical handler in `extrachill-users/inc/auth/register.php`.
  3. Read + sanitize the submitted email; if it's empty or brand-new (`! email_exists()`), return and let normal registration proceed untouched.
  4. If the email already belongs to an account, set an info notice ("Looks like you already have an Extra Chill account with that email. Log in below…") and redirect to `/login/?from_join=true#tab-login` via the existing `EC_Redirect_Handler`, preserving the join-flow context.

## Why this shape

- **Server-side**, uses existing primitives only: `email_exists()`, `EC_Redirect_Handler`, `extrachill_set_notice()`.
- **Respects the existing ability/redirect contract** — routes through `EC_Redirect_Handler` exactly like the canonical registration handler, rather than inventing a new error path.
- **Tightly scoped** to the join/registration entry, as the issue requested — does not redesign the auth flow or touch the higher-stakes create-artist guards.
- **Not an enumeration oracle:** it only acts on a *nonce-verified* join-flow registration submission. The same "this email exists" signal is already exposed today by the duplicate-email error in `extrachill-users`, so this adds no new disclosure — it just turns that dead-end into a helpful login nudge.

## Behavior

- Genuinely-new email → `email_exists()` false → early return → registers exactly as before.
- Existing email in a join-flow submission → redirected to the login tab with the nudge; no second account created.

## Constraints honored

- Conventional commit (`feat:`). No `CHANGELOG.md` edit, no version bump (homeboy owns both).
- Work confined to the `extrachill-artist-platform` worktree; no other repos touched.

## Verification

- `php -l inc/join/join-flow.php` → no syntax errors.
- `phpcs --standard=WordPress inc/join/join-flow.php` → **0 findings** (exit 0); the added code introduces no new phpcs violations.
- The one phpstan note on the new code (`extrachill_set_notice not found`) is a pre-existing, file-wide baseline pattern — the function is theme-defined and phpstan can't resolve it; the original code in this same file already calls it identically in 4 places. No new class of finding introduced.

> Note: the repo's `composer lint:php` references the `WordPress` PHPCS standard but does not declare WPCS as a dev dependency, so the standard isn't installable from this repo's composer alone (pre-existing limitation). Lint was run against the host-installed WordPress Coding Standards.