### PR TITLE
fix: align link-page editor tab-button row with content panel edge

### DIFF
--- a/src/blocks/link-page-editor/style.scss
+++ b/src/blocks/link-page-editor/style.scss
@@ -191,8 +191,12 @@
 	height: 100%;
 }
 
+/* Align the tab-button row's horizontal inset with the content Panel below it
+   (.ec-editor__tab-content uses --spacing-lg). Previously this used --spacing-md
+   (16px) while the content inset --spacing-lg (24px), so the tab buttons sat
+   indented differently from the panel edge — reading as arbitrary indentation. */
 .ec-editor__sidebar-tabs .ec-tabs__tabs {
-	padding: var(--spacing-md) var(--spacing-md) 0;
+	padding: var(--spacing-md) var(--spacing-lg) 0;
 }
 
 /* Tab Content Area.


### PR DESCRIPTION
## Summary
Fixes the "arbitrary tab indentation" on the link-page editor: the Info/Links/Socials tab-button row was inset differently from the content panel beneath it.

## Root cause
- Tab-button row (`.ec-editor__sidebar-tabs .ec-tabs__tabs`) used `--spacing-md` (16px) horizontal padding.
- Content panel (`.ec-editor__tab-content`) insets by `--spacing-lg` (24px).
- The 16px vs 24px mismatch made the tab buttons sit indented differently from the panel edge — a relic from the pre-refactor override soup.

## Fix
Align the desktop tab row's horizontal padding to `--spacing-lg` so the tab buttons line up with the content panel edge below them. Mobile already aligns at `--spacing-md` (both tab row and content use it there) and is left unchanged.