### PR TITLE
chore(deps): bump @extrachill/components 0.5.2 → 0.9.1 (align link-page editor to platform)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,25 @@
 {
   "name": "extrachill-artist-platform",
-  "version": "1.9.1",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extrachill-artist-platform",
-      "version": "1.9.1",
+      "version": "1.10.1",
       "license": "GPL-2.0+",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@extrachill/api-client": "^0.2.1",
-        "@extrachill/components": "^0.5.2",
+        "@extrachill/components": "^0.9.1",
         "@wordpress/api-fetch": "^7.0.0",
         "@wordpress/block-editor": "^14.0.0",
         "@wordpress/blocks": "^15.9.0",
         "@wordpress/components": "^28.0.0",
         "@wordpress/element": "^6.0.0",
-        "@wordpress/i18n": "^5.0.0",
-        "chart.js": "^4.4.0"
+        "@wordpress/i18n": "^5.0.0"
       },
       "devDependencies": {
         "@wordpress/scripts": "^30.15.0"
@@ -2603,12 +2602,12 @@
       "license": "GPL-2.0+"
     },
     "node_modules/@extrachill/components": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.5.2.tgz",
-      "integrity": "sha512-vBacRRqb72EXuZNjgmMMaOO9Ztl7BXMmOnA5idX3PuvLVdeDif1lRoqhtKnOZ+8JFLcajXXrI1N2kGocPnbE2Q==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@extrachill/components/-/components-0.9.1.tgz",
+      "integrity": "sha512-04Xxk5uvu9FYz8Jf/M7lLqfSL2aLx86Y/VU2votQKi4+GWvSC780/ef+ieAwF/7UUORX9nSGJKq9PViDmL/PKA==",
       "license": "GPL-2.0+",
       "peerDependencies": {
-        "react": ">=18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3238,12 +3237,6 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -9896,18 +9889,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/check-node-version": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@extrachill/api-client": "^0.2.1",
-    "@extrachill/components": "^0.5.2",
+    "@extrachill/components": "^0.9.1",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",
     "@wordpress/blocks": "^15.9.0",


### PR DESCRIPTION
## Summary

Bumps `@extrachill/components` from `^0.5.2` to `^0.9.1`, bringing the artist platform onto the same components version the rest of the platform (Studio, community, etc.) already uses. The link-page editor was the last surface pinned to the old 0.5.x line.

## What changed in the components package (0.5.2 → 0.9.1)

Diffed `styles/components.scss` and `dist/*.d.ts` between the two installed versions. The full set of changes that touch existing behavior:

- **`0.9.1`** — removed `max-width: 1080px` from `.ec-block-shell-inner--wide` (now `margin-inline: auto` only) **and** from `.ec-responsive-tabs--inner-wide .ec-responsive-tabs__inner` (rule deleted entirely). This is the "wide-shell cap removal" shipped across the platform.
- **`0.9.0`** — added the `Grid` / `.ec-card-grid` primitive (additive).
- **`0.8.0`** — `ResponsiveTabs` now broadcasts its active tab to the client-context registry by default (opt-out via `broadcastTabContext={false}`). Harmless here — just publishes which editor tab is open for agent consumers.
- **`0.6.0`** — added `StatTile` / `StatGroup` / `ProgressBar` primitives + `.ec-action-row--center` (additive).

No border-radius rules on `.ec-tabs__*`, `.ec-responsive-tabs__*`, `.ec-panel`, `.ec-block-shell*`, or `.ec-action-row*` changed between the two versions.

## Component API / prop compatibility — no call-site changes needed

Verified every component imported by this plugin still exports with the same props in 0.9.1:

- `BlockShell`, `BlockShellInner` (`maxWidth="wide"` still valid), `BlockShellHeader`, `ActionRow` (`align="end"` still valid), `ResponsiveTabs` (`tabs`/`active`/`onChange`/`renderPanel`/`className`/`showDesktopTabs` all unchanged), `Panel` (`compact`/`depth` unchanged), `InlineStatus` (`tone` unchanged), `FieldGroup`, `PanelHeader`, `Section`, `Badge`, `ImagePreview`, `MediaField`.
- `ResponsiveTabs` gained optional props (`innerMaxWidth`, `tabsClassName`, `contextSurface`, `broadcastTabContext`, …) — all optional, no breaking change. `innerMaxWidth` defaults to `'none'` in **both** versions, so the editor never had the `--inner-wide` class applied.
- `npm run build` compiles clean (`webpack 5.103.0 compiled successfully`) with zero missing-export or type errors across all five blocks.

## Why the narrow-tab + rounded-corner symptoms are addressed

This is the careful part — I could not load the rendered editor in a browser, so I'm reasoning from the CSS:

- **The one real behavioral change** affecting this plugin is the removal of the `1080px` cap on `.ec-block-shell-inner--wide`. The link-page editor wraps its whole UI in `<BlockShellInner maxWidth="wide">` (`Editor.js:139`), as do `artist-shop-manager`, `artist-manager`, and `artist-analytics`. Under 0.5.2 the editor was artificially capped at 1080px even on wider viewports; under 0.9.1 it spans the page width and the internal `grid-template-columns: 400px minmax(0, 1fr)` (`style.scss:164`) gets the full track to lay out in. That removes the squeeze where the fixed 400px sidebar plus a capped shell left the layout feeling cramped.
- **The `--inner-wide` 1080px cap was never applied to the editor's `ResponsiveTabs`** — the plugin doesn't pass `innerMaxWidth`, which defaults to `'none'`, and `style.scss:192-195` already force `max-width: none` on `.ec-responsive-tabs__inner` / `__desktop-panel` as belt-and-suspenders. So the narrow-tab symptom is not traceable to that rule in either version; the outer-shell cap removal is the load-bearing fix.
- **No border-radius rules changed** in the components package between 0.5.2 and 0.9.1 for any tab/panel/shell class. If a stray-corner visual remains after this bump, it lives in the plugin's own `style.scss` (e.g. the inner `.ec-panel` keeps its default `border-radius` while `.ec-editor__tab-content` only nulls `border`), not in the components layer. I did **not** touch plugin CSS here because (a) the component styles didn't drift and (b) I can't visually verify a corner change without a browser. Flagging it as a follow-up if the symptom persists after merge.

## 1080px cap removal is desired here

Yes — this matches the fix shipped for Studio. The link-page editor and the three other `maxWidth="wide"` surfaces (`artist-shop-manager`, `artist-manager`, `artist-analytics`) now render at page width, consistent with the rest of the platform. Confirmed in the built CSS:

```
.ec-block-shell-inner--wide{margin-inline:auto}
```

and `grep -rn 1080 build/` returns **zero** matches — no old cap leaks through from a stale component copy.

## Layout risk I could not verify without a browser

- On viewports between 1080px and ~1400px, the editor (and the three other wide-shell blocks) will now render wider than before. The link-page editor's internal grid (`400px minmax(0,1fr)`) handles this cleanly; the other three blocks were already designed against the uncapped shell (they run the same components version Studio uses), so no regressions are expected there.
- Recommend a quick visual smoke test of the link-page editor and the shop-manager/manager/analytics dashboards at ≥1280px after merge.

## Test plan

- [x] `npm install` resolves `@extrachill/components@0.9.1`
- [x] `npm run build` compiles clean across all 5 blocks
- [x] `grep -rn 1080 build/` → no matches (no stale cap)
- [x] Built CSS contains the 0.9.1 additions (`ec-card-grid`, `ec-stat-tile`, `ec-progress-bar`)
- [ ] Visual smoke: link-page editor at desktop width (cannot verify headless)
- [ ] Visual smoke: artist-shop-manager / artist-manager / artist-analytics dashboards