### PR TITLE
fix: make responsive card grids overflow-safe (min(100%, floor))

### DIFF
--- a/assets/css/artist-card.css
+++ b/assets/css/artist-card.css
@@ -15,7 +15,7 @@
 
 .artist-cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
   gap: var(--spacing-lg);
 }
 
@@ -165,14 +165,14 @@
 /* Responsive Design */
 @media (max-width: 1024px) {
   .artist-cards-grid {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
     gap: var(--spacing-md);
   }
 }
 
 @media (max-width: 768px) {
   .artist-cards-grid {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 250px), 1fr));
     gap: var(--spacing-md);
   }
 


### PR DESCRIPTION
## Summary

Makes the `.artist-cards-grid` responsive card grids overflow-safe by wrapping the `minmax` floor in `min(100%, <floor>)`. Previously these grids could force horizontal overflow when the viewport was narrower than the column floor — a real bug on narrow screens. With `min(100%, <floor>)` the column shrinks to fit the container instead of overflowing, while keeping identical layout everywhere else.

This adopts the platform card-grid pattern from Extra-Chill/extrachill-components#16 **locally**, without adding an `@extrachill/components` dependency — this repo does not load the shared components stylesheet and these are CSS-only (non-React) grids.

## Grids fixed (`assets/css/artist-card.css`)

- **Line 18** — `.artist-cards-grid` base: `minmax(300px, 1fr)` → `minmax(min(100%, 300px), 1fr)`
- **Line 168** — `@media (max-width: 1024px)` override: `minmax(280px, 1fr)` → `minmax(min(100%, 280px), 1fr)`
- **Line 175** — `@media (max-width: 768px)` override: `minmax(250px, 1fr)` → `minmax(min(100%, 250px), 1fr)`

All three use `auto-fit` and remain `auto-fit` (fill/fit preserved). Gap, floor values, and media-query breakpoints unchanged. No custom-property indirection introduced — the diff is surgical.

## Scope notes

- `assets/css/artist-card.css` is hand-written CSS shipped as-is (no `src/` source, `wp-scripts build` only compiles `src/blocks/`), so no rebuild was needed.
- Two other grids exist in `src/blocks/artist-shop-manager/style.scss` but are outside this task's scope (different feature, not part of the listed grids).

## Verification

- `npx wp-scripts lint-style assets/css/artist-card.css`: the `min(100%, <floor>)` values introduce **no** new syntax/value errors. The file has pre-existing stylistic warnings (2-space indentation, quote style) on every line, unrelated to this change; running `--fix` would reformat the whole file and balloon the diff, so it was intentionally left alone.

Refs #16