### PR TITLE
fix: wrap leading link-page title emoji server-side so it stops ballooning

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -96,6 +96,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/minimal-head-assets.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-head.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-seo.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/template-helpers.php';
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/management/advanced-tab/link-expiration.php';
 

--- a/inc/link-pages/live/template-helpers.php
+++ b/inc/link-pages/live/template-helpers.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Template display helpers for the live Link Page.
+ *
+ * Pure output helpers shared by the link-page PHP templates (public page and
+ * editor preview iframe). These return pre-escaped HTML — callers must echo
+ * the return value directly without re-escaping.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Bound the leading emoji of a Link Page title so it can no longer balloon.
+ *
+ * Emoji glyphs render at the full font-size and fill the entire em-box. The
+ * link page <h1> title uses --link-page-title-font-size (default 2.1em), so a
+ * leading emoji visually dwarfs the surrounding text. When the title begins
+ * with an emoji, this helper wraps that single leading emoji (including ZWJ
+ * sequences and skin-tone / variation selectors) in a span tagged with the
+ * `.extrch-link-page-title-emoji` class, which CSS already bounds to 0.75em.
+ *
+ * The remainder of the title is escaped with esc_html(). If the title has no
+ * leading emoji, the whole string is returned as esc_html() output unchanged.
+ *
+ * @param string $title Raw profile display title, optionally prefixed with an emoji.
+ * @return string Pre-escaped HTML suitable for direct echo inside an <h1>.
+ *                 Includes an emoji span when a leading emoji is detected.
+ */
+function ec_link_page_wrap_title_emoji( $title ) {
+	if ( ! is_string( $title ) || '' === $title ) {
+		return '';
+	}
+
+	/*
+	 * Match a single leading emoji at the start of the title:
+	 *   \p{Extended_Pictographic}              the base pictographic glyph
+	 *   (?:\x{200D}\p{Extended_Pictographic})* zero or more ZWJ-joined glyphs
+	 *   [\x{FE0F}\x{1F3FB}-\x{1F3FF}]?         optional variation selector or skin tone
+	 *
+	 * Requires PCRE2 10.30+ (PHP 7.3+). Mirrors the LEADING_EMOJI_RE used by
+	 * src/blocks/link-page-editor/components/Preview.js::renderTitle() so the
+	 * server output and the React preview stay in sync.
+	 */
+	$pattern = '/^(\p{Extended_Pictographic}(?:\x{200D}\p{Extended_Pictographic})*[\x{FE0F}\x{1F3FB}-\x{1F3FF}]?)/u';
+
+	if ( preg_match( $pattern, $title, $matches ) ) {
+		$emoji = $matches[1];
+		$rest  = substr( $title, strlen( $emoji ) );
+
+		return '<span class="extrch-link-page-title-emoji">' . esc_html( $emoji ) . '</span>' . esc_html( $rest );
+	}
+
+	return esc_html( $title );
+}

--- a/inc/link-pages/live/templates/extrch-link-page-template.php
+++ b/inc/link-pages/live/templates/extrch-link-page-template.php
@@ -149,7 +149,10 @@ $body_bg_style = '';
             <?php elseif (!empty($data['profile_img_url'])): ?>
                 <div class="<?php echo esc_attr($img_container_classes); ?>"><img src="<?php echo esc_url($data['profile_img_url']); ?>" alt="<?php echo esc_attr($data['display_title']); ?>"></div>
             <?php endif; ?>
-            <h1 class="extrch-link-page-title"><?php echo esc_html($data['display_title']); ?></h1>
+            <h1 class="extrch-link-page-title"><?php
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- ec_link_page_wrap_title_emoji() returns pre-escaped HTML (emoji span + esc_html remainder).
+                echo ec_link_page_wrap_title_emoji( $data['display_title'] );
+            ?></h1>
             <?php if (!empty($data['bio'])): ?><div class="extrch-link-page-bio"><?php echo esc_html($data['bio']); ?></div><?php endif; ?>
         </div>
 


### PR DESCRIPTION
## Problem

