### PR TITLE
refactor: conform link-page editor tab spacing to components primitive

### DIFF
--- a/src/blocks/link-page-editor/components/Editor.js
+++ b/src/blocks/link-page-editor/components/Editor.js
@@ -191,7 +191,7 @@ export default function Editor() {
 							onChange={ setActiveTab }
 							showDesktopTabs={ true }
 							renderPanel={ () => (
-								<Panel className="ec-editor__tab-content" compact depth={ 2 }>
+								<Panel>
 									{ renderTabContent() }
 								</Panel>
 							) }

--- a/src/blocks/link-page-editor/style.scss
+++ b/src/blocks/link-page-editor/style.scss
@@ -193,22 +193,13 @@
 	height: 100%;
 }
 
-/* Align the tab-button row's horizontal inset with the content Panel below it
-   (.ec-editor__tab-content uses --spacing-lg). Previously this used --spacing-md
-   (16px) while the content inset --spacing-lg (24px), so the tab buttons sat
-   indented differently from the panel edge — reading as arbitrary indentation. */
-.ec-editor__sidebar-tabs .ec-tabs__tabs {
-	padding: var(--spacing-md) var(--spacing-lg) 0;
-}
-
-/* Tab Content Area.
-   The ResponsiveTabs renderPanel wraps a <Panel compact depth={2}>. The Panel
-   primitive (.ec-panel) already provides border + radius + background + padding,
-   so this only tunes the inner padding for breathing room — it no longer nills
-   the primitive's border (the source of the "missing border" half-edges). */
-.ec-editor__tab-content {
-	padding: var(--spacing-lg);
-}
+/* Tab-to-content spacing is provided entirely by the @extrachill/components
+   primitive: .ec-responsive-tabs sets the gap between the tab strip and the
+   panel, .ec-tabs__tabs provides the tab-row padding-bottom, and .ec-panel
+   provides the content padding — all at the platform-standard --spacing-md.
+   Do not re-add ad-hoc overrides here; this block composes ResponsiveTabs +
+   Panel the same way the other tab-blocks (artist-manager, artist-shop-manager,
+   studio, community user-settings, community edit-profile) do. */
 
 /* Preview Container */
 .ec-editor__preview-region {
@@ -801,14 +792,6 @@
 	}
 
 
-
-	.ec-editor__sidebar-tabs .ec-tabs__tabs {
-		padding: var(--spacing-md) var(--spacing-md) 0;
-	}
-
-	.ec-editor__tab-content {
-		padding: var(--spacing-md);
-	}
 
 	.ec-editor__preview-region {
 		gap: 12px;


### PR DESCRIPTION
## Summary

Makes the link-page editor's tab-to-content spacing **consistent with every other tab-block on the platform** by removing its ad-hoc overrides and trusting the `@extrachill/components` primitive defaults.

## Audit finding

This block was the **only** tab-block (of 6) that overrode the primitive's spacing. The other 5 — `artist-manager`, `artist-shop-manager`, `studio`, community `user-settings`, community `edit-profile` — compose `ResponsiveTabs` + `Panel` cleanly at the platform-standard `--spacing-md` (16px) with **zero** `ec-tabs__tabs` / `sidebar-tabs` CSS overrides. The link-page editor was the outlier, diverging to `--spacing-lg` (24px) in two places.

The primitive provides canonical spacing in `@extrachill/components/styles/components.scss`:
- `.ec-responsive-tabs { gap: var(--spacing-md) }` — gap between tab strip and panel
- `.ec-responsive-tabs .ec-tabs__tabs { padding-bottom: calc(var(--spacing-md) + var(--spacing-sm)) }` — tab-row bottom breathing room
- `.ec-panel { padding: var(--spacing-md) }` — content padding

## What was removed

**`style.scss`:**
1. Desktop tab-row padding override:
   ```scss
   .ec-editor__sidebar-tabs .ec-tabs__tabs { padding: var(--spacing-md) var(--spacing-lg) 0; }
   ```
   (the `--spacing-lg` horizontal inset + zeroed bottom masked the primitive's `padding-bottom`)
2. Content padding override:
   ```scss
   .ec-editor__tab-content { padding: var(--spacing-lg); }
   ```
   (the Panel primitive `.ec-panel` already provides `padding: var(--spacing-md)`)
3. Redundant mobile `@media` overrides that just re-stated the primitive default.

**`components/Editor.js`:**
4. `<Panel className="ec-editor__tab-content" compact depth={2}>` → `<Panel>` (bare). Removed the custom `className`, `compact`, and `depth={2}` props.

### Why `compact` / `depth={2}` were safe to drop

I verified the primitive: there is **no** `.ec-panel--compact` or `.ec-panel--depth-*` CSS rule anywhere in `@extrachill/components` (those modifiers only exist for `.ec-block-shell--*`, the `BlockShell` primitive). The `compact` and `depth` props on `<Panel>` emit class names with no matching styles — they were no-ops. Removing them changes nothing visually. The `className="ec-editor__tab-content"` became a dead selector once its only declaration (the `--spacing-lg` padding) was removed, so it was dropped too (grep confirms no remaining references).

### Why the renderPanel `<Panel>` is kept (bare)

The outer `<Panel>` is **structurally necessary**: `TabInfo` and `TabLinks` render bare `.ec-tab` divs (no border/background of their own) and rely on the renderPanel-level Panel for card framing. `TabCustomize` / `TabAdvanced` render inner sub-cards (`.ec-customize-card`, bare `<Panel compact>`) but also lack a top-level framing Panel. Removing the wrapper entirely would leave `TabInfo`/`TabLinks` unframed — a visual regression. So the Panel stays, just bare, now receiving the primitive's standard `--spacing-md` padding automatically.

## Verification

- `npm run build` — webpack compiled successfully (no errors).
- `grep 'ec-editor__tab-content' src/` — no remaining references (dead selector fully removed).
- `grep 'spacing-lg' src/blocks/link-page-editor/style.scss` — remaining hits are only on `.ec-editor__body` (grid gap) and `.ec-editor__preview-region` (the preview panel) — **none** on the tab row or tab content.
- This block now composes `<Panel>` like the other 5 tab-blocks, so tab-to-content spacing is consistent platform-wide.

## Notes

Cannot browse the rendered output from here, but the spacing now flows entirely from the primitive defaults documented above, which is exactly what the 5 conforming blocks already use.