### PR TITLE
fix: self-heal stale artist-platform rewrite rules via version-gated flush

### DIFF
--- a/assets/css/extrch-links.css
+++ b/assets/css/extrch-links.css
@@ -126,6 +126,17 @@ body {
   color: var(--link-page-text-color); /* Ensures title uses the main text color variable */
 }
 
+/* A leading emoji in the title. Emoji glyphs render at the full font-size and
+   fill the entire em-box, so at the title's large --link-page-title-font-size
+   (default 2.1em) they visually dwarf the surrounding text. Bound the emoji to
+   a fraction of the title size and keep it inline so it no longer balloons,
+   without shrinking the title text for names that have no emoji. */
+.extrch-link-page-title-emoji {
+  font-size: 0.75em;
+  line-height: 1;
+  vertical-align: middle;
+}
+
 .extrch-link-page-bio {
   color: var(--link-page-text-color); /* Ensures bio uses the main text color variable */
   font-family: var(--link-page-body-font-family); /* Directly apply body font */

--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -135,6 +135,12 @@ class ExtraChillArtistPlatform {
         // Link-page analytics tables are owned and created by extrachill-analytics
         // (ECA) as of extrachill-artist-platform#89 / extrachill-analytics#94.
         flush_rewrite_rules();
+        // Persist the rewrite-rules version so the version-gated flush on init
+        // does not immediately re-run after activation. The constant is defined
+        // in inc/core/artist-platform-rewrite-rules.php, loaded during init().
+        if ( defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
+            update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
+        }
         update_option( 'extrachill_artist_platform_activated', true );
 
         // Provision platform artist profile (suspenders).

--- a/inc/core/artist-platform-rewrite-rules.php
+++ b/inc/core/artist-platform-rewrite-rules.php
@@ -13,6 +13,21 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Rewrite-rules version for the artist platform.
+ *
+ * Bump this constant whenever the routing defined in this file changes. On the
+ * first request after a deploy where this value differs from the stored option,
+ * the rewrite rules are soft-flushed (rebuilt from the current, host-guarded
+ * code) so stale catch-all rules left over from older plugin versions cannot
+ * survive a deploy.
+ *
+ * @see extrachill_artist_platform_maybe_flush_rewrite_rules()
+ */
+if ( ! defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
+    define( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION', '20260704' );
+}
+
+/**
  * Get all excluded slugs dynamically
  *
  * @return array Array of slugs to exclude from artist link page rewrite rules
@@ -129,7 +144,7 @@ function extrachill_resolve_link_domain_query() {
 
     global $wp_query;
     $request_uri  = $_SERVER['REQUEST_URI'] ?? '';
-    $request_path = trim( parse_url( $request_uri, PHP_URL_PATH ), '/' );
+    $request_path = trim( (string) parse_url( $request_uri, PHP_URL_PATH ), '/' );
 
     // Handle join redirect.
     if ( $request_path === 'join' ) {
@@ -237,6 +252,40 @@ function extrachill_init_rewrite_rules() {
 }
 
 /**
+ * Self-heal stale rewrite rules via a version-gated soft flush.
+ *
+ * flush_rewrite_rules() is expensive and must never run unconditionally on
+ * every request. Instead, compare a stored option against the current
+ * EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION constant. When they differ (i.e. the
+ * plugin was updated and the routing may have changed), rebuild the
+ * rewrite_rules option from the current, host-guarded rule set and persist the
+ * new version.
+ *
+ * This is the standard WordPress pattern for keeping rewrite rules correct
+ * across deploys without paying the flush cost on every page load. It is what
+ * prevents residue from older plugin versions (e.g. the bare
+ * `^([^/]+)/?$ -> artist_link_page` catch-all that pre-dated the host guard)
+ * from persisting after the code that registered it has been removed.
+ *
+ * Runs at priority 30, after extrachill_init_rewrite_rules() (priority 25) has
+ * registered the current rule set, so the rebuilt option reflects the latest
+ * add_rewrite_rule() calls.
+ */
+function extrachill_artist_platform_maybe_flush_rewrite_rules() {
+    $stored_version = get_option( 'ec_artist_platform_rewrite_version' );
+
+    if ( $stored_version === EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION ) {
+        return;
+    }
+
+    // Soft flush: rebuild the rewrite_rules option only. Passing false means we
+    // do NOT regenerate .htaccess / server config on every version bump — the
+    // rules we care about live in the WP option, not the static server config.
+    flush_rewrite_rules( false );
+    update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
+}
+
+/**
  * Redirect direct CPT access to extrachill.link domain
  * 
  * Redirects direct access to 'artist_link_page' CPT posts (via their WordPress permalinks)
@@ -289,6 +338,7 @@ function extrachill_redirect_artist_link_page_cpt_to_custom_domain() {
 
 // Hook into WordPress
 add_action( 'init', 'extrachill_init_rewrite_rules', 25 );
+add_action( 'init', 'extrachill_artist_platform_maybe_flush_rewrite_rules', 30 );
 add_filter( 'query_vars', 'extrachill_add_query_vars' );
 add_filter( 'redirect_canonical', 'extrachill_prevent_canonical_redirect_for_link_domain', 10, 2 );
 

--- a/src/blocks/link-page-editor/components/Preview.js
+++ b/src/blocks/link-page-editor/components/Preview.js
@@ -8,6 +8,45 @@
 import { useEffect, useMemo, useRef, Fragment } from '@wordpress/element';
 import { useEditor } from '../context/EditorContext';
 
+/**
+ * Matches a single leading emoji (including ZWJ sequences and
+ * skin-tone / variation selectors) at the start of the profile name.
+ * \p{Extended_Pictographic} covers most pictographic emoji; the optional
+ * ZWJ (\u200D) join handles compound emoji (family, etc.).
+ */
+const LEADING_EMOJI_RE =
+	/^(\p{Extended_Pictographic}(?:\u200D\p{Extended_Pictographic})*[\uFE0F\u{1F3FB}-\u{1F3FF}]?)/u;
+
+/**
+ * Render the profile name for the preview title. If the name begins with an
+ * emoji, wrap it in a bounded span (styled via .extrch-link-page-title-emoji)
+ * so it cannot balloon to the full --link-page-title-font-size. Names without
+ * a leading emoji render unchanged.
+ *
+ * @param {string} name Profile display name, optionally prefixed with an emoji.
+ * @return {import('react').ReactNode} Title node.
+ */
+function renderTitle( name ) {
+	if ( ! name ) {
+		return null;
+	}
+
+	const match = name.match( LEADING_EMOJI_RE );
+	if ( ! match ) {
+		return name;
+	}
+
+	const emoji = match[ 1 ];
+	const rest = name.slice( emoji.length );
+
+	return (
+		<>
+			<span className="extrch-link-page-title-emoji">{ emoji }</span>
+			{ rest }
+		</>
+	);
+}
+
 export default function Preview() {
 	const {
 		computedStyles,
@@ -340,7 +379,9 @@ export default function Preview() {
 							) }
 						</div>
 						{ name && (
-							<h1 className="extrch-link-page-title">{ name }</h1>
+							<h1 className="extrch-link-page-title">
+								{ renderTitle( name ) }
+							</h1>
 						) }
 						{ bio && (
 							<div className="extrch-link-page-bio">{ bio }</div>

--- a/src/blocks/link-page-editor/style.scss
+++ b/src/blocks/link-page-editor/style.scss
@@ -158,12 +158,18 @@
 /* Editor Body - Two Column Layout */
 .ec-editor__body {
 	display: grid;
-	grid-template-columns: 400px 1fr;
+
+	/* minmax(0, 1fr) lets the preview track shrink below its min-content width
+	   instead of blowing out the 400px sidebar / overflowing horizontally. */
+	grid-template-columns: 400px minmax(0, 1fr);
 	min-height: 550px;
 	gap: 0;
 }
 
 .ec-editor__sidebar {
+
+	/* Grid item: allow it to shrink within its 400px track. */
+	min-width: 0;
 	display: flex;
 	flex-direction: column;
 	border-right: 1px solid var(--border-color);
@@ -197,6 +203,10 @@
 
 /* Preview Container */
 .ec-editor__preview-region {
+
+	/* Grid item of .ec-editor__body: must opt out of the default min-width: auto
+	   so wide preview content cannot inflate the 1fr track. */
+	min-width: 0;
 	display: grid;
 	gap: var(--spacing-md);
 	padding: var(--spacing-lg);


### PR DESCRIPTION
## Summary

Fixes the **recurring stale-rewrite-rules regression** on the artist platform that makes `/manage-link-page/` and `/manage-artist/` render the site homepage (and breaks login with a redirect loop). This has regressed at least twice — community reports in **May + July 2026**. A manual `wp rewrite flush` fixed it each time, but nothing deterministically re-flushed after deploys, so the stale rule kept coming back.

## Root cause

The `rewrite_rules` option on `artist.extrachill.com` carried a **stale bare catch-all** rewrite rule:

```
^([^/]+)/?$  ->  index.php?artist_link_page=$matches[1]
```

This rule has **no exclusion list** and **no host guard**. It was registered by an **older plugin version** (introduced in `e7a9b9b` "Initial commit", **removed** in `1e099b6`). The current code is correctly host-guarded — `extrachill_add_rewrite_rules()` early-returns on any non-`extrachill.link` host (so on `artist.extrachill.com` it adds **no** link-page catch-all):

```php
if ( ! $is_link_domain ) {
    add_rewrite_tag( '%artist_link_page%', '([^&]+)' );
    return;
}
```

But the **DB option was never rebuilt** after the code that seeded the bad rule was removed. Updating plugin files does **not** regenerate the `rewrite_rules` option — only `flush_rewrite_rules()` does, and nothing called it on version change/deploy (the existing `register_activation_hook` flush only fires on literal activation, not on file-only updates).

Result: the dead bare catch-all survived indefinitely. `manage-link-page` matched it, resolved to a nonexistent `artist_link_page` slug, and fell through to the homepage. Login redirect looped for the same reason.

**Pollution source note:** the bare catch-all is **not in current code** — verified via `git log -S` across all history (only `e7a9b9b` added it, only `1e099b6` removed it). The version-gated flush below **auto-heals the residue** on the next deploy; no manual flush needed.

## Community evidence

- Community topic: **"Can't edit link page"**
- Reports: **May 2026** and **July 2026** (recurring after each temporary manual flush)
- Affected users: **@psotamusic**, **@mindwater**
- Symptom: `/manage-link-page/` and `/manage-artist/` show the homepage; login redirect-loops

## What changed

### 1. Version-gated soft flush (the actual self-heal) — `inc/core/artist-platform-rewrite-rules.php`

- New constant **`EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION`** (`'20260704'`). Bump it whenever routing in this file changes.
- New **`extrachill_artist_platform_maybe_flush_rewrite_rules()`** hooked on `init` at **priority 30** (after rules register at priority 25). It compares the stored option `ec_artist_platform_rewrite_version` against the constant; on mismatch it calls **`flush_rewrite_rules( false )`** (soft flush — rebuilds the `rewrite_rules` option only, does **not** rewrite `.htaccess`/server config) and persists the new version.

This is the standard WordPress self-healing pattern: **one flush per routing-version change, never per-request** (unconditional `flush_rewrite_rules()` on `init` is a known perf footgun and is explicitly avoided).

### 2. Activation hook — `extrachill-artist-platform.php`

- `activate()` now persists `ec_artist_platform_rewrite_version` after its existing `flush_rewrite_rules()`, so the post-activation `init` does not redundantly re-flush.

### 3. `trim()` null deprecation fix — `inc/core/artist-platform-rewrite-rules.php:144`

```php
// before
$request_path = trim( parse_url( $request_uri, PHP_URL_PATH ), '/' );
// after
$request_path = trim( (string) parse_url( $request_uri, PHP_URL_PATH ), '/' );
```

`parse_url(..., PHP_URL_PATH)` can return `null`; `trim()` is null-unsafe on PHP 8.1+.

## Why this stops it recurring

After this PR merges and the next deploy ships:

1. Plugin loads with `EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION = '20260704'`.
2. On `init` priority 25, `extrachill_add_rewrite_rules()` runs. On `artist.extrachill.com` (non-`.link`) it early-returns — **no catch-all registered**.
3. On `init` priority 30, `extrachill_artist_platform_maybe_flush_rewrite_rules()` sees the stored version is empty/stale → mismatch.
4. `flush_rewrite_rules( false )` rebuilds the `rewrite_rules` option from the **current, host-guarded** rule set → the stale bare catch-all is **gone**.
5. Option updated to `'20260704'` → subsequent requests skip the flush (zero per-request cost).
6. `/manage-link-page/` and `/manage-artist/` no longer match any catch-all → resolve as normal WP pages → editor blocks render. Login redirect loop resolved.

Future routing changes only require bumping the constant; the flush is then automatic on the next deploy. **No manual `wp rewrite flush` ever again.**

> **Multisite note:** `rewrite_rules` and the version option are per-blog. The plugin is active on `artist.extrachill.com` (blog 4), and requests to that domain run in blog 4's context, so the flush targets exactly the blog where the stale rule lives.

## Verification

- `php -l` passes on both changed files.
- Confirmed via `git log -S 'add_rewrite_rule'` and `git log -S "index.php?artist_link_page"` across **all** history that the bare catch-all exists only in `e7a9b9b`→`1e099b6` and is **absent** from current code.
- No other `add_rewrite_rule` call exists anywhere in the plugin (only the host-guarded one at line 71).

## Scope note

This branch is **shared** with a sibling task fixing CSS regressions in `src/blocks/link-page-editor`. This PR's commit touches **PHP only** — the two files above. No `src/` or CSS changes.
