### PR TITLE
Own artist relationship administration

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -78,6 +78,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/relationship-admin-page.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/permissions.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/artist-grid.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/breadcrumbs.php';

--- a/inc/abilities/handlers/admin-cleanup-artist-relationships.php
+++ b/inc/abilities/handlers/admin-cleanup-artist-relationships.php
@@ -29,17 +29,7 @@ function extrachill_artist_platform_ability_admin_cleanup_artist_relationships( 
 		);
 	}
 
-	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/cleanup' );
-	$request->set_param( 'user_id', (int) $input['user_id'] );
-	$request->set_param( 'artist_id', (int) $input['artist_id'] );
+	ec_remove_artist_membership( (int) $input['user_id'], (int) $input['artist_id'] );
 
-	$response = extrachill_api_cleanup_orphan( $request );
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
-	}
-
-	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
-
-	return is_array( $data ) ? $data : array( 'success' => true );
+	return array( 'success' => true );
 }

--- a/inc/abilities/handlers/admin-link-artist-relationship.php
+++ b/inc/abilities/handlers/admin-link-artist-relationship.php
@@ -29,17 +29,14 @@ function extrachill_artist_platform_ability_admin_link_artist_relationship( arra
 		);
 	}
 
-	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/link' );
-	$request->set_param( 'user_id', (int) $input['user_id'] );
-	$request->set_param( 'artist_id', (int) $input['artist_id'] );
-
-	$response = extrachill_api_link_user_to_artist( $request );
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
+	$user_id   = (int) $input['user_id'];
+	$artist_id = (int) $input['artist_id'];
+	if ( ! get_userdata( $user_id ) ) {
+		return new WP_Error( 'invalid_user', __( 'User not found.', 'extrachill-artist-platform' ), array( 'status' => 404 ) );
+	}
+	if ( ! ec_add_artist_membership( $user_id, $artist_id ) ) {
+		return new WP_Error( 'invalid_artist', __( 'Artist profile not found.', 'extrachill-artist-platform' ), array( 'status' => 404 ) );
 	}
 
-	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
-
-	return is_array( $data ) ? $data : array( 'success' => true );
+	return array( 'success' => true );
 }

--- a/inc/abilities/handlers/admin-list-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-artist-relationships.php
@@ -24,17 +24,10 @@ function extrachill_artist_platform_ability_admin_list_artist_relationships( arr
 	$view   = isset( $input['view'] ) ? sanitize_text_field( $input['view'] ) : 'artists';
 	$search = isset( $input['search'] ) ? sanitize_text_field( $input['search'] ) : '';
 
-	$request = new WP_REST_Request( 'GET', '/extrachill/v1/admin/artist-relationships' );
-	$request->set_param( 'view', $view );
-	$request->set_param( 'search', $search );
-
-	$response = extrachill_api_get_artist_relationships( $request );
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
+	$items = ec_get_artist_relationships_for_admin( $view, $search );
+	if ( is_wp_error( $items ) ) {
+		return $items;
 	}
 
-	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
-
-	return is_array( $data ) ? $data : array( 'items' => array() );
+	return array( 'items' => $items );
 }

--- a/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
@@ -18,13 +18,10 @@ defined( 'ABSPATH' ) || exit;
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_admin_list_orphan_artist_relationships( array $input ): array|WP_Error {
-	$response = extrachill_api_get_orphaned_relationships();
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
+	$orphans = ec_get_orphaned_artist_relationships();
+	if ( is_wp_error( $orphans ) ) {
+		return $orphans;
 	}
 
-	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
-
-	return is_array( $data ) ? $data : array( 'orphans' => array() );
+	return array( 'orphans' => $orphans );
 }

--- a/inc/abilities/handlers/admin-unlink-artist-relationship.php
+++ b/inc/abilities/handlers/admin-unlink-artist-relationship.php
@@ -29,17 +29,7 @@ function extrachill_artist_platform_ability_admin_unlink_artist_relationship( ar
 		);
 	}
 
-	$request = new WP_REST_Request( 'POST', '/extrachill/v1/admin/artist-relationships/unlink' );
-	$request->set_param( 'user_id', (int) $input['user_id'] );
-	$request->set_param( 'artist_id', (int) $input['artist_id'] );
+	ec_remove_artist_membership( (int) $input['user_id'], (int) $input['artist_id'] );
 