A leading emoji in an artist's link-page display name was rendering **giant** — dwarfing the surrounding title text — on the **live public page** and the **editor preview iframe**.

## Root cause

The link page title is emitted by the **PHP template** `inc/link-pages/live/templates/extrch-link-page-template.php` as a plain `<h1 class="extrch-link-page-title">`. That `<h1>` uses `--link-page-title-font-size` (default `2.1em`). Emoji glyphs render at the full font-size and fill the entire em-box, so at `2.1em` a leading emoji balloons.

A bounding CSS rule already existed:

```css
.extrch-link-page-title-emoji { font-size: 0.75em; line-height:1; vertical-align:middle; }
```

…in `assets/css/extrch-links.css`. But **nothing wrapped the emoji in that span server-side**, so the rule was dead on every real render path.

## Why the previous fix was the wrong layer

A prior fix wrapped the emoji inside the React `src/blocks/link-page-editor/components/Preview.js` `renderTitle()`. That only covers the React preview component. The actual title — on **both** the public page and the editor preview iframe — is rendered through the **PHP template**, not through React. So the React-only wrap did nothing for real render paths.

## Fix — wrap the leading emoji server-side, in one shared place

1. **New helper** `ec_link_page_wrap_title_emoji( string \$title ): string` in `inc/link-pages/live/template-helpers.php`:
   - Detects a single leading emoji including ZWJ sequences and skin-tone / variation selectors, using PCRE2 `\p{Extended_Pictographic}` with the `u` flag.
   - Wraps it in `<span class="extrch-link-page-title-emoji">…</span>`.
   - `esc_html()`s the remainder of the title.
   - If no leading emoji, returns `esc_html(\$title)` unchanged (no behavior change for emoji-less names — the title is **not** shrunk).
   - Regex mirrors the JS `LEADING_EMOJI_RE` in `Preview.js` exactly, so live page and editor preview stay in sync.
2. **Template** (`extrch-link-page-template.php:152`): replaced the raw `esc_html(\$data['display_title'])` on the visible `<h1>` with the helper output, with a `phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped` + justification comment (the helper returns pre-escaped HTML, so no double-escape).
3. **Loader** (`extrachill-artist-platform.php`): added one `require_once` for the new helpers file alongside the other `inc/link-pages/live/` includes.

## Files changed

- `inc/link-pages/live/template-helpers.php` (new) — `ec_link_page_wrap_title_emoji()` helper.
- `inc/link-pages/live/templates/extrch-link-page-template.php` — visible `<h1>` now uses the helper.
- `extrachill-artist-platform.php` — `require_once` the new helpers file.

## Deliberately NOT changed

- **Attribute uses of `display_title`** (`data-share-title=`, `alt=` on the profile image, `aria-label=`) are left as plain `esc_attr`/`esc_html` text. Only the visible `<h1>` title needs the bounding span; wrapping attribute values would corrupt them.
- **Subscribe modal / inline form** templates use `display_title` only as a fallback for `\$artist_name` rendered at normal body size inside a "Subscribe to X" heading and a sentence — emoji at body size is fine, so no wrap applied.
- **React `Preview.js`** is unchanged — it already produces the same `.extrch-link-page-title-emoji` class, so editor preview and live page now match.
- **Existing `.extrch-link-page-title-emoji` CSS** (0.75em) is left as-is.

## Verification

- `php -l` on all three modified PHP files: clean.
- Standalone PHP harness exercising the helper across edge cases: single emoji, ZWJ family emoji (`👨‍👩‍👧`), no-emoji, empty string, trailing emoji (not wrapped), double-leading (only first wrapped), and `<script>` injection (escaped). All behave correctly.
- PHP-only + CSS-untouched change — no build step needed.

## Known limitation (parity-preserving)

The regex (shared verbatim with the JS preview) does not fully coalesce VS16-then-ZWJ compounds like the rainbow pride flag `🏳️‍🌈` — the base `🏳️` enters the span and the trailing `‍🌈` renders just after it. This is the **same** behavior the React preview has always had, so editor preview and live page remain consistent. Tightening the regex is a follow-up that should land in both layers in lockstep.