### PR TITLE
feat: expose canonical artist read model

### DIFF
--- a/docs/artist-profiles/read-model.md
+++ b/docs/artist-profiles/read-model.md
@@ -1,0 +1,33 @@
+# Artist Profile Read Model
+
+Authorized network consumers should use the `extrachill/artist-get` ability for
+one published artist profile. It is exposed through the WordPress Abilities REST
+surface and accepts an `id` integer.
+
+The response is authoritative on the Artist Platform site and contains:
+
+- `id`, `name`, `slug`, and `permalink`
+- `bio` from the artist profile post content
+- `profile_image_id` / `profile_image_url` and `header_image_id` / `header_image_url`
+- `local_city` for the hometown or local scene and `genre` for the artist style
+- `official_links`, normalized from the artist-managed social-link store
+- `link_page_id` when the artist has a link page
+
+Only published `artist_profile` posts are returned. Draft, private, and missing
+profiles return `invalid_artist`, so cross-site consumers must not query post
+meta directly or duplicate the profile model.
+
+## Core REST Contract
+
+`artist_profile` is a public CPT with `show_in_rest` enabled. Core
+`/wp/v2/artist_profile/<id>` exposes standard post content and `featured_media`
+(the profile image), but it does not expose the header image, local scene,
+genre, or normalized official links because those are Artist Platform metadata.
+Use `extrachill/artist-get` when those fields are needed together.
+
+## Latest Release
+
+The Artist Platform does not currently store a latest-release field. Consumers
+must treat it as unavailable rather than infer it from social or link-page
+URLs. Add it only once an Artist Platform-owned release field has a defined
+editor and privacy contract.

--- a/inc/abilities/handlers/artist-get.php
+++ b/inc/abilities/handlers/artist-get.php
@@ -34,26 +34,14 @@ function extrachill_artist_platform_ability_artist_get( array $input ): array|WP
 
 	$artist = get_post( $artist_id );
 
