### PR TITLE
fix: widen link-page editor preview to 500px

### DIFF
--- a/src/blocks/link-page-editor/style.scss
+++ b/src/blocks/link-page-editor/style.scss
@@ -32,10 +32,12 @@
 .ec-editor {
 	min-height: 600px;
 
-	/* Tunable phone-width preview panel. 430px = large phone
-	   (375 was tried and felt too narrow). Centralized here so the
-	   grid track and any downstream consumer read one value. */
-	--ec-editor-preview-width: 430px;
+	/* Tunable preview panel width. 500px reads best for editing (375 felt
+	   cramped, 430 was still a touch narrow). Centralized here so the grid
+	   track and any downstream consumer read one value. Future: replace this
+	   fixed track with a draggable resize handle (needs a resizable-pane
+	   primitive in @extrachill/components — see PR discussion). */
+	--ec-editor-preview-width: 500px;
 }
 
 .ec-editor__header-left {


### PR DESCRIPTION
Bumps the link-page editor preview panel from 430px to 500px — reads better for editing. One-value change via the existing `--ec-editor-preview-width` CSS var.

**Future idea (not in this PR):** make the preview width draggable via a resize handle. That would need a reusable `ResizablePane` primitive in @extrachill/components — which would also lay groundwork for drag-to-reorder grid layouts down the line. Filed as a follow-up thought, keeping this PR to the quick win.