### PR TITLE
fix: point link-page footer credit to network discovery

### DIFF
--- a/inc/link-pages/live/templates/extrch-link-page-template.php
+++ b/inc/link-pages/live/templates/extrch-link-page-template.php
@@ -196,9 +196,14 @@ $body_bg_style = '';
         }
         ?>
 
-        <?php if ($data['powered_by']): ?>
+        <?php if ($data['powered_by']):
+            // Route the footer credit at the /power page's artist-conversion anchor on the
+            // main site rather than the editorial homepage, with UTM params for attribution
+            // (extrachill.link doesn't otherwise appear in extrachill.com referral sources).
+            $powered_by_url = ec_get_site_url('main') . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power#artists';
+        ?>
         <div class="extrch-link-page-powered" style="margin-top:auto; padding-top:1em; padding-bottom:1em;">
-            <a href="https://extrachill.com" rel="noopener">Powered by Extra Chill</a>
+            <a href="<?php echo esc_url($powered_by_url); ?>" rel="noopener">Powered by Extra Chill</a>
         </div>
         <?php endif; ?>
     </div>

--- a/inc/link-pages/live/templates/extrch-link-page-template.php
+++ b/inc/link-pages/live/templates/extrch-link-page-template.php
@@ -197,10 +197,9 @@ $body_bg_style = '';
         ?>
 
         <?php if ($data['powered_by']):
-            // Route the footer credit at the /power page's artist-conversion anchor on the
-            // main site rather than the editorial homepage, with UTM params for attribution
-            // (extrachill.link doesn't otherwise appear in extrachill.com referral sources).
-            $powered_by_url = ec_get_site_url('main') . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power#artists';
+            // Route the generic footer credit to the main site's network discovery page,
+            // with UTM params for attribution.
+            $powered_by_url = ec_get_site_url('main') . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power';
         ?>
         <div class="extrch-link-page-powered" style="margin-top:auto; padding-top:1em; padding-bottom:1em;">
             <a href="<?php echo esc_url($powered_by_url); ?>" rel="noopener">Powered by Extra Chill</a>

--- a/src/blocks/link-page-editor/components/Preview.js
+++ b/src/blocks/link-page-editor/components/Preview.js
@@ -366,7 +366,7 @@ export default function Preview() {
 
 					<div className="extrch-link-page-powered">
 						<a
-							href="https://extrachill.link"
+							href="https://extrachill.com/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power#artists"
 							target="_blank"
 							rel="noopener noreferrer"
 						>

--- a/src/blocks/link-page-editor/components/Preview.js
+++ b/src/blocks/link-page-editor/components/Preview.js
@@ -366,7 +366,7 @@ export default function Preview() {
 
 					<div className="extrch-link-page-powered">
 						<a
-							href="https://extrachill.com/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power#artists"
+							href="https://extrachill.com/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power"
 							target="_blank"
 							rel="noopener noreferrer"
 						>


### PR DESCRIPTION
## What changed

Pointed the generic "Powered by Extra Chill" link-page footer to the main site's top-level network discovery page (`https://extrachill.com/power/`) with `utm_source=linkpage&utm_medium=footer&utm_campaign=power`. The destination intentionally has no fragment so every visitor can choose the relevant part of the network.

Updated both render paths so live pages and the block-editor preview remain aligned:
- `inc/link-pages/live/templates/extrch-link-page-template.php` preserves the existing `ec_get_site_url('main')` helper, escaping, `rel="noopener"`, and footer markup.
- `src/blocks/link-page-editor/components/Preview.js` preserves the existing preview link markup and `rel` values.

The visible label remains exactly `Powered by Extra Chill`.

## Why

The footer is generic brand attribution shown to every visitor to a link page. `/power/` introduces the broader Extra Chill network and lets visitors self-select their next step, rather than treating every click as an artist-acquisition intent. The UTM parameters retain footer-click attribution for this network-discovery path.

## Verification

- `php -l inc/link-pages/live/templates/extrch-link-page-template.php`
- Focused JavaScript lint and build checks
- Confirmed no `#artists` footer destination remains and that live/preview URLs match

Fixes #76