-	if ( ! $artist || $artist->post_type !== 'artist_profile' ) {
+	if ( ! $artist || $artist->post_type !== 'artist_profile' || $artist->post_status !== 'publish' ) {
 		if ( $did_switch ) {
 			restore_current_blog();
 		}
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}
 
-	$local_city = get_post_meta( $artist_id, '_local_city', true );
-	$genre      = get_post_meta( $artist_id, '_genre', true );
-
-	$profile_image_id  = get_post_thumbnail_id( $artist_id );
-	$profile_image_url = $profile_image_id ? wp_get_attachment_image_url( (int) $profile_image_id, 'medium' ) : null;
-
-	$header_image_id  = get_post_meta( $artist_id, '_artist_profile_header_image_id', true );
-	$header_image_url = $header_image_id ? wp_get_attachment_image_url( (int) $header_image_id, 'large' ) : null;
-
-	$link_page_id = null;
-	if ( function_exists( 'ec_get_link_page_id' ) ) {
-		$link_page_id = ec_get_link_page_id( $artist_id );
-	}
+	$data = ec_get_artist_profile_data( $artist_id );
 
 	if ( $did_switch ) {
 		restore_current_blog();
@@ -61,15 +49,17 @@ function extrachill_artist_platform_ability_artist_get( array $input ): array|WP
 
 	return array(
 		'id'                => (int) $artist_id,
-		'name'              => $artist->post_title,
-		'slug'              => $artist->post_name,
-		'bio'               => $artist->post_content,
-		'local_city'        => $local_city !== '' ? $local_city : null,
-		'genre'             => $genre !== '' ? $genre : null,
-		'profile_image_id'  => $profile_image_id ? (int) $profile_image_id : null,
-		'profile_image_url' => $profile_image_url,
-		'header_image_id'   => $header_image_id ? (int) $header_image_id : null,
-		'header_image_url'  => $header_image_url,
-		'link_page_id'      => $link_page_id ? (int) $link_page_id : null,
+		'name'              => $data['title'],
+		'slug'              => $data['slug'],
+		'permalink'         => $data['permalink'],
+		'bio'               => $data['bio'],
+		'local_city'        => $data['local_city'] !== '' ? $data['local_city'] : null,
+		'genre'             => $data['genre'] !== '' ? $data['genre'] : null,
+		'profile_image_id'  => $data['profile_image_id'] ? (int) $data['profile_image_id'] : null,
+		'profile_image_url' => $data['profile_image_url'] ?: null,
+		'header_image_id'   => $data['header_image_id'] ? (int) $data['header_image_id'] : null,
+		'header_image_url'  => $data['header_image_url'] ?: null,
+		'official_links'    => $data['social_links'],
+		'link_page_id'      => $data['link_page_id'] ?: null,
 	);
 }

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -439,7 +439,7 @@ function extrachill_artist_platform_register_abilities() {
 		'extrachill/artist-get',
 		array(
 			'label'               => __( 'Get artist by ID', 'extrachill-artist-platform' ),
-			'description'         => __( 'Returns a single artist payload.', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns the canonical published artist profile payload, including imagery, profile details, and official links.', 'extrachill-artist-platform' ),
 			'category'            => 'extrachill-artists',
 			'input_schema'        => array(
 				'type'                 => 'object',
@@ -455,6 +455,7 @@ function extrachill_artist_platform_register_abilities() {
 					'id'                => array( 'type' => 'integer' ),
 					'name'              => array( 'type' => 'string' ),
 					'slug'              => array( 'type' => 'string' ),
+					'permalink'         => array( 'type' => 'string', 'format' => 'uri' ),
 					'bio'               => array( 'type' => 'string' ),
 					'local_city'        => array( 'type' => array( 'string', 'null' ) ),
 					'genre'             => array( 'type' => array( 'string', 'null' ) ),
@@ -462,6 +463,7 @@ function extrachill_artist_platform_register_abilities() {
 					'profile_image_url' => array( 'type' => array( 'string', 'null' ) ),
 					'header_image_id'   => array( 'type' => array( 'integer', 'null' ) ),
 					'header_image_url'  => array( 'type' => array( 'string', 'null' ) ),
+					'official_links'    => array( 'type' => 'array' ),
 					'link_page_id'      => array( 'type' => array( 'integer', 'null' ) ),
 				),
 			),

--- a/inc/core/filters/data.php
+++ b/inc/core/filters/data.php
@@ -214,6 +214,9 @@ function ec_get_artist_profile_data( $artist_id, $overrides = array() ) {
 
     $social_links = $meta['_artist_profile_social_links'][0] ?? array();
     $social_links = maybe_unserialize( $social_links );
+    if ( function_exists( 'extrachill_artist_platform_social_links' ) ) {
+        $social_links = extrachill_artist_platform_social_links()->get( $artist_id );
+    }
     if ( ! is_array( $social_links ) ) {
         $social_links = array();
     }
@@ -224,6 +227,8 @@ function ec_get_artist_profile_data( $artist_id, $overrides = array() ) {
     $data = array(
         'artist_id' => (int) $artist_id,
         'title' => get_the_title( $artist_id ) ?: '',
+        'slug' => get_post_field( 'post_name', $artist_id ) ?: '',
+        'permalink' => get_permalink( $artist_id ) ?: '',
         'bio' => ( get_post( $artist_id )->post_content ?? '' ),
         'genre' => $meta['_genre'][0] ?? '',
         'local_city' => $meta['_local_city'][0] ?? '',
@@ -236,6 +241,7 @@ function ec_get_artist_profile_data( $artist_id, $overrides = array() ) {
         'header_image_url' => $header_image_id ? wp_get_attachment_url( $header_image_id ) : '',
         'profile_image_id' => $profile_image_id,
         'profile_image_url' => $profile_image_id ? get_the_post_thumbnail_url( $artist_id, 'large' ) : '',
+        'link_page_id' => function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $artist_id ) : 0,
     );
 
     if ( isset( $overrides['title'] ) ) {

--- a/tests/ArtistProfileDataTest.php
+++ b/tests/ArtistProfileDataTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistProfileDataTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'posts'      => array(
+				12 => (object) array(
+					'post_type'    => 'artist_profile',
+					'post_status'  => 'publish',
+					'post_title'   => 'The Chill Band',
+					'post_name'    => 'the-chill-band',
+					'post_content' => 'A short bio.',
+				),
+			),
+			'meta'       => array(
+				12 => array(
+					'_genre'                          => array( 'Psych rock' ),
+					'_local_city'                     => array( 'Charleston, SC' ),
+					'_artist_profile_header_image_id' => array( 34 ),
+					'_artist_profile_social_links'    => array( array( array( 'type' => 'spotify', 'url' => 'https://spotify.com/artist/chill' ) ) ),
+				),
+			),
+			'thumbnails' => array( 12 => 56 ),
+		);
+	}
+
+	public function test_returns_the_complete_canonical_profile_fields(): void {
+		$this->assertSame(
+			array(
+				'artist_id'         => 12,
+				'title'             => 'The Chill Band',
+				'slug'              => 'the-chill-band',
+				'permalink'         => 'https://artist.example/artists/the-chill-band/',
+				'bio'               => 'A short bio.',
+				'genre'             => 'Psych rock',
+				'local_city'        => 'Charleston, SC',
+				'website_url'       => '',
+				'spotify_url'       => '',
+				'apple_music_url'   => '',
+				'bandcamp_url'      => '',
+				'social_links'      => array( array( 'type' => 'spotify', 'url' => 'https://spotify.com/artist/chill' ) ),
+				'header_image_id'   => 34,
+				'header_image_url'  => 'https://artist.example/media/34.jpg',
+				'profile_image_id'  => 56,
+				'profile_image_url' => 'https://artist.example/media/56.jpg',
+				'link_page_id'      => 0,
+			),
+			ec_get_artist_profile_data( 12 )
+		);
+	}
+
+	public function test_public_ability_returns_only_published_profiles_and_official_links(): void {
+		$result = extrachill_artist_platform_ability_artist_get( array( 'id' => 12 ) );
+
+		$this->assertSame( 'https://artist.example/artists/the-chill-band/', $result['permalink'] );
+		$this->assertSame(
+			array( array( 'type' => 'spotify', 'url' => 'https://spotify.com/artist/chill' ) ),
+			$result['official_links']
+		);
+
+		$GLOBALS['ec_test']['posts'][12]->post_status = 'draft';
+		$result = extrachill_artist_platform_ability_artist_get( array( 'id' => 12 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_artist', $result->get_error_code() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,52 @@ function sanitize_text_field( $value ) {
 	return trim( $value );
 }
 
+function get_post_type( $post_id ) {
+	return $GLOBALS['ec_test']['posts'][ $post_id ]->post_type ?? '';
+}
+
+function get_post_meta( $post_id, $key = '', $single = false ) {
+	$meta = $GLOBALS['ec_test']['meta'][ $post_id ] ?? array();
+	if ( $key === '' ) {
+		return $meta;
+	}
+	$value = $meta[ $key ] ?? ( $single ? '' : array() );
+	return $single && is_array( $value ) ? ( $value[0] ?? '' ) : $value;
+}
+
+function maybe_unserialize( $value ) {
+	return $value;
+}
+
+function get_post_thumbnail_id( $post_id ) {
+	return $GLOBALS['ec_test']['thumbnails'][ $post_id ] ?? 0;
+}
+
+function get_the_title( $post_id ) {
+	return $GLOBALS['ec_test']['posts'][ $post_id ]->post_title ?? '';
+}
+
+function get_post_field( $field, $post_id ) {
+	return $GLOBALS['ec_test']['posts'][ $post_id ]->{$field} ?? '';
+}
+
+function get_permalink( $post_id ) {
+	return 'https://artist.example/artists/' . get_post_field( 'post_name', $post_id ) . '/';
+}
+
+function get_post( $post_id ) {
+	return $GLOBALS['ec_test']['posts'][ $post_id ] ?? null;
+}
+
+function wp_get_attachment_url( $attachment_id ) {
+	return 'https://artist.example/media/' . $attachment_id . '.jpg';
+}
+
+function get_the_post_thumbnail_url( $post_id, $size ) {
+	$attachment_id = get_post_thumbnail_id( $post_id );
+	return $attachment_id ? wp_get_attachment_url( $attachment_id ) : false;
+}
+
 function ec_get_artist_relationships_for_admin( $view, $search ) {
 	$GLOBALS['ec_test']['list'] = array( $view, $search );
 	return $GLOBALS['ec_test']['list_result'] ?? array();
@@ -62,3 +108,5 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-link-artist-rel
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-unlink-artist-relationship.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';
+require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';


### PR DESCRIPTION
## Summary
- extend the existing `extrachill/artist-get` ability with canonical permalinks and normalized official links
- restrict the cross-site profile payload to published artist profiles and source it from the centralized Artist Platform model
- document the consumer contract, inventory Core REST coverage, and add focused profile contract tests

## Verification
- `php -l` passed for all changed PHP files
- focused PHP contract assertions passed
- `composer test` and `composer lint:php` are blocked because `vendor/bin/phpunit` and `vendor/bin/phpcs` are absent
- `npm run lint:js` remains blocked by 2,214 pre-existing errors outside this PHP-only change