-	$response = extrachill_api_unlink_user_from_artist( $request );
-
-	if ( is_wp_error( $response ) ) {
-		return $response;
-	}
-
-	$data = $response instanceof WP_REST_Response ? $response->get_data() : (array) $response;
-
-	return is_array( $data ) ? $data : array( 'success' => true );
+	return array( 'success' => true );
 }

--- a/inc/artist-profiles/admin/relationship-admin-page.php
+++ b/inc/artist-profiles/admin/relationship-admin-page.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Network administration for artist-user relationships.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+add_action( 'network_admin_menu', 'ec_register_artist_relationship_admin_page' );
+add_action( 'admin_post_ec_artist_relationship', 'ec_handle_artist_relationship_admin_action' );
+
+/** Register the owner-native relationship administration page. */
+function ec_register_artist_relationship_admin_page() {
+	add_submenu_page(
+		'settings.php',
+		__( 'Artist Relationships', 'extrachill-artist-platform' ),
+		__( 'Artist Relationships', 'extrachill-artist-platform' ),
+		'manage_network_options',
+		'ec-artist-relationships',
+		'ec_render_artist_relationship_admin_page'
+	);
+}
+
+/** Execute a relationship mutation through its public ability. */
+function ec_handle_artist_relationship_admin_action() {
+	if ( ! current_user_can( 'manage_network_options' ) ) {
+		wp_die( esc_html__( 'You do not have permission to manage artist relationships.', 'extrachill-artist-platform' ) );
+	}
+	check_admin_referer( 'ec_artist_relationship' );
+
+	$action = isset( $_POST['relationship_action'] ) ? sanitize_key( wp_unslash( $_POST['relationship_action'] ) ) : '';
+	$names  = array(
+		'link'    => 'extrachill/admin-link-artist-relationship',
+		'unlink'  => 'extrachill/admin-unlink-artist-relationship',
+		'cleanup' => 'extrachill/admin-cleanup-artist-relationships',
+	);
+	$result = new WP_Error( 'invalid_action', __( 'Invalid relationship action.', 'extrachill-artist-platform' ) );
+	if ( isset( $names[ $action ] ) ) {
+		$ability = wp_get_ability( $names[ $action ] );
+		$result  = $ability ? $ability->execute(
+			array(
+				'user_id'   => isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0,
+				'artist_id' => isset( $_POST['artist_id'] ) ? absint( $_POST['artist_id'] ) : 0,
+			)
+		) : new WP_Error( 'ability_not_found', __( 'Relationship ability is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	$url = add_query_arg(
+		array(
+			'page'   => 'ec-artist-relationships',
+			'view'   => isset( $_POST['view'] ) ? sanitize_key( wp_unslash( $_POST['view'] ) ) : 'artists',
+			'notice' => is_wp_error( $result ) ? $result->get_error_message() : __( 'Relationship updated.', 'extrachill-artist-platform' ),
+			'type'   => is_wp_error( $result ) ? 'error' : 'success',
+		),
+		network_admin_url( 'settings.php' )
+	);
+	wp_safe_redirect( $url );
+	exit;
+}
+
+/** Render the relationship list, link form, and orphan cleanup workflow. */
+function ec_render_artist_relationship_admin_page() {
+	$requested_view = isset( $_GET['view'] ) ? sanitize_key( wp_unslash( $_GET['view'] ) ) : 'artists';
+	$view   = in_array( $requested_view, array( 'artists', 'users', 'orphans' ), true ) ? $requested_view : 'artists';
+	$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+	$name   = 'orphans' === $view ? 'extrachill/admin-list-orphan-artist-relationships' : 'extrachill/admin-list-artist-relationships';
+	$input  = 'orphans' === $view ? array() : array( 'view' => $view, 'search' => $search );
+	$ability = wp_get_ability( $name );
+	$result  = $ability ? $ability->execute( $input ) : new WP_Error( 'ability_not_found', __( 'Relationship ability is unavailable.', 'extrachill-artist-platform' ) );
+	$notice_type = isset( $_GET['type'] ) && 'error' === sanitize_key( wp_unslash( $_GET['type'] ) ) ? 'error' : 'success';
+	?>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Artist Relationships', 'extrachill-artist-platform' ); ?></h1>
+		<?php if ( isset( $_GET['notice'] ) ) : ?>
+			<div class="notice notice-<?php echo esc_attr( $notice_type ); ?> is-dismissible"><p><?php echo esc_html( wp_unslash( $_GET['notice'] ) ); ?></p></div>
+		<?php endif; ?>
+		<p><?php esc_html_e( 'Manage bidirectional links between network users and artist profiles.', 'extrachill-artist-platform' ); ?></p>
+		<nav class="nav-tab-wrapper">
+			<?php foreach ( array( 'artists' => __( 'Artists', 'extrachill-artist-platform' ), 'users' => __( 'Users', 'extrachill-artist-platform' ), 'orphans' => __( 'Orphans', 'extrachill-artist-platform' ) ) as $key => $label ) : ?>
+				<a class="nav-tab <?php echo $view === $key ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'ec-artist-relationships', 'view' => $key ), network_admin_url( 'settings.php' ) ) ); ?>"><?php echo esc_html( $label ); ?></a>
+			<?php endforeach; ?>
+		</nav>
+
+		<?php if ( 'orphans' !== $view ) : ?>
+			<form method="get" style="margin: 16px 0">
+				<input type="hidden" name="page" value="ec-artist-relationships"><input type="hidden" name="view" value="<?php echo esc_attr( $view ); ?>">
+				<label class="screen-reader-text" for="relationship-search"><?php esc_html_e( 'Search relationships', 'extrachill-artist-platform' ); ?></label>
+				<input id="relationship-search" type="search" name="search" value="<?php echo esc_attr( $search ); ?>">
+				<?php submit_button( __( 'Search', 'extrachill-artist-platform' ), 'secondary', '', false ); ?>
+			</form>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="margin: 16px 0">
+				<input type="hidden" name="action" value="ec_artist_relationship"><input type="hidden" name="relationship_action" value="link"><input type="hidden" name="view" value="<?php echo esc_attr( $view ); ?>">
+				<?php wp_nonce_field( 'ec_artist_relationship' ); ?>
+				<label><?php esc_html_e( 'User ID', 'extrachill-artist-platform' ); ?> <input type="number" min="1" name="user_id" required></label>
+				<label><?php esc_html_e( 'Artist ID', 'extrachill-artist-platform' ); ?> <input type="number" min="1" name="artist_id" required></label>
+				<?php submit_button( __( 'Link User', 'extrachill-artist-platform' ), 'primary', '', false ); ?>
+			</form>
+		<?php endif; ?>
+
+		<?php if ( is_wp_error( $result ) ) : ?>
+			<div class="notice notice-error"><p><?php echo esc_html( $result->get_error_message() ); ?></p></div>
+		<?php else : ec_render_artist_relationship_admin_table( $view, 'orphans' === $view ? $result['orphans'] : $result['items'] ); endif; ?>
+	</div>
+	<?php
+}
+
+/**
+ * Render relationship rows using core table styling.
+ *
+ * @param string $view  Current view.
+ * @param array  $items Relationship rows.
+ */
+function ec_render_artist_relationship_admin_table( $view, array $items ) {
+	?>
+	<table class="widefat striped"><thead><tr><th><?php echo 'users' === $view ? esc_html__( 'User', 'extrachill-artist-platform' ) : esc_html__( 'Artist', 'extrachill-artist-platform' ); ?></th><th><?php echo 'orphans' === $view ? esc_html__( 'Invalid Artist ID', 'extrachill-artist-platform' ) : esc_html__( 'Relationships', 'extrachill-artist-platform' ); ?></th></tr></thead><tbody>
+	<?php if ( empty( $items ) ) : ?><tr><td colspan="2"><?php esc_html_e( 'No relationships found.', 'extrachill-artist-platform' ); ?></td></tr><?php endif; ?>
+	<?php foreach ( $items as $item ) : ?>
+		<tr><td><?php echo esc_html( 'artists' === $view ? $item['title'] . ' (#' . $item['id'] . ')' : $item['user']['display_name'] ?? $item['display_name'] ); ?></td><td>
+		<?php
+		$relationships = 'artists' === $view ? $item['members'] : ( 'users' === $view ? $item['artists'] : array( array( 'ID' => $item['user']['ID'], 'artist_id' => $item['invalid_artist_id'] ) ) );
+		foreach ( $relationships as $relationship ) {
+			$user_id   = 'artists' === $view ? $relationship['ID'] : ( 'users' === $view ? $item['ID'] : $relationship['ID'] );
+			$artist_id = 'artists' === $view ? $item['id'] : ( 'users' === $view ? $relationship['ID'] : $relationship['artist_id'] );
+			$label     = 'artists' === $view ? $relationship['display_name'] . ' (' . $relationship['user_login'] . ')' : ( 'users' === $view ? $relationship['post_title'] : '#' . $artist_id );
+			echo esc_html( $label ) . ' ';
+			?>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" style="display:inline-block;margin:0 12px 4px 0"><input type="hidden" name="action" value="ec_artist_relationship"><input type="hidden" name="relationship_action" value="<?php echo 'orphans' === $view ? 'cleanup' : 'unlink'; ?>"><input type="hidden" name="view" value="<?php echo esc_attr( $view ); ?>"><input type="hidden" name="user_id" value="<?php echo esc_attr( $user_id ); ?>"><input type="hidden" name="artist_id" value="<?php echo esc_attr( $artist_id ); ?>"><?php wp_nonce_field( 'ec_artist_relationship' ); ?><?php submit_button( 'orphans' === $view ? __( 'Clean Up', 'extrachill-artist-platform' ) : __( 'Remove', 'extrachill-artist-platform' ), 'small', '', false ); ?></form>
+			<?php
+		}
+		?>
+		</td></tr>
+	<?php endforeach; ?>
+	</tbody></table>
+	<?php
+}

--- a/inc/artist-profiles/admin/user-linking.php
+++ b/inc/artist-profiles/admin/user-linking.php
@@ -3,7 +3,7 @@
  * Core Artist-User Relationship Functions
  *
  * Bidirectional relationship management between users and artist profiles.
- * UI and admin tooling moved to extrachill-admin-tools plugin.
+ * This plugin owns both the relationship domain and its operator tooling.
  *
  * @package ExtraChillArtistPlatform
  */
@@ -198,4 +198,128 @@ function ec_get_user_artist_memberships( $user_id ) {
     );
 
     return get_posts( $args );
+}
+
+/**
+ * Lists artist-user relationships for network administration.
+ *
+ * @param string $view   View mode: artists or users.
+ * @param string $search Optional search term.
+ * @return array|WP_Error Relationship rows or an artist-site configuration error.
+ */
+function ec_get_artist_relationships_for_admin( $view = 'artists', $search = '' ) {
+    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+    if ( ! $artist_blog_id ) {
+        return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
+    }
+
+    $view   = 'users' === $view ? 'users' : 'artists';
+    $search = sanitize_text_field( $search );
+    $items  = array();
+
+    switch_to_blog( $artist_blog_id );
+    try {
+        if ( 'artists' === $view ) {
+            $args = array(
+                'post_type'      => 'artist_profile',
+                'post_status'    => 'any',
+                'posts_per_page' => 50,
+                'orderby'        => 'title',
+                'order'          => 'ASC',
+            );
+            if ( '' !== $search ) {
+                $args['s'] = $search;
+            }
+
+            foreach ( get_posts( $args ) as $artist ) {
+                $members = array_map(
+                    static function ( $member ) {
+                        return array(
+                            'ID'           => $member->ID,
+                            'user_login'   => $member->user_login,
+                            'display_name' => $member->display_name,
+                        );
+                    },
+                    ec_get_linked_members( $artist->ID )
+                );
+                $items[] = array(
+                    'id'      => $artist->ID,
+                    'title'   => $artist->post_title,
+                    'members' => $members,
+                );
+            }
+        } else {
+            $args = array(
+                'number'     => 50,
+                'meta_query' => array(
+                    'relation' => 'OR',
+                    array( 'key' => 'user_is_artist', 'value' => '1', 'compare' => '=' ),
+                    array( 'key' => 'user_is_professional', 'value' => '1', 'compare' => '=' ),
+                ),
+            );
+            if ( '' !== $search ) {
+                $args['search']         = '*' . $search . '*';
+                $args['search_columns'] = array( 'user_login', 'user_email', 'display_name' );
+            }
+
+            foreach ( ( new WP_User_Query( $args ) )->get_results() as $user ) {
+                $artists = array_map(
+                    static function ( $artist ) {
+                        return array( 'ID' => $artist->ID, 'post_title' => $artist->post_title );
+                    },
+                    ec_get_user_artist_memberships( $user->ID )
+                );
+                $items[] = array(
+                    'ID'           => $user->ID,
+                    'user_login'   => $user->user_login,
+                    'user_email'   => $user->user_email,
+                    'display_name' => $user->display_name,
+                    'artists'      => $artists,
+                );
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    return $items;
+}
+
+/**
+ * Finds user-side relationship entries whose artist post no longer exists.
+ *
+ * @return array|WP_Error Orphan rows or an artist-site configuration error.
+ */
+function ec_get_orphaned_artist_relationships() {
+    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+    if ( ! $artist_blog_id ) {
+        return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
+    }
+
+    $orphans = array();
+    switch_to_blog( $artist_blog_id );
+    try {
+        foreach ( get_users( array( 'meta_key' => '_artist_profile_ids' ) ) as $user ) {
+            $artist_ids = get_user_meta( $user->ID, '_artist_profile_ids', true );
+            if ( ! is_array( $artist_ids ) ) {
+                continue;
+            }
+            foreach ( $artist_ids as $artist_id ) {
+                if ( ! get_post( $artist_id ) || 'artist_profile' !== get_post_type( $artist_id ) ) {
+                    $orphans[] = array(
+                        'user'              => array(
+                            'ID'           => $user->ID,
+                            'user_login'   => $user->user_login,
+                            'display_name' => $user->display_name,
+                        ),
+                        'invalid_artist_id' => $artist_id,
+                    );
+                }
+            }
+        }
+    } finally {
+        restore_current_blog();
+    }
+
+    return $orphans;
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+	<testsuites>
+		<testsuite name="Extra Chill Artist Platform">
+			<directory>tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/AdminArtistRelationshipsTest.php
+++ b/tests/AdminArtistRelationshipsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class AdminArtistRelationshipsTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array();
+	}
+
+	public function test_list_preserves_items_envelope_and_filters_input(): void {
+		$GLOBALS['ec_test']['list_result'] = array( array( 'id' => 12 ) );
+
+		$result = extrachill_artist_platform_ability_admin_list_artist_relationships(
+			array( 'view' => 'artists', 'search' => '  Band  ' )
+		);
+
+		$this->assertSame( array( 'artists', 'Band' ), $GLOBALS['ec_test']['list'] );
+		$this->assertSame( array( 'items' => array( array( 'id' => 12 ) ) ), $result );
+	}
+
+	public function test_link_uses_canonical_membership_mutator(): void {
+		$result = extrachill_artist_platform_ability_admin_link_artist_relationship(
+			array( 'user_id' => 7, 'artist_id' => 19 )
+		);
+
+		$this->assertSame( array( 7, 19 ), $GLOBALS['ec_test']['added'] );
+		$this->assertSame( array( 'success' => true ), $result );
+	}
+
+	public function test_link_rejects_missing_user(): void {
+		$GLOBALS['ec_test']['missing_user'] = true;
+
+		$result = extrachill_artist_platform_ability_admin_link_artist_relationship(
+			array( 'user_id' => 7, 'artist_id' => 19 )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_user', $result->get_error_code() );
+	}
+
+	public function test_unlink_and_cleanup_use_canonical_membership_mutator(): void {
+		$this->assertSame(
+			array( 'success' => true ),
+			extrachill_artist_platform_ability_admin_unlink_artist_relationship( array( 'user_id' => 4, 'artist_id' => 8 ) )
+		);
+		$this->assertSame( array( 4, 8 ), $GLOBALS['ec_test']['removed'] );
+
+		extrachill_artist_platform_ability_admin_cleanup_artist_relationships( array( 'user_id' => 5, 'artist_id' => 9 ) );
+		$this->assertSame( array( 5, 9 ), $GLOBALS['ec_test']['removed'] );
+	}
+
+	public function test_orphan_list_preserves_orphans_envelope(): void {
+		$GLOBALS['ec_test']['orphan_result'] = array( array( 'invalid_artist_id' => 44 ) );
+
+		$this->assertSame(
+			array( 'orphans' => array( array( 'invalid_artist_id' => 44 ) ) ),
+			extrachill_artist_platform_ability_admin_list_orphan_artist_relationships( array() )
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+function __( $text ) {
+	return $text;
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+$GLOBALS['ec_test'] = array();
+
+function sanitize_text_field( $value ) {
+	return trim( $value );
+}
+
+function ec_get_artist_relationships_for_admin( $view, $search ) {
+	$GLOBALS['ec_test']['list'] = array( $view, $search );
+	return $GLOBALS['ec_test']['list_result'] ?? array();
+}
+
+function ec_get_orphaned_artist_relationships() {
+	return $GLOBALS['ec_test']['orphan_result'] ?? array();
+}
+
+function get_userdata( $user_id ) {
+	return empty( $GLOBALS['ec_test']['missing_user'] ) ? (object) array( 'ID' => $user_id ) : false;
+}
+
+function ec_add_artist_membership( $user_id, $artist_id ) {
+	$GLOBALS['ec_test']['added'] = array( $user_id, $artist_id );
+	return $GLOBALS['ec_test']['add_result'] ?? true;
+}
+
+function ec_remove_artist_membership( $user_id, $artist_id ) {
+	$GLOBALS['ec_test']['removed'] = array( $user_id, $artist_id );
+	return true;
+}
+
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-artist-relationships.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-link-artist-relationship.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-unlink-artist-relationship.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-artist-relationships.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';


### PR DESCRIPTION
## Summary
- move relationship list and orphan discovery implementations into artist-platform while preserving the existing five ability names and response envelopes
- route link, unlink, and cleanup through the canonical `ec_add_artist_membership()` and `ec_remove_artist_membership()` primitives
- add a focused network-admin page for artist/user views, search, linking, unlinking, orphan discovery, and cleanup
- remove the relationship abilities' runtime dependency on Extra Chill API and Admin Tools

## Reused primitives
- existing `extrachill/admin-*-artist-relationship*` abilities remain the public operator contract
- existing `_artist_profile_ids` / `_artist_member_ids` accessors and canonical membership mutators remain the domain contract
- existing `ec_get_blog_id( 'artist' )`, `ec_get_linked_members()`, and `ec_get_user_artist_memberships()` reads preserve current multisite behavior

## Parity gap
The abilities previously delegated back into `extrachill-api` implementation functions, and the only UI lived in Admin Tools. This PR moves the proven list/orphan implementations to their owning plugin and supplies a small core-styled network-admin surface that invokes the abilities directly.

## Behavior and permissions
- preserves `items`, `orphans`, and `success` response envelopes used by current operators
- preserves artists/users search, 50-row limits, all-status artist listing, and user-side orphan detection behavior
- preserves network-admin-only access through `manage_network_options`; admin mutations also require a nonce
- adds explicit 404 errors for invalid users or artist profiles during linking instead of calling the API's unavailable legacy `ec_add_member_to_artist()` symbol

## Tests
- `vendor/bin/phpunit` (5 tests, 10 assertions)
- PHP syntax checks for all changed PHP files
- `git diff --check`
- repository-wide `npm run lint:js` and `npm run lint:css` remain red on pre-existing unrelated violations (2,222 JS and 1,572 CSS findings)
- `homeboy review extrachill-artist-platform lint` was not run because Homeboy refused to start on the hot host (load 12.3 / 8 CPUs)

## Dependencies
- no runtime dependency on `extrachill-admin-tools`
- no runtime dependency on Extra Chill API relationship implementation functions
- requires the existing WordPress Abilities API and Extra Chill multisite `ec_get_blog_id()` mapping already used by this plugin

Closes #109
Related retirement epic: Extra-Chill/extrachill-admin-tools#16
Identity-contract context: #46, #58