### PR TITLE
Pay down PHPCS lint debt

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -19,152 +19,151 @@ define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 if ( ! defined( 'EXTRCH_LINKPAGE_DEV' ) ) {
-    define( 'EXTRCH_LINKPAGE_DEV', false );
+	define( 'EXTRCH_LINKPAGE_DEV', false );
 }
 
 if ( file_exists( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
-    require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'vendor/autoload.php';
+	require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'vendor/autoload.php';
 }
 
 class ExtraChillArtistPlatform {
 
-    private static $instance = null;
+	private static $instance = null;
 
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    private function __construct() {
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-post-types.php';
-        $this->init_hooks();
-    }
+	private function __construct() {
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-post-types.php';
+		$this->init_hooks();
+	}
 
 
-    private function init_hooks() {
-        add_action( 'init', 'extrachill_artist_platform_register_blocks' );
-        add_action( 'init', array( $this, 'init' ), 15 );
-        add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
-        register_activation_hook( __FILE__, array( $this, 'activate' ) );
-        register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
-    }
+	private function init_hooks() {
+		add_action( 'init', 'extrachill_artist_platform_register_blocks' );
+		add_action( 'init', array( $this, 'init' ), 15 );
+		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+		register_activation_hook( __FILE__, array( $this, 'activate' ) );
+		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
+	}
 
-    public function init() {
-        $this->load_includes();
-    }
+	public function init() {
+		$this->load_includes();
+	}
 
-    public function load_textdomain() {
-        load_plugin_textdomain( 
-            'extrachill-artist-platform', 
-            false, 
-            dirname( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME ) . '/languages' 
-        );
-    }
+	public function load_textdomain() {
+		load_plugin_textdomain(
+			'extrachill-artist-platform',
+			false,
+			dirname( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME ) . '/languages'
+		);
+	}
 
-    private function load_includes() {
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/class-templates.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/social-icons.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/fonts.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/templates.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/page-title.php';
+	private function load_includes() {
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/class-templates.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/social-icons.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/fonts.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/templates.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/page-title.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/relationship-admin-page.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/permissions.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/artist-grid.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/breadcrumbs.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/section-registry.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/default-sections.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/shows-section.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/coverage-section.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/subscribe-data-functions.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/relationship-admin-page.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/permissions.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/artist-grid.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/breadcrumbs.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/section-registry.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/default-sections.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/shows-section.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/coverage-section.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/subscribe-data-functions.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/create-link-page.php';
-        // Link-page analytics (write path, read provider, prune, and tables) is
-        // owned by extrachill-analytics (ECA) as of extrachill-artist-platform#89
-        // / extrachill-analytics#94. AP consumes it via the
-        // extrachill_get_link_page_analytics filter (see the artist-get-analytics
-        // ability) and renders it through the artist-analytics block.
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/minimal-head-assets.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-head.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-seo.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/create-link-page.php';
+		// Link-page analytics (write path, read provider, prune, and tables) is
+		// owned by extrachill-analytics (ECA) as of extrachill-artist-platform#89
+		// / extrachill-analytics#94. AP consumes it via the
+		// extrachill_get_link_page_analytics filter (see the artist-get-analytics
+		// ability) and renders it through the artist-analytics block.
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/minimal-head-assets.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-head.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-seo.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/management/advanced-tab/link-expiration.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/management/advanced-tab/link-expiration.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/manage-roster-ui.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/roster-filter-handlers.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/manage-roster-ui.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/roster-filter-handlers.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/database/subscriber-db.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/database/subscriber-db.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/save.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/sync.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/delete.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/add.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/save.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/sync.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/delete.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/actions/add.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/homepage-artist-card-actions.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/homepage-hooks.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/homepage-artist-card-actions.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/join/join-flow.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/join/artist-access-approval.php';
-        
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/nav.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-artist-provisioning.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/join/join-flow.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/join/artist-access-approval.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/analytics/activation-funnel.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/nav.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-artist-provisioning.php';
 
-        ExtraChillArtistPlatform_PageTemplates::instance();
-        ExtraChillArtistPlatform_Assets::instance();
-        ExtraChillArtistPlatform_SocialLinks::instance();
-        ExtraChillArtistPlatform_Fonts::instance();
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/analytics/activation-funnel.php';
 
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/abilities/abilities.php';
+		ExtraChillArtistPlatform_PageTemplates::instance();
+		ExtraChillArtistPlatform_Assets::instance();
+		ExtraChillArtistPlatform_SocialLinks::instance();
+		ExtraChillArtistPlatform_Fonts::instance();
 
-        add_action('after_switch_theme', 'extrachill_artist_create_subscribers_table');
-    }
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/abilities/abilities.php';
 
-    public static function activate() {
-        // Link-page analytics tables are owned and created by extrachill-analytics
-        // (ECA) as of extrachill-artist-platform#89 / extrachill-analytics#94.
-        flush_rewrite_rules();
-        // Persist the rewrite-rules version so the version-gated flush on init
-        // does not immediately re-run after activation. The constant is defined
-        // in inc/core/artist-platform-rewrite-rules.php, loaded during init().
-        if ( defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
-            update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
-        }
-        update_option( 'extrachill_artist_platform_activated', true );
+		add_action( 'after_switch_theme', 'extrachill_artist_create_subscribers_table' );
+	}
 
-        // Provision platform artist profile (suspenders).
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-artist-provisioning.php';
-        if ( function_exists( 'ec_activate_provision_platform_artist' ) ) {
-            ec_activate_provision_platform_artist();
-        }
-    }
+	public static function activate() {
+		// Link-page analytics tables are owned and created by extrachill-analytics
+		// (ECA) as of extrachill-artist-platform#89 / extrachill-analytics#94.
+		flush_rewrite_rules();
+		// Persist the rewrite-rules version so the version-gated flush on init
+		// does not immediately re-run after activation. The constant is defined
+		// in inc/core/artist-platform-rewrite-rules.php, loaded during init().
+		if ( defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
+			update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
+		}
+		update_option( 'extrachill_artist_platform_activated', true );
 
-    public static function deactivate() {
-        flush_rewrite_rules();
-        delete_option( 'extrachill_artist_platform_activated' );
+		// Provision platform artist profile (suspenders).
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-artist-provisioning.php';
+		if ( function_exists( 'ec_activate_provision_platform_artist' ) ) {
+			ec_activate_provision_platform_artist();
+		}
+	}
 
-        // Link-page analytics pruning cron is owned by extrachill-analytics (ECA)
-        // as of extrachill-artist-platform#89 / extrachill-analytics#94. ECA also
-        // unschedules AP's legacy 'extrachill_artist_daily_analytics_prune_event'
-        // in its coexistence shim, so nothing to unschedule here.
-    }
+	public static function deactivate() {
+		flush_rewrite_rules();
+		delete_option( 'extrachill_artist_platform_activated' );
 
+		// Link-page analytics pruning cron is owned by extrachill-analytics (ECA)
+		// as of extrachill-artist-platform#89 / extrachill-analytics#94. ECA also
+		// unschedules AP's legacy 'extrachill_artist_daily_analytics_prune_event'
+		// in its coexistence shim, so nothing to unschedule here.
+	}
 }
 
 function extrachill_artist_platform() {
-    return ExtraChillArtistPlatform::instance();
+	return ExtraChillArtistPlatform::instance();
 }
 
 extrachill_artist_platform();
@@ -173,11 +172,11 @@ extrachill_artist_platform();
  * Register Gutenberg blocks from build directory.
  */
 function extrachill_artist_platform_register_blocks() {
-    register_block_type( __DIR__ . '/build/blocks/link-page-editor' );
-    register_block_type( __DIR__ . '/build/blocks/artist-analytics' );
-    register_block_type( __DIR__ . '/build/blocks/artist-manager' );
-    register_block_type( __DIR__ . '/build/blocks/artist-creator' );
-    register_block_type( __DIR__ . '/build/blocks/artist-shop-manager' );
+	register_block_type( __DIR__ . '/build/blocks/link-page-editor' );
+	register_block_type( __DIR__ . '/build/blocks/artist-analytics' );
+	register_block_type( __DIR__ . '/build/blocks/artist-manager' );
+	register_block_type( __DIR__ . '/build/blocks/artist-creator' );
+	register_block_type( __DIR__ . '/build/blocks/artist-shop-manager' );
 }
 
 /**
@@ -187,16 +186,18 @@ function extrachill_artist_platform_register_blocks() {
  * Safe to run multiple times - checks if migration already complete.
  */
 function extrachill_artist_platform_migrate_pages() {
-    // Migrate manage-artist-profiles -> manage-artist
-    $old_page = get_page_by_path( 'manage-artist-profiles' );
-    if ( $old_page ) {
-        wp_update_post( array(
-            'ID'           => $old_page->ID,
-            'post_name'    => 'manage-artist',
-            'post_title'   => 'Manage Artist',
-            'post_content' => '<!-- wp:extrachill/artist-manager /-->',
-        ) );
-    }
+	// Migrate manage-artist-profiles -> manage-artist
+	$old_page = get_page_by_path( 'manage-artist-profiles' );
+	if ( $old_page ) {
+		wp_update_post(
+			array(
+				'ID'           => $old_page->ID,
+				'post_name'    => 'manage-artist',
+				'post_title'   => 'Manage Artist',
+				'post_content' => '<!-- wp:extrachill/artist-manager /-->',
+			)
+		);
+	}
 }
 
 /**
@@ -206,37 +207,39 @@ function extrachill_artist_platform_migrate_pages() {
  * Called on plugin activation and admin_init with version check.
  */
 function extrachill_artist_platform_create_pages() {
-    $pages = array(
-        'create-artist' => array(
-            'title'   => 'Create Artist',
-            'content' => '<!-- wp:extrachill/artist-creator /-->',
-        ),
-        'manage-artist' => array(
-            'title'   => 'Manage Artist',
-            'content' => '<!-- wp:extrachill/artist-manager /-->',
-        ),
-        'manage-link-page' => array(
-            'title'   => 'Manage Link Page',
-            'content' => '<!-- wp:extrachill/link-page-editor /-->',
-        ),
-        'manage-shop' => array(
-            'title'   => 'Manage Shop',
-            'content' => '<!-- wp:extrachill/artist-shop-manager /-->',
-        ),
-    );
+	$pages = array(
+		'create-artist'    => array(
+			'title'   => 'Create Artist',
+			'content' => '<!-- wp:extrachill/artist-creator /-->',
+		),
+		'manage-artist'    => array(
+			'title'   => 'Manage Artist',
+			'content' => '<!-- wp:extrachill/artist-manager /-->',
+		),
+		'manage-link-page' => array(
+			'title'   => 'Manage Link Page',
+			'content' => '<!-- wp:extrachill/link-page-editor /-->',
+		),
+		'manage-shop'      => array(
+			'title'   => 'Manage Shop',
+			'content' => '<!-- wp:extrachill/artist-shop-manager /-->',
+		),
+	);
 
-    foreach ( $pages as $slug => $page_data ) {
-        $existing_page = get_page_by_path( $slug );
-        if ( ! $existing_page ) {
-            wp_insert_post( array(
-                'post_title'   => $page_data['title'],
-                'post_name'    => $slug,
-                'post_content' => $page_data['content'],
-                'post_status'  => 'publish',
-                'post_type'    => 'page',
-            ) );
-        }
-    }
+	foreach ( $pages as $slug => $page_data ) {
+		$existing_page = get_page_by_path( $slug );
+		if ( ! $existing_page ) {
+			wp_insert_post(
+				array(
+					'post_title'   => $page_data['title'],
+					'post_name'    => $slug,
+					'post_content' => $page_data['content'],
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				)
+			);
+		}
+	}
 }
 
 /**
@@ -245,14 +248,14 @@ function extrachill_artist_platform_create_pages() {
  * Ensures pages are migrated/created on plugin upgrades, not just fresh activations.
  */
 function extrachill_artist_platform_maybe_create_pages() {
-    $current_version = EXTRACHILL_ARTIST_PLATFORM_VERSION;
-    $stored_version = get_option( 'extrachill_artist_platform_pages_version', '0' );
+	$current_version = EXTRACHILL_ARTIST_PLATFORM_VERSION;
+	$stored_version  = get_option( 'extrachill_artist_platform_pages_version', '0' );
 
-    if ( version_compare( $stored_version, $current_version, '<' ) ) {
-        extrachill_artist_platform_migrate_pages();
-        extrachill_artist_platform_create_pages();
-        update_option( 'extrachill_artist_platform_pages_version', $current_version );
-    }
+	if ( version_compare( $stored_version, $current_version, '<' ) ) {
+		extrachill_artist_platform_migrate_pages();
+		extrachill_artist_platform_create_pages();
+		update_option( 'extrachill_artist_platform_pages_version', $current_version );
+	}
 }
 add_action( 'admin_init', 'extrachill_artist_platform_maybe_create_pages' );
 
@@ -284,55 +287,55 @@ add_action( 'admin_init', 'extrachill_artist_platform_maybe_create_pages' );
  * @return void
  */
 function extrachill_artist_platform_heal_zero_modified_dates() {
-    global $wpdb;
+	global $wpdb;
 
-    $healed_version = '1.0.0';
-    $stored = get_option( 'extrachill_artist_platform_feed_date_heal', '0' );
-    if ( version_compare( $stored, $healed_version, '>=' ) ) {
-        return;
-    }
+	$healed_version = '1.0.0';
+	$stored         = get_option( 'extrachill_artist_platform_feed_date_heal', '0' );
+	if ( version_compare( $stored, $healed_version, '>=' ) ) {
+		return;
+	}
 
-    $zero = '0000-00-00 00:00:00';
+	$zero = '0000-00-00 00:00:00';
 
-    // Resolve this blog's UTC offset as a MySQL CONVERT_TZ offset string.
-    // wp_timezone() is per-site and DST-aware; it yields '+00:00' on a site
-    // configured for UTC and e.g. '-04:00' on America/New_York during EDT.
-    $tz      = wp_timezone();
-    $seconds = $tz->getOffset( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
-    $sign    = $seconds < 0 ? '-' : '+';
-    $abs     = abs( (int) $seconds );
-    $offset  = sprintf( '%s%02d:%02d', $sign, intdiv( $abs, HOUR_IN_SECONDS ), intdiv( $abs % HOUR_IN_SECONDS, MINUTE_IN_SECONDS ) );
+	// Resolve this blog's UTC offset as a MySQL CONVERT_TZ offset string.
+	// wp_timezone() is per-site and DST-aware; it yields '+00:00' on a site
+	// configured for UTC and e.g. '-04:00' on America/New_York during EDT.
+	$tz      = wp_timezone();
+	$seconds = $tz->getOffset( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) );
+	$sign    = $seconds < 0 ? '-' : '+';
+	$abs     = abs( (int) $seconds );
+	$offset  = sprintf( '%s%02d:%02d', $sign, intdiv( $abs, HOUR_IN_SECONDS ), intdiv( $abs % HOUR_IN_SECONDS, MINUTE_IN_SECONDS ) );
 
-    // Repair a zero post_date_gmt first, derived from the valid local post_date.
-    $wpdb->query(
-        $wpdb->prepare(
-            "UPDATE {$wpdb->posts}
+	// Repair a zero post_date_gmt first, derived from the valid local post_date.
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE {$wpdb->posts}
              SET post_date_gmt = CONVERT_TZ( post_date, %s, '+00:00' )
              WHERE post_date_gmt = %s
                AND post_date <> %s",
-            $offset,
-            $zero,
-            $zero
-        )
-    );
+			$offset,
+			$zero,
+			$zero
+		)
+	);
 
-    // Backfill modified dates. post_modified mirrors the local post_date;
-    // post_modified_gmt is derived from the LOCAL post_date (never trusted from
-    // post_date_gmt). Heals all statuses so a future status flip to publish
-    // cannot resurface the feed crash.
-    $wpdb->query(
-        $wpdb->prepare(
-            "UPDATE {$wpdb->posts}
+	// Backfill modified dates. post_modified mirrors the local post_date;
+	// post_modified_gmt is derived from the LOCAL post_date (never trusted from
+	// post_date_gmt). Heals all statuses so a future status flip to publish
+	// cannot resurface the feed crash.
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE {$wpdb->posts}
              SET post_modified     = post_date,
                  post_modified_gmt = CONVERT_TZ( post_date, %s, '+00:00' )
              WHERE post_modified_gmt = %s
                AND post_date <> %s",
-            $offset,
-            $zero,
-            $zero
-        )
-    );
+			$offset,
+			$zero,
+			$zero
+		)
+	);
 
-    update_option( 'extrachill_artist_platform_feed_date_heal', $healed_version );
+	update_option( 'extrachill_artist_platform_feed_date_heal', $healed_version );
 }
 add_action( 'admin_init', 'extrachill_artist_platform_heal_zero_modified_dates' );

--- a/inc/abilities/handlers/artist-export-subscribers.php
+++ b/inc/abilities/handlers/artist-export-subscribers.php
@@ -38,10 +38,13 @@ function extrachill_artist_platform_ability_artist_export_subscribers( array $in
 
 	$exported_filter = $include_exported ? null : 0;
 
-	$subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array(
-		'limit'    => -1,
-		'exported' => $exported_filter,
-	) );
+	$subscribers = extrachill_artist_get_artist_subscribers(
+		$artist_id,
+		array(
+			'limit'    => -1,
+			'exported' => $exported_filter,
+		)
+	);
 
 	$subscriber_ids_to_mark = array();
 	$export_data            = array();

--- a/inc/abilities/handlers/artist-list-subscribers.php
+++ b/inc/abilities/handlers/artist-list-subscribers.php
@@ -39,10 +39,13 @@ function extrachill_artist_platform_ability_artist_list_subscribers( array $inpu
 	}
 
 	$offset      = ( $page - 1 ) * $per_page;
-	$subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array(
-		'limit'  => $per_page,
-		'offset' => $offset,
-	) );
+	$subscribers = extrachill_artist_get_artist_subscribers(
+		$artist_id,
+		array(
+			'limit'  => $per_page,
+			'offset' => $offset,
+		)
+	);
 
 	global $wpdb;
 	$table = $wpdb->prefix . 'artist_subscribers';

--- a/inc/abilities/handlers/artist-list-subscribers.php
+++ b/inc/abilities/handlers/artist-list-subscribers.php
@@ -50,6 +50,7 @@ function extrachill_artist_platform_ability_artist_list_subscribers( array $inpu
 	global $wpdb;
 	$table = $wpdb->prefix . 'artist_subscribers';
 	$total = (int) $wpdb->get_var(
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is derived exclusively from the trusted WordPress database prefix.
 		$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d", $artist_id )
 	);
 

--- a/inc/abilities/handlers/artist-update-links.php
+++ b/inc/abilities/handlers/artist-update-links.php
@@ -45,10 +45,12 @@ function extrachill_artist_platform_ability_artist_update_links( array $input ):
 
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-link-page-links' ) : null;
 		if ( $ability ) {
-			$result = $ability->execute( array(
-				'artist_id' => $artist_id,
-				'links'     => $input['links'],
-			) );
+			$result = $ability->execute(
+				array(
+					'artist_id' => $artist_id,
+					'links'     => $input['links'],
+				)
+			);
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
@@ -63,10 +65,12 @@ function extrachill_artist_platform_ability_artist_update_links( array $input ):
 
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-link-page-styles' ) : null;
 		if ( $ability ) {
-			$result = $ability->execute( array(
-				'artist_id' => $artist_id,
-				'css_vars'  => $input['css_vars'],
-			) );
+			$result = $ability->execute(
+				array(
+					'artist_id' => $artist_id,
+					'css_vars'  => $input['css_vars'],
+				)
+			);
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
@@ -107,10 +111,12 @@ function extrachill_artist_platform_ability_artist_update_links( array $input ):
 
 		$ability = function_exists( 'wp_get_ability' ) ? wp_get_ability( 'extrachill/save-social-links' ) : null;
 		if ( $ability ) {
-			$result = $ability->execute( array(
-				'artist_id'    => $artist_id,
-				'social_links' => $input['socials'],
-			) );
+			$result = $ability->execute(
+				array(
+					'artist_id'    => $artist_id,
+					'social_links' => $input['socials'],
+				)
+			);
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/inc/abilities/handlers/update-artist.php
+++ b/inc/abilities/handlers/update-artist.php
@@ -38,12 +38,12 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( isset( $input['name'] ) ) {
 		$post_data['post_title'] = sanitize_text_field( wp_unslash( $input['name'] ) );
-		$has_updates = true;
+		$has_updates             = true;
 	}
 
 	if ( isset( $input['bio'] ) ) {
 		$post_data['post_content'] = wp_kses_post( wp_unslash( $input['bio'] ) );
-		$has_updates = true;
+		$has_updates               = true;
 	}
 
 	if ( array_key_exists( 'local_city', $input ) ) {

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -79,7 +79,7 @@ function extrachill_artist_platform_get_next_id( $link_page_id, $type ) {
 
 	$meta_key   = $map[ $type ];
 	$next_index = (int) get_post_meta( $link_page_id, $meta_key, true );
-	$next_index++;
+	++$next_index;
 	update_post_meta( $link_page_id, $meta_key, $next_index );
 
 	return sprintf( '%d-%s-%d', $link_page_id, $type, $next_index );

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -57,7 +57,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -96,11 +96,11 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'name' => array(
+					'name'       => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'        => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
@@ -108,11 +108,11 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'      => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
-					'user_id' => array(
+					'user_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'User ID to link as member. Defaults to current user.', 'extrachill-artist-platform' ),
 					),
@@ -145,23 +145,23 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'        => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'name' => array(
+					'name'             => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'              => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
-					'local_city' => array(
+					'local_city'       => array(
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'            => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
@@ -169,7 +169,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'header_image_id' => array(
+					'header_image_id'  => array(
 						'type'        => 'integer',
 						'description' => __( 'Header image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -206,7 +206,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'links' => array(
+					'links'     => array(
 						'type'        => 'array',
 						'description' => __( 'Array of link sections with nested links.', 'extrachill-artist-platform' ),
 					),
@@ -243,7 +243,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'css_vars' => array(
+					'css_vars'  => array(
 						'type'        => 'object',
 						'description' => __( 'CSS variables to save. Merged with existing.', 'extrachill-artist-platform' ),
 					),
@@ -276,15 +276,15 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'           => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'settings' => array(
+					'settings'            => array(
 						'type'        => 'object',
 						'description' => __( 'Settings to save.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'                 => array(
 						'type'        => 'string',
 						'description' => __( 'Short bio displayed on the public link page.', 'extrachill-artist-platform' ),
 					),
@@ -292,7 +292,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Background image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'profile_image_id' => array(
+					'profile_image_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -325,7 +325,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -367,9 +367,21 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
-					'search'   => array( 'type' => 'string', 'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ) ),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -406,7 +418,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'days' => array( 'type' => 'integer', 'minimum' => 0, 'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ) ),
+					'days' => array(
+						'type'        => 'integer',
+						'minimum'     => 0,
+						'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -445,7 +461,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -490,7 +510,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -521,14 +545,39 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'                 => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'links'              => array( 'type' => 'array', 'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ) ),
-					'css_vars'           => array( 'type' => 'object', 'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ) ),
-					'settings'           => array( 'type' => 'object', 'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ) ),
-					'socials'            => array( 'type' => 'array', 'description' => __( 'Social link objects.', 'extrachill-artist-platform' ) ),
-					'background_image_id' => array( 'type' => 'integer', 'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ) ),
-					'profile_image_id'   => array( 'type' => 'integer', 'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ) ),
-					'bio'                => array( 'type' => 'string', 'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ) ),
+					'id'                  => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'links'               => array(
+						'type'        => 'array',
+						'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ),
+					),
+					'css_vars'            => array(
+						'type'        => 'object',
+						'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ),
+					),
+					'settings'            => array(
+						'type'        => 'object',
+						'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ),
+					),
+					'socials'             => array(
+						'type'        => 'array',
+						'description' => __( 'Social link objects.', 'extrachill-artist-platform' ),
+					),
+					'background_image_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'profile_image_id'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'bio'                 => array(
+						'type'        => 'string',
+						'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -559,7 +608,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -594,7 +647,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -628,7 +685,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -661,9 +722,20 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'type', 'url' ),
 				'properties'           => array(
-					'id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'type' => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'  => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'type' => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'  => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -696,10 +768,24 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ) ),
-					'type'      => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'       => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ),
+					),
+					'type'      => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'       => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -732,8 +818,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -768,8 +861,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'email' ),
 				'properties'           => array(
-					'id'    => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'email' => array( 'type' => 'string', 'format' => 'email', 'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ) ),
+					'id'    => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'email' => array(
+						'type'        => 'string',
+						'format'      => 'email',
+						'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -802,9 +903,22 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'       => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
+					'id'       => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -840,8 +954,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'               => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'include_exported' => array( 'type' => 'boolean', 'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ) ),
+					'id'               => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'include_exported' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -878,8 +999,17 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'         => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'date_range' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 90, 'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ) ),
+					'id'         => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'date_range' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -918,8 +1048,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'view'   => array( 'type' => 'string', 'enum' => array( 'artists', 'users' ), 'description' => __( 'View mode.', 'extrachill-artist-platform' ) ),
-					'search' => array( 'type' => 'string', 'description' => __( 'Search term.', 'extrachill-artist-platform' ) ),
+					'view'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'artists', 'users' ),
+						'description' => __( 'View mode.', 'extrachill-artist-platform' ),
+					),
+					'search' => array(
+						'type'        => 'string',
+						'description' => __( 'Search term.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -952,8 +1089,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -986,8 +1131,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1051,8 +1204,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),

--- a/inc/artist-profiles/admin/relationship-admin-page.php
+++ b/inc/artist-profiles/admin/relationship-admin-page.php
@@ -62,13 +62,16 @@ function ec_handle_artist_relationship_admin_action() {
 /** Render the relationship list, link form, and orphan cleanup workflow. */
 function ec_render_artist_relationship_admin_page() {
 	$requested_view = isset( $_GET['view'] ) ? sanitize_key( wp_unslash( $_GET['view'] ) ) : 'artists';
-	$view   = in_array( $requested_view, array( 'artists', 'users', 'orphans' ), true ) ? $requested_view : 'artists';
-	$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
-	$name   = 'orphans' === $view ? 'extrachill/admin-list-orphan-artist-relationships' : 'extrachill/admin-list-artist-relationships';
-	$input  = 'orphans' === $view ? array() : array( 'view' => $view, 'search' => $search );
-	$ability = wp_get_ability( $name );
-	$result  = $ability ? $ability->execute( $input ) : new WP_Error( 'ability_not_found', __( 'Relationship ability is unavailable.', 'extrachill-artist-platform' ) );
-	$notice_type = isset( $_GET['type'] ) && 'error' === sanitize_key( wp_unslash( $_GET['type'] ) ) ? 'error' : 'success';
+	$view           = in_array( $requested_view, array( 'artists', 'users', 'orphans' ), true ) ? $requested_view : 'artists';
+	$search         = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+	$name           = 'orphans' === $view ? 'extrachill/admin-list-orphan-artist-relationships' : 'extrachill/admin-list-artist-relationships';
+	$input          = 'orphans' === $view ? array() : array(
+		'view'   => $view,
+		'search' => $search,
+	);
+	$ability        = wp_get_ability( $name );
+	$result         = $ability ? $ability->execute( $input ) : new WP_Error( 'ability_not_found', __( 'Relationship ability is unavailable.', 'extrachill-artist-platform' ) );
+	$notice_type    = isset( $_GET['type'] ) && 'error' === sanitize_key( wp_unslash( $_GET['type'] ) ) ? 'error' : 'success';
 	?>
 	<div class="wrap">
 		<h1><?php esc_html_e( 'Artist Relationships', 'extrachill-artist-platform' ); ?></h1>
@@ -77,8 +80,26 @@ function ec_render_artist_relationship_admin_page() {
 		<?php endif; ?>
 		<p><?php esc_html_e( 'Manage bidirectional links between network users and artist profiles.', 'extrachill-artist-platform' ); ?></p>
 		<nav class="nav-tab-wrapper">
-			<?php foreach ( array( 'artists' => __( 'Artists', 'extrachill-artist-platform' ), 'users' => __( 'Users', 'extrachill-artist-platform' ), 'orphans' => __( 'Orphans', 'extrachill-artist-platform' ) ) as $key => $label ) : ?>
-				<a class="nav-tab <?php echo $view === $key ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'ec-artist-relationships', 'view' => $key ), network_admin_url( 'settings.php' ) ) ); ?>"><?php echo esc_html( $label ); ?></a>
+			<?php
+			foreach ( array(
+				'artists' => __( 'Artists', 'extrachill-artist-platform' ),
+				'users'   => __( 'Users', 'extrachill-artist-platform' ),
+				'orphans' => __( 'Orphans', 'extrachill-artist-platform' ),
+			) as $key => $label ) :
+				?>
+				<a class="nav-tab <?php echo $view === $key ? 'nav-tab-active' : ''; ?>" href="
+				<?php
+				echo esc_url(
+					add_query_arg(
+						array(
+							'page' => 'ec-artist-relationships',
+							'view' => $key,
+						),
+						network_admin_url( 'settings.php' )
+					)
+				);
+				?>
+									"><?php echo esc_html( $label ); ?></a>
 			<?php endforeach; ?>
 		</nav>
 
@@ -100,7 +121,11 @@ function ec_render_artist_relationship_admin_page() {
 
 		<?php if ( is_wp_error( $result ) ) : ?>
 			<div class="notice notice-error"><p><?php echo esc_html( $result->get_error_message() ); ?></p></div>
-		<?php else : ec_render_artist_relationship_admin_table( $view, 'orphans' === $view ? $result['orphans'] : $result['items'] ); endif; ?>
+			<?php
+		else :
+			ec_render_artist_relationship_admin_table( $view, 'orphans' === $view ? $result['orphans'] : $result['items'] );
+endif;
+		?>
 	</div>
 	<?php
 }
@@ -114,11 +139,19 @@ function ec_render_artist_relationship_admin_page() {
 function ec_render_artist_relationship_admin_table( $view, array $items ) {
 	?>
 	<table class="widefat striped"><thead><tr><th><?php echo 'users' === $view ? esc_html__( 'User', 'extrachill-artist-platform' ) : esc_html__( 'Artist', 'extrachill-artist-platform' ); ?></th><th><?php echo 'orphans' === $view ? esc_html__( 'Invalid Artist ID', 'extrachill-artist-platform' ) : esc_html__( 'Relationships', 'extrachill-artist-platform' ); ?></th></tr></thead><tbody>
-	<?php if ( empty( $items ) ) : ?><tr><td colspan="2"><?php esc_html_e( 'No relationships found.', 'extrachill-artist-platform' ); ?></td></tr><?php endif; ?>
+	<?php
+	if ( empty( $items ) ) :
+		?>
+		<tr><td colspan="2"><?php esc_html_e( 'No relationships found.', 'extrachill-artist-platform' ); ?></td></tr><?php endif; ?>
 	<?php foreach ( $items as $item ) : ?>
 		<tr><td><?php echo esc_html( 'artists' === $view ? $item['title'] . ' (#' . $item['id'] . ')' : $item['user']['display_name'] ?? $item['display_name'] ); ?></td><td>
 		<?php
-		$relationships = 'artists' === $view ? $item['members'] : ( 'users' === $view ? $item['artists'] : array( array( 'ID' => $item['user']['ID'], 'artist_id' => $item['invalid_artist_id'] ) ) );
+		$relationships = 'artists' === $view ? $item['members'] : ( 'users' === $view ? $item['artists'] : array(
+			array(
+				'ID'        => $item['user']['ID'],
+				'artist_id' => $item['invalid_artist_id'],
+			),
+		) );
 		foreach ( $relationships as $relationship ) {
 			$user_id   = 'artists' === $view ? $relationship['ID'] : ( 'users' === $view ? $item['ID'] : $relationship['ID'] );
 			$artist_id = 'artists' === $view ? $item['id'] : ( 'users' === $view ? $relationship['ID'] : $relationship['artist_id'] );

--- a/inc/artist-profiles/admin/user-linking.php
+++ b/inc/artist-profiles/admin/user-linking.php
@@ -19,60 +19,60 @@ defined( 'ABSPATH' ) || exit;
  * @return bool True on success, false on failure or if already a member.
  */
 function ec_add_artist_membership( $user_id, $artist_id ) {
-    $user_id  = absint( $user_id );
-    $artist_id = absint( $artist_id );
+	$user_id   = absint( $user_id );
+	$artist_id = absint( $artist_id );
 
-    if ( ! $user_id || ! $artist_id ) {
-        return false;
-    }
+	if ( ! $user_id || ! $artist_id ) {
+		return false;
+	}
 
-    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 
-    // Step 1: Verify artist exists (artist site)
-    try {
-        if ( $artist_blog_id ) {
-            switch_to_blog( $artist_blog_id );
-        }
+	// Step 1: Verify artist exists (artist site)
+	try {
+		if ( $artist_blog_id ) {
+			switch_to_blog( $artist_blog_id );
+		}
 
-        if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-            return false;
-        }
+		if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
+			return false;
+		}
 
-        // Step 2: Update Artist Profile Post Meta (_artist_member_ids on artist_profile post)
-        $current_member_ids_on_artist = get_post_meta( $artist_id, '_artist_member_ids', true );
-        if ( ! is_array( $current_member_ids_on_artist ) ) {
-            $current_member_ids_on_artist = [];
-        }
+		// Step 2: Update Artist Profile Post Meta (_artist_member_ids on artist_profile post)
+		$current_member_ids_on_artist = get_post_meta( $artist_id, '_artist_member_ids', true );
+		if ( ! is_array( $current_member_ids_on_artist ) ) {
+			$current_member_ids_on_artist = array();
+		}
 
-        if ( ! in_array( $user_id, $current_member_ids_on_artist, true ) ) {
-            $current_member_ids_on_artist[] = $user_id;
-            $current_member_ids_on_artist   = array_unique( array_map( 'absint', $current_member_ids_on_artist ) );
-            $current_member_ids_on_artist   = array_values( array_filter( $current_member_ids_on_artist ) );
-            update_post_meta( $artist_id, '_artist_member_ids', $current_member_ids_on_artist );
-        }
-    } finally {
-        if ( $artist_blog_id ) {
-            restore_current_blog();
-        }
-    }
+		if ( ! in_array( $user_id, $current_member_ids_on_artist, true ) ) {
+			$current_member_ids_on_artist[] = $user_id;
+			$current_member_ids_on_artist   = array_unique( array_map( 'absint', $current_member_ids_on_artist ) );
+			$current_member_ids_on_artist   = array_values( array_filter( $current_member_ids_on_artist ) );
+			update_post_meta( $artist_id, '_artist_member_ids', $current_member_ids_on_artist );
+		}
+	} finally {
+		if ( $artist_blog_id ) {
+			restore_current_blog();
+		}
+	}
 
-    // Step 3: Update User Meta (_artist_profile_ids on user)
-    $current_artist_ids_on_user = get_user_meta( $user_id, '_artist_profile_ids', true );
-    if ( ! is_array( $current_artist_ids_on_user ) ) {
-        $current_artist_ids_on_user = [];
-    }
+	// Step 3: Update User Meta (_artist_profile_ids on user)
+	$current_artist_ids_on_user = get_user_meta( $user_id, '_artist_profile_ids', true );
+	if ( ! is_array( $current_artist_ids_on_user ) ) {
+		$current_artist_ids_on_user = array();
+	}
 
-    if ( ! in_array( $artist_id, $current_artist_ids_on_user, true ) ) {
-        $current_artist_ids_on_user[] = $artist_id;
-        $current_artist_ids_on_user   = array_unique( array_map( 'absint', $current_artist_ids_on_user ) );
-        $current_artist_ids_on_user   = array_values( array_filter( $current_artist_ids_on_user ) );
+	if ( ! in_array( $artist_id, $current_artist_ids_on_user, true ) ) {
+		$current_artist_ids_on_user[] = $artist_id;
+		$current_artist_ids_on_user   = array_unique( array_map( 'absint', $current_artist_ids_on_user ) );
+		$current_artist_ids_on_user   = array_values( array_filter( $current_artist_ids_on_user ) );
 
-        if ( ! update_user_meta( $user_id, '_artist_profile_ids', $current_artist_ids_on_user ) ) {
-            return false;
-        }
-    }
+		if ( ! update_user_meta( $user_id, '_artist_profile_ids', $current_artist_ids_on_user ) ) {
+			return false;
+		}
+	}
 
-    return true;
+	return true;
 }
 
 /**
@@ -84,56 +84,56 @@ function ec_add_artist_membership( $user_id, $artist_id ) {
  * @return bool True on success, false on failure.
  */
 function ec_remove_artist_membership( $user_id, $artist_id ) {
-     $user_id  = absint( $user_id );
-     $artist_id = absint( $artist_id );
- 
-     if ( ! $user_id || ! $artist_id ) {
-         return false;
-     }
- 
-     // Step 1: Update User Meta (_artist_profile_ids on user)
-     $current_artist_ids_on_user      = get_user_meta( $user_id, '_artist_profile_ids', true );
-     $user_meta_updated_successfully = true;
- 
-     if ( is_array( $current_artist_ids_on_user ) && ! empty( $current_artist_ids_on_user ) ) {
-         $key_on_user_meta = array_search( $artist_id, $current_artist_ids_on_user, true );
-         if ( $key_on_user_meta !== false ) {
-             unset( $current_artist_ids_on_user[ $key_on_user_meta ] );
-             $current_artist_ids_on_user = array_values( $current_artist_ids_on_user );
-             if ( ! update_user_meta( $user_id, '_artist_profile_ids', $current_artist_ids_on_user ) ) {
-                 $user_meta_updated_successfully = false;
-             }
-         }
-     }
- 
-     $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
- 
-     // Step 2: Update Artist Profile Post Meta (_artist_member_ids on artist_profile post)
-     try {
-         if ( $artist_blog_id ) {
-             switch_to_blog( $artist_blog_id );
-         }
- 
-         $current_member_ids_on_artist = get_post_meta( $artist_id, '_artist_member_ids', true );
-         if ( ! is_array( $current_member_ids_on_artist ) ) {
-             $current_member_ids_on_artist = [];
-         }
- 
-         $key_on_artist_meta = array_search( $user_id, $current_member_ids_on_artist, true );
-         if ( $key_on_artist_meta !== false ) {
-             unset( $current_member_ids_on_artist[ $key_on_artist_meta ] );
-             $current_member_ids_on_artist = array_unique( array_map( 'absint', $current_member_ids_on_artist ) );
-             $current_member_ids_on_artist = array_values( array_filter( $current_member_ids_on_artist ) );
-             update_post_meta( $artist_id, '_artist_member_ids', $current_member_ids_on_artist );
-         }
-     } finally {
-         if ( $artist_blog_id ) {
-             restore_current_blog();
-         }
-     }
- 
-     return $user_meta_updated_successfully;
- }
+	$user_id   = absint( $user_id );
+	$artist_id = absint( $artist_id );
+
+	if ( ! $user_id || ! $artist_id ) {
+		return false;
+	}
+
+	// Step 1: Update User Meta (_artist_profile_ids on user)
+	$current_artist_ids_on_user     = get_user_meta( $user_id, '_artist_profile_ids', true );
+	$user_meta_updated_successfully = true;
+
+	if ( is_array( $current_artist_ids_on_user ) && ! empty( $current_artist_ids_on_user ) ) {
+		$key_on_user_meta = array_search( $artist_id, $current_artist_ids_on_user, true );
+		if ( $key_on_user_meta !== false ) {
+			unset( $current_artist_ids_on_user[ $key_on_user_meta ] );
+			$current_artist_ids_on_user = array_values( $current_artist_ids_on_user );
+			if ( ! update_user_meta( $user_id, '_artist_profile_ids', $current_artist_ids_on_user ) ) {
+				$user_meta_updated_successfully = false;
+			}
+		}
+	}
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+
+	// Step 2: Update Artist Profile Post Meta (_artist_member_ids on artist_profile post)
+	try {
+		if ( $artist_blog_id ) {
+			switch_to_blog( $artist_blog_id );
+		}
+
+		$current_member_ids_on_artist = get_post_meta( $artist_id, '_artist_member_ids', true );
+		if ( ! is_array( $current_member_ids_on_artist ) ) {
+			$current_member_ids_on_artist = array();
+		}
+
+		$key_on_artist_meta = array_search( $user_id, $current_member_ids_on_artist, true );
+		if ( $key_on_artist_meta !== false ) {
+			unset( $current_member_ids_on_artist[ $key_on_artist_meta ] );
+			$current_member_ids_on_artist = array_unique( array_map( 'absint', $current_member_ids_on_artist ) );
+			$current_member_ids_on_artist = array_values( array_filter( $current_member_ids_on_artist ) );
+			update_post_meta( $artist_id, '_artist_member_ids', $current_member_ids_on_artist );
+		}
+	} finally {
+		if ( $artist_blog_id ) {
+			restore_current_blog();
+		}
+	}
+
+	return $user_meta_updated_successfully;
+}
 
 /**
  * Gets users linked to a specific artist profile.
@@ -142,33 +142,33 @@ function ec_remove_artist_membership( $user_id, $artist_id ) {
  * @return array Array of WP_User objects.
  */
 function ec_get_linked_members( $artist_profile_id ) {
-    if ( ! $artist_profile_id ) {
-        return array();
-    }
+	if ( ! $artist_profile_id ) {
+		return array();
+	}
 
-    $serialized_int_fragment = sprintf( 'i:%d;', $artist_profile_id );
-    $string_id = (string) $artist_profile_id;
-    $serialized_str_fragment = sprintf( 's:%d:"%s";', strlen( $string_id ), $string_id );
+	$serialized_int_fragment = sprintf( 'i:%d;', $artist_profile_id );
+	$string_id               = (string) $artist_profile_id;
+	$serialized_str_fragment = sprintf( 's:%d:"%s";', strlen( $string_id ), $string_id );
 
-    $args = array(
-        'meta_query' => array(
-            'relation' => 'OR',
-            array(
-                'key'     => '_artist_profile_ids',
-                'value'   => $serialized_int_fragment,
-                'compare' => 'LIKE'
-            ),
-            array(
-                'key'     => '_artist_profile_ids',
-                'value'   => $serialized_str_fragment,
-                'compare' => 'LIKE'
-            )
-        ),
-        'fields' => 'all',
-    );
-    $user_query = new WP_User_Query( $args );
+	$args       = array(
+		'meta_query' => array(
+			'relation' => 'OR',
+			array(
+				'key'     => '_artist_profile_ids',
+				'value'   => $serialized_int_fragment,
+				'compare' => 'LIKE',
+			),
+			array(
+				'key'     => '_artist_profile_ids',
+				'value'   => $serialized_str_fragment,
+				'compare' => 'LIKE',
+			),
+		),
+		'fields'     => 'all',
+	);
+	$user_query = new WP_User_Query( $args );
 
-    return $user_query->get_results();
+	return $user_query->get_results();
 }
 
 /**
@@ -178,26 +178,26 @@ function ec_get_linked_members( $artist_profile_id ) {
  * @return array Array of artist profile post objects.
  */
 function ec_get_user_artist_memberships( $user_id ) {
-    if ( ! $user_id ) {
-        return array();
-    }
+	if ( ! $user_id ) {
+		return array();
+	}
 
-    $artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
+	$artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
 
-    if ( empty( $artist_ids ) || ! is_array( $artist_ids ) ) {
-        return array();
-    }
+	if ( empty( $artist_ids ) || ! is_array( $artist_ids ) ) {
+		return array();
+	}
 
-    $args = array(
-        'post_type' => 'artist_profile',
-        'post_status' => 'any',
-        'post__in' => $artist_ids,
-        'orderby' => 'title',
-        'order' => 'ASC',
-        'posts_per_page' => -1
-    );
+	$args = array(
+		'post_type'      => 'artist_profile',
+		'post_status'    => 'any',
+		'post__in'       => $artist_ids,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+		'posts_per_page' => -1,
+	);
 
-    return get_posts( $args );
+	return get_posts( $args );
 }
 
 /**
@@ -208,81 +208,92 @@ function ec_get_user_artist_memberships( $user_id ) {
  * @return array|WP_Error Relationship rows or an artist-site configuration error.
  */
 function ec_get_artist_relationships_for_admin( $view = 'artists', $search = '' ) {
-    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-    if ( ! $artist_blog_id ) {
-        return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
-    }
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
+	}
 
-    $view   = 'users' === $view ? 'users' : 'artists';
-    $search = sanitize_text_field( $search );
-    $items  = array();
+	$view   = 'users' === $view ? 'users' : 'artists';
+	$search = sanitize_text_field( $search );
+	$items  = array();
 
-    switch_to_blog( $artist_blog_id );
-    try {
-        if ( 'artists' === $view ) {
-            $args = array(
-                'post_type'      => 'artist_profile',
-                'post_status'    => 'any',
-                'posts_per_page' => 50,
-                'orderby'        => 'title',
-                'order'          => 'ASC',
-            );
-            if ( '' !== $search ) {
-                $args['s'] = $search;
-            }
+	switch_to_blog( $artist_blog_id );
+	try {
+		if ( 'artists' === $view ) {
+			$args = array(
+				'post_type'      => 'artist_profile',
+				'post_status'    => 'any',
+				'posts_per_page' => 50,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			);
+			if ( '' !== $search ) {
+				$args['s'] = $search;
+			}
 
-            foreach ( get_posts( $args ) as $artist ) {
-                $members = array_map(
-                    static function ( $member ) {
-                        return array(
-                            'ID'           => $member->ID,
-                            'user_login'   => $member->user_login,
-                            'display_name' => $member->display_name,
-                        );
-                    },
-                    ec_get_linked_members( $artist->ID )
-                );
-                $items[] = array(
-                    'id'      => $artist->ID,
-                    'title'   => $artist->post_title,
-                    'members' => $members,
-                );
-            }
-        } else {
-            $args = array(
-                'number'     => 50,
-                'meta_query' => array(
-                    'relation' => 'OR',
-                    array( 'key' => 'user_is_artist', 'value' => '1', 'compare' => '=' ),
-                    array( 'key' => 'user_is_professional', 'value' => '1', 'compare' => '=' ),
-                ),
-            );
-            if ( '' !== $search ) {
-                $args['search']         = '*' . $search . '*';
-                $args['search_columns'] = array( 'user_login', 'user_email', 'display_name' );
-            }
+			foreach ( get_posts( $args ) as $artist ) {
+				$members = array_map(
+					static function ( $member ) {
+						return array(
+							'ID'           => $member->ID,
+							'user_login'   => $member->user_login,
+							'display_name' => $member->display_name,
+						);
+					},
+					ec_get_linked_members( $artist->ID )
+				);
+				$items[] = array(
+					'id'      => $artist->ID,
+					'title'   => $artist->post_title,
+					'members' => $members,
+				);
+			}
+		} else {
+			$args = array(
+				'number'     => 50,
+				'meta_query' => array(
+					'relation' => 'OR',
+					array(
+						'key'     => 'user_is_artist',
+						'value'   => '1',
+						'compare' => '=',
+					),
+					array(
+						'key'     => 'user_is_professional',
+						'value'   => '1',
+						'compare' => '=',
+					),
+				),
+			);
+			if ( '' !== $search ) {
+				$args['search']         = '*' . $search . '*';
+				$args['search_columns'] = array( 'user_login', 'user_email', 'display_name' );
+			}
 
-            foreach ( ( new WP_User_Query( $args ) )->get_results() as $user ) {
-                $artists = array_map(
-                    static function ( $artist ) {
-                        return array( 'ID' => $artist->ID, 'post_title' => $artist->post_title );
-                    },
-                    ec_get_user_artist_memberships( $user->ID )
-                );
-                $items[] = array(
-                    'ID'           => $user->ID,
-                    'user_login'   => $user->user_login,
-                    'user_email'   => $user->user_email,
-                    'display_name' => $user->display_name,
-                    'artists'      => $artists,
-                );
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+			foreach ( ( new WP_User_Query( $args ) )->get_results() as $user ) {
+				$artists = array_map(
+					static function ( $artist ) {
+						return array(
+							'ID'         => $artist->ID,
+							'post_title' => $artist->post_title,
+						);
+					},
+					ec_get_user_artist_memberships( $user->ID )
+				);
+				$items[] = array(
+					'ID'           => $user->ID,
+					'user_login'   => $user->user_login,
+					'user_email'   => $user->user_email,
+					'display_name' => $user->display_name,
+					'artists'      => $artists,
+				);
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    return $items;
+	return $items;
 }
 
 /**
@@ -291,35 +302,35 @@ function ec_get_artist_relationships_for_admin( $view = 'artists', $search = '' 
  * @return array|WP_Error Orphan rows or an artist-site configuration error.
  */
 function ec_get_orphaned_artist_relationships() {
-    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-    if ( ! $artist_blog_id ) {
-        return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
-    }
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'no_artist_site', __( 'Artist site not configured.', 'extrachill-artist-platform' ), array( 'status' => 400 ) );
+	}
 
-    $orphans = array();
-    switch_to_blog( $artist_blog_id );
-    try {
-        foreach ( get_users( array( 'meta_key' => '_artist_profile_ids' ) ) as $user ) {
-            $artist_ids = get_user_meta( $user->ID, '_artist_profile_ids', true );
-            if ( ! is_array( $artist_ids ) ) {
-                continue;
-            }
-            foreach ( $artist_ids as $artist_id ) {
-                if ( ! get_post( $artist_id ) || 'artist_profile' !== get_post_type( $artist_id ) ) {
-                    $orphans[] = array(
-                        'user'              => array(
-                            'ID'           => $user->ID,
-                            'user_login'   => $user->user_login,
-                            'display_name' => $user->display_name,
-                        ),
-                        'invalid_artist_id' => $artist_id,
-                    );
-                }
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+	$orphans = array();
+	switch_to_blog( $artist_blog_id );
+	try {
+		foreach ( get_users( array( 'meta_key' => '_artist_profile_ids' ) ) as $user ) {
+			$artist_ids = get_user_meta( $user->ID, '_artist_profile_ids', true );
+			if ( ! is_array( $artist_ids ) ) {
+				continue;
+			}
+			foreach ( $artist_ids as $artist_id ) {
+				if ( ! get_post( $artist_id ) || 'artist_profile' !== get_post_type( $artist_id ) ) {
+					$orphans[] = array(
+						'user'              => array(
+							'ID'           => $user->ID,
+							'user_login'   => $user->user_login,
+							'display_name' => $user->display_name,
+						),
+						'invalid_artist_id' => $artist_id,
+					);
+				}
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    return $orphans;
+	return $orphans;
 }

--- a/inc/artist-profiles/frontend/artist-grid.php
+++ b/inc/artist-profiles/frontend/artist-grid.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Artist Grid Display Functions
- * 
+ *
  * Handles artist profile grid display with activity-based sorting,
  * user exclusion logic, and responsive grid layouts.
  */
@@ -17,29 +17,29 @@ defined( 'ABSPATH' ) || exit;
  * @return int|false Unix timestamp (UTC/GMT) of the latest activity, or false on error.
  */
 function ec_get_artist_profile_last_activity_timestamp( $artist_profile_id ) {
-    $artist_profile_id = absint( $artist_profile_id );
-    if ( ! $artist_profile_id || get_post_type( $artist_profile_id ) !== 'artist_profile' ) {
-        return false;
-    }
+	$artist_profile_id = absint( $artist_profile_id );
+	if ( ! $artist_profile_id || get_post_type( $artist_profile_id ) !== 'artist_profile' ) {
+		return false;
+	}
 
-    // Get profile's last modified timestamp (GMT)
-    $profile_modified_gmt = get_post_modified_time( 'U', true, $artist_profile_id );
-    if ( ! $profile_modified_gmt ) {
-        $profile_modified_gmt = get_post_time( 'U', true, $artist_profile_id );
-    }
-    
-    $latest_activity_timestamp = $profile_modified_gmt ?: 0;
+	// Get profile's last modified timestamp (GMT)
+	$profile_modified_gmt = get_post_modified_time( 'U', true, $artist_profile_id );
+	if ( ! $profile_modified_gmt ) {
+		$profile_modified_gmt = get_post_time( 'U', true, $artist_profile_id );
+	}
 
-    // Check link page activity
-    $link_page_id = apply_filters( 'ec_get_link_page_id', $artist_profile_id );
-    if ( $link_page_id ) {
-        $link_page_modified = get_post_modified_time( 'U', true, $link_page_id );
-        if ( $link_page_modified && $link_page_modified > $latest_activity_timestamp ) {
-            $latest_activity_timestamp = $link_page_modified;
-        }
-    }
+	$latest_activity_timestamp = $profile_modified_gmt ?: 0;
 
-    return $latest_activity_timestamp > 0 ? $latest_activity_timestamp : false;
+	// Check link page activity
+	$link_page_id = apply_filters( 'ec_get_link_page_id', $artist_profile_id );
+	if ( $link_page_id ) {
+		$link_page_modified = get_post_modified_time( 'U', true, $link_page_id );
+		if ( $link_page_modified && $link_page_modified > $latest_activity_timestamp ) {
+			$latest_activity_timestamp = $link_page_modified;
+		}
+	}
+
+	return $latest_activity_timestamp > 0 ? $latest_activity_timestamp : false;
 }
 
 /**
@@ -50,104 +50,106 @@ function ec_get_artist_profile_last_activity_timestamp( $artist_profile_id ) {
  * @param bool $show_pagination     Whether to display pagination below the grid (default: true)
  */
 function ec_display_artist_cards_grid( $limit = 24, $exclude_user_artists = false, $show_pagination = true ) {
-    // Get current page from query var
-    $current_page = max( 1, get_query_var( 'paged', 1 ) );
+	// Get current page from query var
+	$current_page = max( 1, get_query_var( 'paged', 1 ) );
 
-    // Get all published artist profiles for sorting (only IDs for efficiency)
-    $args = array(
-        'post_type'              => 'artist_profile',
-        'post_status'            => 'publish',
-        'posts_per_page'         => -1,
-        'fields'                 => 'ids',
-        'no_found_rows'          => true,
-        'update_post_term_cache' => false,
-        'update_post_meta_cache' => false,
-    );
+	// Get all published artist profiles for sorting (only IDs for efficiency)
+	$args = array(
+		'post_type'              => 'artist_profile',
+		'post_status'            => 'publish',
+		'posts_per_page'         => -1,
+		'fields'                 => 'ids',
+		'no_found_rows'          => true,
+		'update_post_term_cache' => false,
+		'update_post_meta_cache' => false,
+	);
 
-    // Exclude current user's owned artists if requested
-    if ( $exclude_user_artists && is_user_logged_in() ) {
-        $user_artist_ids = ec_get_artists_for_user( get_current_user_id() );
-        if ( ! empty( $user_artist_ids ) ) {
-            $args['post__not_in'] = $user_artist_ids;
-        }
-    }
+	// Exclude current user's owned artists if requested
+	if ( $exclude_user_artists && is_user_logged_in() ) {
+		$user_artist_ids = ec_get_artists_for_user( get_current_user_id() );
+		if ( ! empty( $user_artist_ids ) ) {
+			$args['post__not_in'] = $user_artist_ids;
+		}
+	}
 
-    $artist_ids = get_posts( $args );
+	$artist_ids = get_posts( $args );
 
-    if ( empty( $artist_ids ) ) {
-        echo '<div class="no-artists-found">';
-        echo '<p>' . esc_html__( 'No artists have joined the platform yet.', 'extrachill-artist-platform' ) . '</p>';
-        if ( is_user_logged_in() && ec_can_create_artist_profiles( get_current_user_id() ) ) {
-            echo '<p><a href="' . esc_url( home_url( '/create-artist/' ) ) . '" class="button">';
-            echo esc_html__( 'Create the First Artist Profile', 'extrachill-artist-platform' );
-            echo '</a></p>';
-        }
-        echo '</div>';
-        return;
-    }
+	if ( empty( $artist_ids ) ) {
+		echo '<div class="no-artists-found">';
+		echo '<p>' . esc_html__( 'No artists have joined the platform yet.', 'extrachill-artist-platform' ) . '</p>';
+		if ( is_user_logged_in() && ec_can_create_artist_profiles( get_current_user_id() ) ) {
+			echo '<p><a href="' . esc_url( home_url( '/create-artist/' ) ) . '" class="button">';
+			echo esc_html__( 'Create the First Artist Profile', 'extrachill-artist-platform' );
+			echo '</a></p>';
+		}
+		echo '</div>';
+		return;
+	}
 
-    // Create array with activity timestamps for sorting
-    $artists_with_activity = array();
-    foreach ( $artist_ids as $artist_profile_id ) {
-        $activity_timestamp      = ec_get_artist_profile_last_activity_timestamp( $artist_profile_id );
-        $artists_with_activity[] = array(
-            'id'       => $artist_profile_id,
-            'activity' => $activity_timestamp ?: 0,
-        );
-    }
+	// Create array with activity timestamps for sorting
+	$artists_with_activity = array();
+	foreach ( $artist_ids as $artist_profile_id ) {
+		$activity_timestamp      = ec_get_artist_profile_last_activity_timestamp( $artist_profile_id );
+		$artists_with_activity[] = array(
+			'id'       => $artist_profile_id,
+			'activity' => $activity_timestamp ?: 0,
+		);
+	}
 
-    // Sort by activity (most recent first)
-    usort( $artists_with_activity, function( $a, $b ) {
-        return $b['activity'] - $a['activity'];
-    });
+	// Sort by activity (most recent first)
+	usort(
+		$artists_with_activity,
+		function ( $a, $b ) {
+			return $b['activity'] - $a['activity'];
+		}
+	);
 
-    // Extract sorted IDs
-    $sorted_artist_ids = wp_list_pluck( $artists_with_activity, 'id' );
+	// Extract sorted IDs
+	$sorted_artist_ids = wp_list_pluck( $artists_with_activity, 'id' );
 
-    // Calculate pagination
-    $total_artists = count( $sorted_artist_ids );
-    $total_pages   = ceil( $total_artists / $limit );
-    $current_page  = max( 1, min( $current_page, $total_pages ) );
-    $offset        = ( $current_page - 1 ) * $limit;
+	// Calculate pagination
+	$total_artists = count( $sorted_artist_ids );
+	$total_pages   = ceil( $total_artists / $limit );
+	$current_page  = max( 1, min( $current_page, $total_pages ) );
+	$offset        = ( $current_page - 1 ) * $limit;
 
-    // Get artists for current page
-    $paged_artist_ids = array_slice( $sorted_artist_ids, $offset, $limit );
+	// Get artists for current page
+	$paged_artist_ids = array_slice( $sorted_artist_ids, $offset, $limit );
 
-    // Create WP_Query for proper pagination support
-    $query_args = array(
-        'post_type'      => 'artist_profile',
-        'post_status'    => 'publish',
-        'post__in'       => $paged_artist_ids,
-        'orderby'        => 'post__in', // Preserve our custom sorting
-        'posts_per_page' => count( $paged_artist_ids ),
-        'paged'          => $current_page,
-    );
+	// Create WP_Query for proper pagination support
+	$query_args = array(
+		'post_type'      => 'artist_profile',
+		'post_status'    => 'publish',
+		'post__in'       => $paged_artist_ids,
+		'orderby'        => 'post__in', // Preserve our custom sorting
+		'posts_per_page' => count( $paged_artist_ids ),
+		'paged'          => $current_page,
+	);
 
-    $artists_query = new WP_Query( $query_args );
+	$artists_query = new WP_Query( $query_args );
 
-    echo '<div class="artist-directory-grid">';
+	echo '<div class="artist-directory-grid">';
 
-    echo '<div class="artist-cards-grid">';
-    if ( $artists_query->have_posts() ) {
-        while ( $artists_query->have_posts() ) {
-            $artists_query->the_post();
-            include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/artist-card.php';
-        }
-        wp_reset_postdata();
-    }
-    echo '</div>';
+	echo '<div class="artist-cards-grid">';
+	if ( $artists_query->have_posts() ) {
+		while ( $artists_query->have_posts() ) {
+			$artists_query->the_post();
+			include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/artist-card.php';
+		}
+		wp_reset_postdata();
+	}
+	echo '</div>';
 
-    if ( $show_pagination && $total_pages > 1 ) {
-        $pagination_query                                = new WP_Query();
-        $pagination_query->max_num_pages                 = $total_pages;
-        $pagination_query->found_posts                   = $total_artists;
-        $pagination_query->query_vars['posts_per_page']  = $limit;
+	if ( $show_pagination && $total_pages > 1 ) {
+		$pagination_query                               = new WP_Query();
+		$pagination_query->max_num_pages                = $total_pages;
+		$pagination_query->found_posts                  = $total_artists;
+		$pagination_query->query_vars['posts_per_page'] = $limit;
 
-        echo '<div class="artist-grid-pagination">';
-        extrachill_pagination( $pagination_query, 'artist-archive', 'artist' );
-        echo '</div>';
-    }
+		echo '<div class="artist-grid-pagination">';
+		extrachill_pagination( $pagination_query, 'artist-archive', 'artist' );
+		echo '</div>';
+	}
 
-    echo '</div>';
-
+	echo '</div>';
 }

--- a/inc/artist-profiles/frontend/breadcrumbs.php
+++ b/inc/artist-profiles/frontend/breadcrumbs.php
@@ -76,11 +76,11 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_artist_profile_archive_
  * @return string Empty string
  */
 function ec_artist_profile_breadcrumb_override( $custom_trail ) {
-    if ( ! is_singular( 'artist_profile' ) ) {
-        return $custom_trail;
-    }
+	if ( ! is_singular( 'artist_profile' ) ) {
+		return $custom_trail;
+	}
 
-    return '';
+	return '';
 }
 add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_artist_profile_breadcrumb_override' );
 
@@ -95,12 +95,12 @@ add_filter( 'extrachill_breadcrumbs_override_trail', 'ec_artist_profile_breadcru
  * @return string Modified label
  */
 function ec_artist_platform_back_to_home_label( $label, $url ) {
-    // Don't override on homepage (homepage should say "Back to Extra Chill")
-    if ( is_front_page() ) {
-        return $label;
-    }
+	// Don't override on homepage (homepage should say "Back to Extra Chill")
+	if ( is_front_page() ) {
+		return $label;
+	}
 
-    return '← Back to Artist Platform';
+	return '← Back to Artist Platform';
 }
 add_filter( 'extrachill_back_to_home_label', 'ec_artist_platform_back_to_home_label', 10, 2 );
 

--- a/inc/artist-profiles/frontend/coverage-section.php
+++ b/inc/artist-profiles/frontend/coverage-section.php
@@ -360,7 +360,10 @@ function ec_render_artist_profile_coverage_section( $artist_id, $artist_term_id 
 					<div class="related-tax-meta">
 						<?php if ( ! empty( $card['date_str'] ) ) : ?>
 							<div class="ec-related-meta-item">
-								<?php if ( function_exists( 'ec_icon' ) ) { echo ec_icon( 'calendar' ); } // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+								<?php
+								if ( function_exists( 'ec_icon' ) ) {
+								echo ec_icon( 'calendar' ); } // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								?>
 								<span><?php echo esc_html( $card['date_str'] ); ?></span>
 							</div>
 						<?php endif; ?>

--- a/inc/artist-profiles/frontend/default-sections.php
+++ b/inc/artist-profiles/frontend/default-sections.php
@@ -36,23 +36,23 @@ defined( 'ABSPATH' ) || exit;
  * @return array[]
  */
 function ec_register_default_artist_profile_sections( $sections, $artist_id, $artist_term_id ) {
-    $sections[] = array(
-        'id'       => 'hero',
-        'label'    => __( 'Overview', 'extrachill-artist-platform' ),
-        'priority' => 10,
-        'as_tab'   => false,
-        'render'   => 'ec_render_artist_profile_hero_section',
-    );
+	$sections[] = array(
+		'id'       => 'hero',
+		'label'    => __( 'Overview', 'extrachill-artist-platform' ),
+		'priority' => 10,
+		'as_tab'   => false,
+		'render'   => 'ec_render_artist_profile_hero_section',
+	);
 
-    $sections[] = array(
-        'id'       => 'overview',
-        'label'    => __( 'About', 'extrachill-artist-platform' ),
-        'priority' => 20,
-        'as_tab'   => false,
-        'render'   => 'ec_render_artist_profile_overview_section',
-    );
+	$sections[] = array(
+		'id'       => 'overview',
+		'label'    => __( 'About', 'extrachill-artist-platform' ),
+		'priority' => 20,
+		'as_tab'   => false,
+		'render'   => 'ec_render_artist_profile_overview_section',
+	);
 
-    return $sections;
+	return $sections;
 }
 add_filter( 'ec_artist_profile_sections', 'ec_register_default_artist_profile_sections', 10, 3 );
 
@@ -67,122 +67,126 @@ add_filter( 'ec_artist_profile_sections', 'ec_register_default_artist_profile_se
  * @return void
  */
 function ec_render_artist_profile_hero_section( $artist_profile_id, $artist_term_id = 0 ) {
-    $genre      = get_post_meta( $artist_profile_id, '_genre', true );
-    $local_city = get_post_meta( $artist_profile_id, '_local_city', true );
+	$genre      = get_post_meta( $artist_profile_id, '_genre', true );
+	$local_city = get_post_meta( $artist_profile_id, '_local_city', true );
 
-    // Prepare for Hero Section
-    $hero_background_style = '';
-    $header_image_id = get_post_meta( $artist_profile_id, '_artist_profile_header_image_id', true );
+	// Prepare for Hero Section
+	$hero_background_style = '';
+	$header_image_id       = get_post_meta( $artist_profile_id, '_artist_profile_header_image_id', true );
 
-    if ( $header_image_id ) {
-        $image_url = wp_get_attachment_image_url( $header_image_id, 'full' ); // Or 'large', depending on desired size
-        if ( $image_url ) {
-            $hero_background_style = 'style="background-image: url(\'' . esc_url( $image_url ) . '\');"';
-        }
-    } else {
-        // Fallback for no specific header image; class-based styling can apply
-        $hero_background_style = '';
-    }
-    ?>
+	if ( $header_image_id ) {
+		$image_url = wp_get_attachment_image_url( $header_image_id, 'full' ); // Or 'large', depending on desired size
+		if ( $image_url ) {
+			$hero_background_style = 'style="background-image: url(\'' . esc_url( $image_url ) . '\');"';
+		}
+	} else {
+		// Fallback for no specific header image; class-based styling can apply
+		$hero_background_style = '';
+	}
+	?>
 
-                        <div class="artist-profile-header artist-hero" <?php echo $hero_background_style; ?>>
-                            <div class="artist-hero-overlay"></div>
-                            <div class="artist-hero-content">
-                                <?php
-                                // --- Manage Artist Button (Moved to top of hero content) ---
-                                if ( is_user_logged_in() ) :
-                                    // Display "Manage Artist Profile" button if the current user can manage members for this artist profile.
-                                    // This uses the custom capability 'manage_artist_members'.
-                                    if ( ec_can_manage_artist( get_current_user_id(), $artist_profile_id ) ) :
-                                        $manage_artist_url = get_permalink( get_page_by_path( 'manage-artist' ) );
-                                        if ( $manage_artist_url ) {
-                                            echo '<div class="artist-profile-actions">';
-                                            echo '<a href="' . esc_url( $manage_artist_url ) . '" class="button-2 button-medium artist-manage-button">Manage Artist</a>';
-                                            echo '</div>';
-                                        }
-                                    endif;
-                                endif;
-                                // --- End Manage Artist Button (Moved) ---
-                                ?>
-                                <?php // Display Profile Picture and then Title/Meta in a flex row
-                                // The artist-hero-top-row container helps to align the image and the text content side-by-side.
-                                ?>
-                                <div class="artist-hero-top-row">
-                                    <?php if ( has_post_thumbnail( $artist_profile_id ) ) : ?>
-                                        <div class="artist-profile-featured-image">
-                                            <?php echo get_the_post_thumbnail( $artist_profile_id, 'medium' ); // This is the actual profile picture ?>
-                                        </div>
-                                    <?php endif; ?>
-                                    <div class="artist-hero-text-content">
-                                        <h1 class="artist-hero-title" itemprop="headline"><?php echo esc_html( get_the_title( $artist_profile_id ) ); ?></h1>
+						<div class="artist-profile-header artist-hero" <?php echo $hero_background_style; ?>>
+							<div class="artist-hero-overlay"></div>
+							<div class="artist-hero-content">
+								<?php
+								// --- Manage Artist Button (Moved to top of hero content) ---
+								if ( is_user_logged_in() ) :
+									// Display "Manage Artist Profile" button if the current user can manage members for this artist profile.
+									// This uses the custom capability 'manage_artist_members'.
+									if ( ec_can_manage_artist( get_current_user_id(), $artist_profile_id ) ) :
+										$manage_artist_url = get_permalink( get_page_by_path( 'manage-artist' ) );
+										if ( $manage_artist_url ) {
+											echo '<div class="artist-profile-actions">';
+											echo '<a href="' . esc_url( $manage_artist_url ) . '" class="button-2 button-medium artist-manage-button">Manage Artist</a>';
+											echo '</div>';
+										}
+									endif;
+								endif;
+								// --- End Manage Artist Button (Moved) ---
+								?>
+								<?php
+								// Display Profile Picture and then Title/Meta in a flex row
+								// The artist-hero-top-row container helps to align the image and the text content side-by-side.
+								?>
+								<div class="artist-hero-top-row">
+									<?php if ( has_post_thumbnail( $artist_profile_id ) ) : ?>
+										<div class="artist-profile-featured-image">
+											<?php echo get_the_post_thumbnail( $artist_profile_id, 'medium' ); // This is the actual profile picture ?>
+										</div>
+									<?php endif; ?>
+									<div class="artist-hero-text-content">
+										<h1 class="artist-hero-title" itemprop="headline"><?php echo esc_html( get_the_title( $artist_profile_id ) ); ?></h1>
 
-                                        <?php if ( ! empty( $genre ) || ! empty( $local_city ) ) : ?>
-                                            <p class="artist-meta-info">
-                                                <?php if ( ! empty( $genre ) ) : ?>
-                                                    <span class="artist-genre"><strong><?php esc_html_e( 'Genre:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $genre ); ?></span>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $genre ) && ! empty( $local_city ) ) : ?>
-                                                    <span class="artist-meta-separator">|</span>
-                                                <?php endif; ?>
-                                                <?php if ( ! empty( $local_city ) ) : ?>
-                                                    <span class="artist-local-scene"><strong><?php esc_html_e( 'Local Scene:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $local_city ); ?></span>
-                                                <?php endif; ?>
-                                            </p>
-                                        <?php endif; ?>
-                                    </div>
-                                </div>
+										<?php if ( ! empty( $genre ) || ! empty( $local_city ) ) : ?>
+											<p class="artist-meta-info">
+												<?php if ( ! empty( $genre ) ) : ?>
+													<span class="artist-genre"><strong><?php esc_html_e( 'Genre:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $genre ); ?></span>
+												<?php endif; ?>
+												<?php if ( ! empty( $genre ) && ! empty( $local_city ) ) : ?>
+													<span class="artist-meta-separator">|</span>
+												<?php endif; ?>
+												<?php if ( ! empty( $local_city ) ) : ?>
+													<span class="artist-local-scene"><strong><?php esc_html_e( 'Local Scene:', 'extrachill-artist-platform' ); ?></strong> <?php echo esc_html( $local_city ); ?></span>
+												<?php endif; ?>
+											</p>
+										<?php endif; ?>
+									</div>
+								</div>
 
-                                <?php
-                                // Use centralized social links rendering
-                                $social_manager = extrachill_artist_platform_social_links();
-                                echo $social_manager->render_social_icons( $artist_profile_id, array(
-                                    'container_class' => 'artist-social-links',
-                                    'icon_class' => 'extrch-social-icon'
-                                ) );
-                                ?>
+								<?php
+								// Use centralized social links rendering
+								$social_manager = extrachill_artist_platform_social_links();
+								echo $social_manager->render_social_icons(
+									$artist_profile_id,
+									array(
+										'container_class' => 'artist-social-links',
+										'icon_class'      => 'extrch-social-icon',
+									)
+								);
+								?>
 
-                                <?php
-                                // --- Display Artist Link Page URL (New) ---
-                                $link_page_id_for_url_display = apply_filters('ec_get_link_page_id', $artist_profile_id);
-                                if ( $link_page_id_for_url_display && get_post_type( $link_page_id_for_url_display ) === 'artist_link_page' ) {
-                                    global $post; // Ensure $post is the artist_profile CPT object
-                                    if ( isset( $post ) && $post->post_type === 'artist_profile' ) {
-                                        $artist_slug_for_url = $post->post_name;
-                                        $public_url_href = '';
-                                        $public_url_display_text = '';
+								<?php
+								// --- Display Artist Link Page URL (New) ---
+								$link_page_id_for_url_display = apply_filters( 'ec_get_link_page_id', $artist_profile_id );
+								if ( $link_page_id_for_url_display && get_post_type( $link_page_id_for_url_display ) === 'artist_link_page' ) {
+									global $post; // Ensure $post is the artist_profile CPT object
+									if ( isset( $post ) && $post->post_type === 'artist_profile' ) {
+										$artist_slug_for_url     = $post->post_name;
+										$public_url_href         = '';
+										$public_url_display_text = '';
 
-                                        if ( defined('EXTRCH_LINKPAGE_DEV') && EXTRCH_LINKPAGE_DEV ) {
-                                            $public_url_href = get_permalink( $link_page_id_for_url_display );
-                                        } else {
-                                            // Use canonical extrachill.link URL
-                                            $public_url_href = 'https://extrachill.link/' . $artist_slug_for_url;
-                                        }
+										if ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV ) {
+											$public_url_href = get_permalink( $link_page_id_for_url_display );
+										} else {
+											// Use canonical extrachill.link URL
+											$public_url_href = 'https://extrachill.link/' . $artist_slug_for_url;
+										}
 
-                                        if ( ! empty( $public_url_href ) ) {
-                                            $public_url_display_text = preg_replace( '#^https?://#', '', $public_url_href );
+										if ( ! empty( $public_url_href ) ) {
+											$public_url_display_text = preg_replace( '#^https?://#', '', $public_url_href );
 
-                                            echo '<div class="artist-public-link-display">';
-                                            echo '<a href="' . esc_url( $public_url_href ) . '" class="button-3 button-medium" rel="ugc noopener">' . esc_html( $public_url_display_text ) . '</a>';
-                                            echo '</div>';
-                                        }
-                                    }
-                                }
-                                // --- End Display Artist Link Page URL (New) ---
-                                ?>
+											echo '<div class="artist-public-link-display">';
+											echo '<a href="' . esc_url( $public_url_href ) . '" class="button-3 button-medium" rel="ugc noopener">' . esc_html( $public_url_display_text ) . '</a>';
+											echo '</div>';
+										}
+									}
+								}
+								// --- End Display Artist Link Page URL (New) ---
+								?>
 
-                            </div>
-                        </div>
+							</div>
+						</div>
 
-                        <?php
-                        /**
-                         * generate_after_entry_title hook.
-                         *
-                         * @since 0.1
-                         * @hooked generate_post_meta - 10
-                         */
-                        // do_action( 'generate_after_entry_title' ); // Maybe hide default meta?
-                        ?>
-<?php
+						<?php
+						/**
+						 * generate_after_entry_title hook.
+						 *
+						 * @since 0.1
+						 * @hooked generate_post_meta - 10
+						 */
+						// do_action( 'generate_after_entry_title' ); // Maybe hide default meta?
+						?>
+	<?php
 }
 
 /**
@@ -197,24 +201,24 @@ function ec_render_artist_profile_hero_section( $artist_profile_id, $artist_term
  * @return void
  */
 function ec_render_artist_profile_overview_section( $artist_profile_id, $artist_term_id = 0 ) {
-    ?>
-                        <div class="entry-content" itemprop="text">
-                            <?php
-                            // --- Artist Bio Section ---
-                            $artist_name = get_the_title( $artist_profile_id );
-                            $artist_bio = get_post_field( 'post_content', $artist_profile_id );
+	?>
+						<div class="entry-content" itemprop="text">
+							<?php
+							// --- Artist Bio Section ---
+							$artist_name = get_the_title( $artist_profile_id );
+							$artist_bio  = get_post_field( 'post_content', $artist_profile_id );
 
-                            echo '<div class="artist-bio-section">';
-                            echo '<h2 class="section-title">' . esc_html( sprintf( __( 'About %s', 'extrachill-artist-platform' ), $artist_name ) ) . '</h2>';
-                            if ( ! empty( $artist_bio ) ) {
-                                echo '<div class="artist-bio">';
-                                echo wpautop( $artist_bio );
-                                echo '</div>';
-                            } else {
-                                echo '<p>' . __( 'No biography available yet.', 'extrachill-artist-platform' ) . '</p>';
-                            }
-                            echo '</div>'; // .artist-bio-section
-                            ?>
-                        </div><!-- .entry-content -->
-<?php
+							echo '<div class="artist-bio-section">';
+							echo '<h2 class="section-title">' . esc_html( sprintf( __( 'About %s', 'extrachill-artist-platform' ), $artist_name ) ) . '</h2>';
+							if ( ! empty( $artist_bio ) ) {
+								echo '<div class="artist-bio">';
+								echo wpautop( $artist_bio );
+								echo '</div>';
+							} else {
+								echo '<p>' . __( 'No biography available yet.', 'extrachill-artist-platform' ) . '</p>';
+							}
+							echo '</div>'; // .artist-bio-section
+							?>
+						</div><!-- .entry-content -->
+	<?php
 }

--- a/inc/artist-profiles/frontend/section-registry.php
+++ b/inc/artist-profiles/frontend/section-registry.php
@@ -46,59 +46,62 @@ defined( 'ABSPATH' ) || exit;
  * @return array[] Ordered list of normalized section arrays.
  */
 function ec_get_artist_profile_sections( $artist_id, $artist_term_id = null ) {
-    $artist_id = (int) $artist_id;
-    if ( $artist_id <= 0 ) {
-        return array();
-    }
+	$artist_id = (int) $artist_id;
+	if ( $artist_id <= 0 ) {
+		return array();
+	}
 
-    if ( null === $artist_term_id ) {
-        $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
-    }
-    $artist_term_id = (int) $artist_term_id;
+	if ( null === $artist_term_id ) {
+		$artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
+	}
+	$artist_term_id = (int) $artist_term_id;
 
-    /**
-     * Filter the artist profile sections.
-     *
-     * @param array[] $sections       Registered sections.
-     * @param int     $artist_id      Artist profile post ID.
-     * @param int     $artist_term_id Bound main-blog `artist` term_id (0 if unbound).
-     */
-    $sections = apply_filters( 'ec_artist_profile_sections', array(), $artist_id, $artist_term_id );
+	/**
+	 * Filter the artist profile sections.
+	 *
+	 * @param array[] $sections       Registered sections.
+	 * @param int     $artist_id      Artist profile post ID.
+	 * @param int     $artist_term_id Bound main-blog `artist` term_id (0 if unbound).
+	 */
+	$sections = apply_filters( 'ec_artist_profile_sections', array(), $artist_id, $artist_term_id );
 
-    if ( ! is_array( $sections ) ) {
-        return array();
-    }
+	if ( ! is_array( $sections ) ) {
+		return array();
+	}
 
-    // Normalize, drop invalid entries, apply visibility gating.
-    $normalized = array();
-    foreach ( $sections as $section ) {
-        if ( ! is_array( $section ) || empty( $section['id'] ) || empty( $section['render'] ) || ! is_callable( $section['render'] ) ) {
-            continue;
-        }
+	// Normalize, drop invalid entries, apply visibility gating.
+	$normalized = array();
+	foreach ( $sections as $section ) {
+		if ( ! is_array( $section ) || empty( $section['id'] ) || empty( $section['render'] ) || ! is_callable( $section['render'] ) ) {
+			continue;
+		}
 
-        $section['id']       = (string) $section['id'];
-        $section['label']    = isset( $section['label'] ) ? (string) $section['label'] : '';
-        $section['priority'] = isset( $section['priority'] ) ? (int) $section['priority'] : 10;
-        $section['as_tab']   = ! empty( $section['as_tab'] );
+		$section['id']       = (string) $section['id'];
+		$section['label']    = isset( $section['label'] ) ? (string) $section['label'] : '';
+		$section['priority'] = isset( $section['priority'] ) ? (int) $section['priority'] : 10;
+		$section['as_tab']   = ! empty( $section['as_tab'] );
 
-        if ( isset( $section['visible'] ) && is_callable( $section['visible'] ) ) {
-            if ( ! call_user_func( $section['visible'], $artist_id, $artist_term_id ) ) {
-                continue;
-            }
-        }
+		if ( isset( $section['visible'] ) && is_callable( $section['visible'] ) ) {
+			if ( ! call_user_func( $section['visible'], $artist_id, $artist_term_id ) ) {
+				continue;
+			}
+		}
 
-        $normalized[] = $section;
-    }
+		$normalized[] = $section;
+	}
 
-    // Stable sort by priority.
-    usort( $normalized, function ( $a, $b ) {
-        if ( $a['priority'] === $b['priority'] ) {
-            return 0;
-        }
-        return ( $a['priority'] < $b['priority'] ) ? -1 : 1;
-    } );
+	// Stable sort by priority.
+	usort(
+		$normalized,
+		function ( $a, $b ) {
+			if ( $a['priority'] === $b['priority'] ) {
+				return 0;
+			}
+			return ( $a['priority'] < $b['priority'] ) ? -1 : 1;
+		}
+	);
 
-    return $normalized;
+	return $normalized;
 }
 
 /**
@@ -114,18 +117,18 @@ function ec_get_artist_profile_sections( $artist_id, $artist_term_id = null ) {
  * @return void
  */
 function ec_render_artist_profile_sections( $artist_id, $artist_term_id = null ) {
-    $artist_id = (int) $artist_id;
-    if ( $artist_id <= 0 ) {
-        return;
-    }
+	$artist_id = (int) $artist_id;
+	if ( $artist_id <= 0 ) {
+		return;
+	}
 
-    if ( null === $artist_term_id ) {
-        $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
-    }
-    $artist_term_id = (int) $artist_term_id;
+	if ( null === $artist_term_id ) {
+		$artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_id ) : 0;
+	}
+	$artist_term_id = (int) $artist_term_id;
 
-    $sections = ec_get_artist_profile_sections( $artist_id, $artist_term_id );
-    foreach ( $sections as $section ) {
-        call_user_func( $section['render'], $artist_id, $artist_term_id );
-    }
+	$sections = ec_get_artist_profile_sections( $artist_id, $artist_term_id );
+	foreach ( $sections as $section ) {
+		call_user_func( $section['render'], $artist_id, $artist_term_id );
+	}
 }

--- a/inc/artist-profiles/frontend/shows-section.php
+++ b/inc/artist-profiles/frontend/shows-section.php
@@ -143,7 +143,7 @@ function ec_artist_shows_gather( $artist_term_id ) {
 		return $memo[ $artist_term_id ];
 	}
 
-	$empty = array(
+	$empty                   = array(
 		'upcoming' => array(),
 		'past'     => array(),
 	);
@@ -194,7 +194,7 @@ function ec_artist_shows_gather( $artist_term_id ) {
 		return $empty;
 	}
 
-	$found = array(
+	$found                   = array(
 		'upcoming' => isset( $result['upcoming'] ) && is_array( $result['upcoming'] ) ? $result['upcoming'] : array(),
 		'past'     => isset( $result['past'] ) && is_array( $result['past'] ) ? $result['past'] : array(),
 	);

--- a/inc/artist-profiles/frontend/templates/archive-artist_profile.php
+++ b/inc/artist-profiles/frontend/templates/archive-artist_profile.php
@@ -17,13 +17,13 @@ get_header();
 <?php extrachill_breadcrumbs(); ?>
 
 <div class="ec-edge-gutter">
-    <header class="page-header">
-        <h1 class="page-title"><?php esc_html_e( 'Artist Directory', 'extrachill-artist-platform' ); ?></h1>
-    </header>
+	<header class="page-header">
+		<h1 class="page-title"><?php esc_html_e( 'Artist Directory', 'extrachill-artist-platform' ); ?></h1>
+	</header>
 
-    <div class="taxonomy-description">
-        <p><?php esc_html_e( 'These are all the artists who are part of the Extra Chill Artist Platform. Explore and get to know them below.', 'extrachill-artist-platform' ); ?></p>
-    </div>
+	<div class="taxonomy-description">
+		<p><?php esc_html_e( 'These are all the artists who are part of the Extra Chill Artist Platform. Explore and get to know them below.', 'extrachill-artist-platform' ); ?></p>
+	</div>
 </div>
 
 
@@ -33,9 +33,9 @@ do_action( 'extrachill_archive_above_posts' );
 ?>
 
 <div class="full-width-breakout ec-mobile-full-width-panel">
-    <div class="article-container">
-        <?php ec_display_artist_cards_grid( 24, false, true ); ?>
-    </div>
+	<div class="article-container">
+		<?php ec_display_artist_cards_grid( 24, false, true ); ?>
+	</div>
 </div>
 
 <?php do_action( 'extrachill_after_body_content' ); ?>

--- a/inc/artist-profiles/frontend/templates/artist-card.php
+++ b/inc/artist-profiles/frontend/templates/artist-card.php
@@ -15,14 +15,14 @@ defined( 'ABSPATH' ) || exit;
 
 $template_artist_id = 0;
 if ( isset( $args ) && is_array( $args ) && array_key_exists( 'artist_id', $args ) ) {
-    $template_artist_id = absint( $args['artist_id'] );
+	$template_artist_id = absint( $args['artist_id'] );
 }
 
 $artist_id = $template_artist_id ? $template_artist_id : get_the_ID();
 
 $artist_post = get_post( $artist_id );
 if ( ! $artist_post ) {
-    return;
+	return;
 }
 
 $artist_name = $artist_post->post_title;
@@ -30,19 +30,19 @@ $artist_url  = get_permalink( $artist_id );
 $artist_bio  = $artist_post->post_content;
 
 $profile_image_id = get_post_thumbnail_id( $artist_id );
-$profile_image     = '';
+$profile_image    = '';
 if ( $profile_image_id ) {
-    $profile_image = wp_get_attachment_image(
-        $profile_image_id,
-        'thumbnail',
-        false,
-        array(
-            'alt'      => wp_strip_all_tags( $artist_name ),
-            'loading'  => 'lazy',
-            'decoding' => 'async',
-            'sizes'    => '(max-width: 480px) 50px, 60px',
-        )
-    );
+	$profile_image = wp_get_attachment_image(
+		$profile_image_id,
+		'thumbnail',
+		false,
+		array(
+			'alt'      => wp_strip_all_tags( $artist_name ),
+			'loading'  => 'lazy',
+			'decoding' => 'async',
+			'sizes'    => '(max-width: 480px) 50px, 60px',
+		)
+	);
 }
 
 $header_image_id  = get_post_meta( $artist_id, '_artist_profile_header_image_id', true );
@@ -55,59 +55,64 @@ $hero_style = $header_image_url ? 'background-image: url(' . esc_url( $header_im
 ?>
 
 <div class="artist-profile-card">
-    <div class="artist-hero-section" <?php if ($hero_style) echo 'style="' . esc_attr($hero_style) . '"'; ?>>
-        <div class="artist-hero-overlay"></div>
-        <div class="artist-hero-content">
-            <?php if ( $profile_image ) : ?>
-                <div class="artist-profile-image-overlay">
-                    <?php echo wp_kses_post( $profile_image ); ?>
-                </div>
-            <?php endif; ?>
+	<div class="artist-hero-section"
+	<?php
+	if ( $hero_style ) {
+		echo 'style="' . esc_attr( $hero_style ) . '"';}
+	?>
+	>
+		<div class="artist-hero-overlay"></div>
+		<div class="artist-hero-content">
+			<?php if ( $profile_image ) : ?>
+				<div class="artist-profile-image-overlay">
+					<?php echo wp_kses_post( $profile_image ); ?>
+				</div>
+			<?php endif; ?>
 
-            <div class="artist-info-overlay">
-                <h4 class="artist-name">
-                    <a href="<?php echo esc_url($artist_url); ?>"><?php echo esc_html($artist_name); ?></a>
-                </h4>
+			<div class="artist-info-overlay">
+				<h4 class="artist-name">
+					<a href="<?php echo esc_url( $artist_url ); ?>"><?php echo esc_html( $artist_name ); ?></a>
+				</h4>
 
-                <?php if ($genre || $local_city) : ?>
-                    <div class="artist-meta">
-                        <?php if ($genre) : ?>
-                            <span class="artist-genre"><?php echo esc_html($genre); ?></span>
-                        <?php endif; ?>
-                        <?php if ($genre && $local_city) : ?>
-                            <span class="meta-separator">•</span>
-                        <?php endif; ?>
-                        <?php if ($local_city) : ?>
-                            <span class="artist-location"><?php echo esc_html($local_city); ?></span>
-                        <?php endif; ?>
-                    </div>
-                <?php endif; ?>
-            </div>
-        </div>
-    </div>
+				<?php if ( $genre || $local_city ) : ?>
+					<div class="artist-meta">
+						<?php if ( $genre ) : ?>
+							<span class="artist-genre"><?php echo esc_html( $genre ); ?></span>
+						<?php endif; ?>
+						<?php if ( $genre && $local_city ) : ?>
+							<span class="meta-separator">•</span>
+						<?php endif; ?>
+						<?php if ( $local_city ) : ?>
+							<span class="artist-location"><?php echo esc_html( $local_city ); ?></span>
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
 
-    <div class="artist-card-content">
-        <?php if ($artist_bio) : ?>
-            <div class="artist-card-bio">
-                <p><?php echo esc_html(wp_trim_words($artist_bio, 15, '...')); ?></p>
-            </div>
-        <?php endif; ?>
+	<div class="artist-card-content">
+		<?php if ( $artist_bio ) : ?>
+			<div class="artist-card-bio">
+				<p><?php echo esc_html( wp_trim_words( $artist_bio, 15, '...' ) ); ?></p>
+			</div>
+		<?php endif; ?>
 
-        <div class="artist-card-actions">
-            <a href="<?php echo esc_url($artist_url); ?>" class="button-1 button-medium" data-action-button>
-                <?php esc_html_e('View Profile', 'extrachill-artist-platform'); ?>
-            </a>
-            <?php
-            /**
-             * Action hook for extending artist card actions
-             *
-             * Allows other parts of the plugin to add additional buttons or actions
-             * to the artist card based on context (homepage, directory, etc.)
-             *
-             * @param int $artist_id The artist profile post ID
-             */
-            do_action('ec_artist_card_actions', $artist_id);
-            ?>
-        </div>
-    </div>
+		<div class="artist-card-actions">
+			<a href="<?php echo esc_url( $artist_url ); ?>" class="button-1 button-medium" data-action-button>
+				<?php esc_html_e( 'View Profile', 'extrachill-artist-platform' ); ?>
+			</a>
+			<?php
+			/**
+			 * Action hook for extending artist card actions
+			 *
+			 * Allows other parts of the plugin to add additional buttons or actions
+			 * to the artist card based on context (homepage, directory, etc.)
+			 *
+			 * @param int $artist_id The artist profile post ID
+			 */
+			do_action( 'ec_artist_card_actions', $artist_id );
+			?>
+		</div>
+	</div>
 </div>

--- a/inc/artist-profiles/frontend/templates/single-artist_profile.php
+++ b/inc/artist-profiles/frontend/templates/single-artist_profile.php
@@ -11,67 +11,68 @@
 
 get_header(); ?>
 
-    <div class="main-content">
-        <main id="main" class="site-main">
-            <?php
-            /**
-             * Custom hook for before main content.
-             */
-            do_action( 'extrachill_before_body_content' );
+	<div class="main-content">
+		<main id="main" class="site-main">
+			<?php
+			/**
+			 * Custom hook for before main content.
+			 */
+			do_action( 'extrachill_before_body_content' );
 
-            // --- Display Breadcrumbs ---
-            // Moved to be a direct child of <main>, before the while loop and <article>
-            if ( function_exists( 'extrachill_breadcrumbs' ) ) {
-                extrachill_breadcrumbs();
-            }
-            // --- End Breadcrumbs ---
+			// --- Display Breadcrumbs ---
+			// Moved to be a direct child of <main>, before the while loop and <article>
+			if ( function_exists( 'extrachill_breadcrumbs' ) ) {
+				extrachill_breadcrumbs();
+			}
+			// --- End Breadcrumbs ---
 
-            // --- Main Post Loop ---
-            while ( have_posts() ) : the_post();
+			// --- Main Post Loop ---
+			while ( have_posts() ) :
+				the_post();
 
-                $artist_profile_id = get_the_ID();
+				$artist_profile_id = get_the_ID();
 
-                // Resolve the bound main-blog `artist` term (Primitive 1) so
-                // term-scoped sections (Shows/Coverage/Community) can query the
-                // network. 0 when the profile has no term yet.
-                $artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_profile_id ) : 0;
+				// Resolve the bound main-blog `artist` term (Primitive 1) so
+				// term-scoped sections (Shows/Coverage/Community) can query the
+				// network. 0 when the profile has no term yet.
+				$artist_term_id = function_exists( 'ec_get_artist_term_id' ) ? ec_get_artist_term_id( $artist_profile_id ) : 0;
 
-            ?>
+				?>
 
-                <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> >
-                    <div class="ec-edge-gutter">
-                        <?php
-                        // Render every registered section in priority order.
-                        // The default sections reproduce the previous hardcoded
-                        // hero + entry-content blocks (no visual change).
-                        if ( function_exists( 'ec_render_artist_profile_sections' ) ) {
-                            ec_render_artist_profile_sections( $artist_profile_id, $artist_term_id );
-                        }
-                        ?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> >
+					<div class="ec-edge-gutter">
+						<?php
+						// Render every registered section in priority order.
+						// The default sections reproduce the previous hardcoded
+						// hero + entry-content blocks (no visual change).
+						if ( function_exists( 'ec_render_artist_profile_sections' ) ) {
+							ec_render_artist_profile_sections( $artist_profile_id, $artist_term_id );
+						}
+						?>
 
-                        <?php
-                        /**
-                         * generate_after_content hook.
-                         *
-                         * @since 0.1
-                         */
-                        do_action( 'extra_chill_after_content' );
-                        ?>
-                    </div>
-                </article><!-- #post-## -->
+						<?php
+						/**
+						 * generate_after_content hook.
+						 *
+						 * @since 0.1
+						 */
+						do_action( 'extra_chill_after_content' );
+						?>
+					</div>
+				</article><!-- #post-## -->
 
-            <?php endwhile; // end of the loop. ?>
+			<?php endwhile; // end of the loop. ?>
 
-            <?php
-            /**
-             * generate_after_main_content hook.
-             *
-             * @since 0.1
-             */
-            do_action( 'extrachill_after_body_content' );
-            ?>
-        </main><!-- #main -->
-    </div><!-- .main-content -->
+			<?php
+			/**
+			 * generate_after_main_content hook.
+			 *
+			 * @since 0.1
+			 */
+			do_action( 'extrachill_after_body_content' );
+			?>
+		</main><!-- #main -->
+	</div><!-- .main-content -->
 
 <?php
 /**

--- a/inc/artist-profiles/roster/artist-invitation-emails.php
+++ b/inc/artist-profiles/roster/artist-invitation-emails.php
@@ -33,17 +33,23 @@ function ec_send_artist_invitation_email( $recipient_email, $artist_name, $membe
 	// Construct the invitation link
 	$invitation_base_url = home_url( '/' );
 	if ( EC_INVITE_STATUS_NEW_USER === $invitation_status ) {
-		$invitation_link = add_query_arg( array(
-			'action'    => 'ec_accept_invite',
-			'token'     => $invitation_token,
-			'artist_id' => $artist_id,
-		), trailingslashit( $invitation_base_url ) . 'register/' );
+		$invitation_link = add_query_arg(
+			array(
+				'action'    => 'ec_accept_invite',
+				'token'     => $invitation_token,
+				'artist_id' => $artist_id,
+			),
+			trailingslashit( $invitation_base_url ) . 'register/'
+		);
 	} else {
-		$invitation_link = add_query_arg( array(
-			'action'    => 'ec_accept_invite',
-			'token'     => $invitation_token,
-			'artist_id' => $artist_id,
-		), get_permalink( $artist_id ) );
+		$invitation_link = add_query_arg(
+			array(
+				'action'    => 'ec_accept_invite',
+				'token'     => $invitation_token,
+				'artist_id' => $artist_id,
+			),
+			get_permalink( $artist_id )
+		);
 	}
 
 	/* translators: 1: artist name, 2: site name */
@@ -89,20 +95,22 @@ function ec_send_artist_invitation_email( $recipient_email, $artist_name, $membe
 		return false;
 	}
 
-	$result = ec_send_email( array(
-		'to'         => $recipient_email,
-		'subject'    => $subject,
-		'from_name'  => 'Extra Chill Community',
-		'from_email' => 'admin@extrachill.com',
-		'template'   => 'extrachill/branded',
-		'context'    => array(
-			'recipient_name' => $recipient_name,
-			'subject_html'   => esc_html( $subject ),
-			'body_html'      => $body_html,
-			'cta_url'        => $invitation_link,
-			'cta_label'      => $cta_label,
-		),
-	) );
+	$result = ec_send_email(
+		array(
+			'to'         => $recipient_email,
+			'subject'    => $subject,
+			'from_name'  => 'Extra Chill Community',
+			'from_email' => 'admin@extrachill.com',
+			'template'   => 'extrachill/branded',
+			'context'    => array(
+				'recipient_name' => $recipient_name,
+				'subject_html'   => esc_html( $subject ),
+				'body_html'      => $body_html,
+				'cta_url'        => $invitation_link,
+				'cta_label'      => $cta_label,
+			),
+		)
+	);
 
 	$sent = is_array( $result ) && ! empty( $result['success'] );
 
@@ -123,12 +131,12 @@ function ec_send_artist_invitation_email( $recipient_email, $artist_name, $membe
 function ec_handle_invitation_acceptance() {
 	if ( isset( $_GET['action'] ) && 'ec_accept_invite' === $_GET['action'] && isset( $_GET['token'] ) && isset( $_GET['artist_id'] ) ) {
 		$token        = sanitize_text_field( $_GET['token'] );
-		$artist_id    = apply_filters('ec_get_artist_id', $_GET);
+		$artist_id    = apply_filters( 'ec_get_artist_id', $_GET );
 		$redirect_url = get_permalink( $artist_id );
 
 		if ( ! $redirect_url ) {
 			// Fallback if artist profile doesn't exist for some reason
-			$redirect_url = home_url('/');
+			$redirect_url = home_url( '/' );
 		}
 
 		// 1. User must be logged in

--- a/inc/artist-profiles/roster/manage-roster-ui.php
+++ b/inc/artist-profiles/roster/manage-roster-ui.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Handles the display and specific UI logic for the "Manage Artist Members" section 
+ * Handles the display and specific UI logic for the "Manage Artist Members" section
  * on the frontend manage artist profile page.
  */
 
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . '/roster-data-functions.php'; // Include the new data functions file
+require_once __DIR__ . '/roster-data-functions.php'; // Include the new data functions file
 
 /**
  * Displays the entire "Manage Artist Members" interface.
@@ -15,136 +15,140 @@ require_once dirname( __FILE__ ) . '/roster-data-functions.php'; // Include the 
  * @param int $artist_id The ID of the artist profile being managed.
  * @param int $current_user_id The ID of the user currently viewing/editing the page.
  */
-if (!function_exists('ec_display_manage_members_section')) {
-function ec_display_manage_members_section( $artist_id, $current_user_id ) {
-    if ( ! $artist_id || ! $current_user_id ) {
-        echo '<p>' . esc_html__( 'Cannot display member management: Missing artist or user information.', 'extrachill-artist-platform' ) . '</p>';
-        return;
-    }
+if ( ! function_exists( 'ec_display_manage_members_section' ) ) {
+	function ec_display_manage_members_section( $artist_id, $current_user_id ) {
+		if ( ! $artist_id || ! $current_user_id ) {
+			echo '<p>' . esc_html__( 'Cannot display member management: Missing artist or user information.', 'extrachill-artist-platform' ) . '</p>';
+			return;
+		}
 
-    $linked_members_raw = ec_get_linked_members( $artist_id );
-    $pending_invitations_raw = ec_get_pending_invitations( $artist_id );
+		$linked_members_raw      = ec_get_linked_members( $artist_id );
+		$pending_invitations_raw = ec_get_pending_invitations( $artist_id );
 
-    $linked_user_ids = [];
-    $processed_emails = []; 
-    $invited_display_names = []; 
-    $has_any_members = false;
+		$linked_user_ids       = array();
+		$processed_emails      = array();
+		$invited_display_names = array();
+		$has_any_members       = false;
 
-    ?>
-    <h2><?php esc_html_e( 'Artist Roster', 'extrachill-artist-platform' ); ?></h2>
-    
-    <div id="ec-manage-members-section">
-        
-        <ul id="ec-unified-roster-list" class="ec-members-list">
-            <?php 
-            // 1. Display Linked Members
-            if ( ! empty( $linked_members_raw ) ) :
-                foreach ( $linked_members_raw as $member_obj ) : 
-                    $user_info = get_userdata( $member_obj->ID );
-                    if ( $user_info ) :
-                        $has_any_members = true;
-                        $linked_user_ids[] = $user_info->ID;
-                        $processed_emails[] = strtolower($user_info->user_email);
-            ?>
-                        <?php
-                        $community_profile_url = function_exists( 'extrachill_get_user_community_profile_url' )
-                            ? extrachill_get_user_community_profile_url( $user_info->ID )
-                            : '';
-                        ?>
-                        <li data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" class="ec-member-linked">
-                            <?php echo get_avatar( $user_info->ID, 32 ); ?>
-                            <span class="member-name"><?php
-                                if ( ! empty( $community_profile_url ) ) :
-                                    ?><a href="<?php echo esc_url( $community_profile_url ); ?>"><?php echo esc_html( $user_info->display_name ); ?></a><?php
-                                else :
-                                    echo esc_html( $user_info->display_name );
-                                endif;
-                            ?> (<?php echo esc_html( $user_info->user_login ); ?>)</span>
-                            <span class="member-status-label">(Linked Account)</span>
-                            <?php if ( $user_info->ID !== $current_user_id ) : ?>
-                                <button type="button" class="button-2 button-small ec-remove-member-button" data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" title="<?php esc_attr_e( 'Remove this member from artist', 'extrachill-artist-platform' ); ?>">&times; <?php esc_html_e('Remove', 'extrachill-artist-platform'); ?></button>
-                            <?php else: ?>
-                                <span class="is-current-user"><?php esc_html_e('You', 'extrachill-artist-platform'); ?></span>
-                            <?php endif; ?>
-                        </li>
-            <?php 
-                    endif;
-                endforeach;
-            endif;
+		?>
+	<h2><?php esc_html_e( 'Artist Roster', 'extrachill-artist-platform' ); ?></h2>
 
-            // 2. Display Pending Invitations (for users not already linked)
-            if ( ! empty( $pending_invitations_raw ) ) :
-                foreach ( $pending_invitations_raw as $invite ) :
-                    if ( in_array( strtolower($invite['email']), $processed_emails ) ) {
-                        continue;
-                    }
-                    $has_any_members = true;
-                    $processed_emails[] = strtolower($invite['email']); 
+	<div id="ec-manage-members-section">
 
-                    $invited_on_formatted = date_i18n( get_option( 'date_format' ), $invite['invited_on'] );
-                    $status_text = '';
-                    switch ( $invite['status'] ) {
-                        case EC_INVITE_STATUS_EXISTING_ARTIST:
-                            $status_text = __( 'Invited (Existing User)', 'extrachill-artist-platform' );
-                            break;
-                        case EC_INVITE_STATUS_NEW_USER:
-                            $status_text = __( 'Invited (New User)', 'extrachill-artist-platform' );
-                            break;
-                        default:
-                            $status_text = __( 'Invited (Status: ', 'extrachill-artist-platform' ) . esc_html( $invite['status'] ) . ')';
-                    }
-            ?>
-                    <li data-invite-id="<?php echo esc_attr( $invite['id'] ); ?>" class="ec-member-pending-invite">
-                        <span class="member-avatar-placeholder"></span> 
-                        <span class="member-email"><?php echo esc_html( $invite['email'] ); ?></span>
-                        <span class="member-status-label">(<?php echo esc_html( $status_text ); ?>: <?php echo esc_html( $invited_on_formatted ); ?>)</span>
-                        <span class="member-actions">
-                            <?php
-                            /*
-                             * Cancel Invite is handled by the React `artist-manager` block,
-                             * which calls DELETE /extrachill/v1/artists/{id}/roster/invites/{invite_id}
-                             * (extrachill-api) -> ec_remove_pending_invitation(). No AJAX; capability
-                             * enforced via ec_can_manage_artist() in the REST handler. This legacy
-                             * server-rendered roster UI is not the active surface.
-                             */
-                            ?>
-                        </span>
-                    </li>
-            <?php 
-                endforeach;
-            endif;
+		<ul id="ec-unified-roster-list" class="ec-members-list">
+			<?php
+			// 1. Display Linked Members
+			if ( ! empty( $linked_members_raw ) ) :
+				foreach ( $linked_members_raw as $member_obj ) :
+					$user_info = get_userdata( $member_obj->ID );
+					if ( $user_info ) :
+						$has_any_members    = true;
+						$linked_user_ids[]  = $user_info->ID;
+						$processed_emails[] = strtolower( $user_info->user_email );
+						?>
+						<?php
+						$community_profile_url = function_exists( 'extrachill_get_user_community_profile_url' )
+							? extrachill_get_user_community_profile_url( $user_info->ID )
+							: '';
+						?>
+						<li data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" class="ec-member-linked">
+							<?php echo get_avatar( $user_info->ID, 32 ); ?>
+							<span class="member-name">
+							<?php
+							if ( ! empty( $community_profile_url ) ) :
+								?>
+									<a href="<?php echo esc_url( $community_profile_url ); ?>"><?php echo esc_html( $user_info->display_name ); ?></a>
+									<?php
+								else :
+									echo esc_html( $user_info->display_name );
+								endif;
+								?>
+							(<?php echo esc_html( $user_info->user_login ); ?>)</span>
+							<span class="member-status-label">(Linked Account)</span>
+							<?php if ( $user_info->ID !== $current_user_id ) : ?>
+								<button type="button" class="button-2 button-small ec-remove-member-button" data-user-id="<?php echo esc_attr( $user_info->ID ); ?>" title="<?php esc_attr_e( 'Remove this member from artist', 'extrachill-artist-platform' ); ?>">&times; <?php esc_html_e( 'Remove', 'extrachill-artist-platform' ); ?></button>
+							<?php else : ?>
+								<span class="is-current-user"><?php esc_html_e( 'You', 'extrachill-artist-platform' ); ?></span>
+							<?php endif; ?>
+						</li>
+						<?php
+					endif;
+				endforeach;
+				endif;
 
-            if ( ! $has_any_members ) :
-            ?>
-                <li class="no-members"><?php esc_html_e( 'No members listed for this artist yet.', 'extrachill-artist-platform' ); ?></li>
-            <?php endif; ?>
-        </ul>
+			// 2. Display Pending Invitations (for users not already linked)
+			if ( ! empty( $pending_invitations_raw ) ) :
+				foreach ( $pending_invitations_raw as $invite ) :
+					if ( in_array( strtolower( $invite['email'] ), $processed_emails ) ) {
+						continue;
+					}
+					$has_any_members    = true;
+					$processed_emails[] = strtolower( $invite['email'] );
 
-        <div id="ec-add-member-controls" style="margin-bottom: 20px;">
-            <a href="#" id="ec-show-add-member-form-link" class="button-2 button-medium"><?php esc_html_e('[+] Add Member', 'extrachill-artist-platform'); ?></a>
-            <div id="ec-add-member-form-area" class="ec-add-member-form" style="display: none; margin-top: 15px;">
-                <h4><?php esc_html_e('Invite New Member by Email', 'extrachill-artist-platform'); ?></h4>
-                <div class="form-group">
-                    <label for="ec-new-member-email-input" style="display:block; margin-bottom: 5px;">
-                        <?php esc_html_e( 'Email Address:', 'extrachill-artist-platform' ); ?>
-                    </label>
-                    <input type="email" id="ec-new-member-email-input" name="ec_new_member_email" style="width: 100%; max-width: 300px; margin-bottom:10px;">
-                </div>
-                <button type="button" id="ec-send-invite-member-button" class="button-2 button-medium"><?php esc_html_e('Send Invitation', 'extrachill-artist-platform'); ?></button>
-                <a href="#" id="ec-cancel-add-member-form-link" style="margin-left: 10px; display: inline-block; vertical-align: middle;">
-                    <?php esc_html_e('Cancel', 'extrachill-artist-platform'); ?>
-                </a>
-            </div>
-        </div>
-        
-        <?php // Only remove_member_ids is needed now for main form submission for linked members ?>
-        <input type="hidden" name="remove_member_ids" id="ec-remove-member-ids-frontend" value="">
-    </div>
+					$invited_on_formatted = date_i18n( get_option( 'date_format' ), $invite['invited_on'] );
+					$status_text          = '';
+					switch ( $invite['status'] ) {
+						case EC_INVITE_STATUS_EXISTING_ARTIST:
+							$status_text = __( 'Invited (Existing User)', 'extrachill-artist-platform' );
+							break;
+						case EC_INVITE_STATUS_NEW_USER:
+							$status_text = __( 'Invited (New User)', 'extrachill-artist-platform' );
+							break;
+						default:
+							$status_text = __( 'Invited (Status: ', 'extrachill-artist-platform' ) . esc_html( $invite['status'] ) . ')';
+					}
+					?>
+					<li data-invite-id="<?php echo esc_attr( $invite['id'] ); ?>" class="ec-member-pending-invite">
+						<span class="member-avatar-placeholder"></span>
+						<span class="member-email"><?php echo esc_html( $invite['email'] ); ?></span>
+						<span class="member-status-label">(<?php echo esc_html( $status_text ); ?>: <?php echo esc_html( $invited_on_formatted ); ?>)</span>
+						<span class="member-actions">
+							<?php
+							/*
+							 * Cancel Invite is handled by the React `artist-manager` block,
+							 * which calls DELETE /extrachill/v1/artists/{id}/roster/invites/{invite_id}
+							 * (extrachill-api) -> ec_remove_pending_invitation(). No AJAX; capability
+							 * enforced via ec_can_manage_artist() in the REST handler. This legacy
+							 * server-rendered roster UI is not the active surface.
+							 */
+							?>
+						</span>
+					</li>
+					<?php
+				endforeach;
+				endif;
 
-    <!-- Invitation Modal - Remove inline display:none -->
-    <!-- Modal and plaintext member logic removed for simplification -->
-    <?php
-}
+			if ( ! $has_any_members ) :
+				?>
+				<li class="no-members"><?php esc_html_e( 'No members listed for this artist yet.', 'extrachill-artist-platform' ); ?></li>
+			<?php endif; ?>
+		</ul>
+
+		<div id="ec-add-member-controls" style="margin-bottom: 20px;">
+			<a href="#" id="ec-show-add-member-form-link" class="button-2 button-medium"><?php esc_html_e( '[+] Add Member', 'extrachill-artist-platform' ); ?></a>
+			<div id="ec-add-member-form-area" class="ec-add-member-form" style="display: none; margin-top: 15px;">
+				<h4><?php esc_html_e( 'Invite New Member by Email', 'extrachill-artist-platform' ); ?></h4>
+				<div class="form-group">
+					<label for="ec-new-member-email-input" style="display:block; margin-bottom: 5px;">
+						<?php esc_html_e( 'Email Address:', 'extrachill-artist-platform' ); ?>
+					</label>
+					<input type="email" id="ec-new-member-email-input" name="ec_new_member_email" style="width: 100%; max-width: 300px; margin-bottom:10px;">
+				</div>
+				<button type="button" id="ec-send-invite-member-button" class="button-2 button-medium"><?php esc_html_e( 'Send Invitation', 'extrachill-artist-platform' ); ?></button>
+				<a href="#" id="ec-cancel-add-member-form-link" style="margin-left: 10px; display: inline-block; vertical-align: middle;">
+					<?php esc_html_e( 'Cancel', 'extrachill-artist-platform' ); ?>
+				</a>
+			</div>
+		</div>
+
+			<?php // Only remove_member_ids is needed now for main form submission for linked members ?>
+		<input type="hidden" name="remove_member_ids" id="ec-remove-member-ids-frontend" value="">
+	</div>
+
+	<!-- Invitation Modal - Remove inline display:none -->
+	<!-- Modal and plaintext member logic removed for simplification -->
+		<?php
+	}
 } // Close the function_exists check
 
-?> 
+?>

--- a/inc/artist-profiles/roster/roster-data-functions.php
+++ b/inc/artist-profiles/roster/roster-data-functions.php
@@ -56,95 +56,100 @@ if ( ! defined( 'EC_INVITE_STATUS_NEW_USER' ) ) {
 
 /**
  * Get pending invitations for an artist.
+ *
  * @param int $artist_id
  * @return array Array of pending invitation objects/arrays
  */
 function ec_get_pending_invitations( $artist_id ) {
-    $invitations = get_post_meta( $artist_id, '_pending_invitations', true );
-    return is_array( $invitations ) ? $invitations : array();
+	$invitations = get_post_meta( $artist_id, '_pending_invitations', true );
+	return is_array( $invitations ) ? $invitations : array();
 }
 
 /**
  * Generates a unique invitation token.
+ *
  * @return string The unique token.
  */
 function ec_generate_invite_token() {
-    return wp_generate_password( 32, false, false ); // 32 chars, no special chars
+	return wp_generate_password( 32, false, false ); // 32 chars, no special chars
 }
 
 /**
  * Adds a pending invitation for an artist.
  * Checks if the email belongs to an existing user and if that user is an artist.
  * (Does not send email yet).
- * @param int $artist_id
+ *
+ * @param int    $artist_id
  * @param string $display_name
  * @param string $email
  * @return bool|array|string False on general failure, new invitation entry array on success,
  *                             or a specific error string like 'error_not_artist' or 'error_already_pending'.
  */
-function ec_add_pending_invitation( $artist_id, $display_name, $email ) { // Removed $status_hint as it will be determined internally
-    if ( empty( $email ) || !is_email( $email ) ) {
-        return false; // General validation failure
-    }
+function ec_add_pending_invitation( $artist_id, $display_name, $email ) {
+	// Removed $status_hint as it will be determined internally
+	if ( empty( $email ) || ! is_email( $email ) ) {
+		return false; // General validation failure
+	}
 
-    $invitations = ec_get_pending_invitations( $artist_id );
+	$invitations = ec_get_pending_invitations( $artist_id );
 
-    // Check if email already has a pending invite for this artist
-    foreach ( $invitations as $invite ) {
-        if ( isset( $invite['email'] ) && strtolower($invite['email']) === strtolower($email) ) {
-            return 'error_already_pending'; // Specific error for already pending
-        }
-    }
+	// Check if email already has a pending invite for this artist
+	foreach ( $invitations as $invite ) {
+		if ( isset( $invite['email'] ) && strtolower( $invite['email'] ) === strtolower( $email ) ) {
+			return 'error_already_pending'; // Specific error for already pending
+		}
+	}
 
-    $new_invite_id = 'inv_' . wp_generate_password( 12, false );
-    $token = ec_generate_invite_token();
-    $final_status = '';
+	$new_invite_id = 'inv_' . wp_generate_password( 12, false );
+	$token         = ec_generate_invite_token();
+	$final_status  = '';
 
-    $existing_user_id = email_exists( $email );
-    if ( $existing_user_id ) {
-        // User exists. We will invite them. 
-        // The acceptance process will handle adding 'user_is_artist' meta if needed.
-        $final_status = EC_INVITE_STATUS_EXISTING_ARTIST; // Use this status; acceptance will verify/add meta.
-    } else {
-        // New user
-        $final_status = EC_INVITE_STATUS_NEW_USER;
-    }
+	$existing_user_id = email_exists( $email );
+	if ( $existing_user_id ) {
+		// User exists. We will invite them.
+		// The acceptance process will handle adding 'user_is_artist' meta if needed.
+		$final_status = EC_INVITE_STATUS_EXISTING_ARTIST; // Use this status; acceptance will verify/add meta.
+	} else {
+		// New user
+		$final_status = EC_INVITE_STATUS_NEW_USER;
+	}
 
-    $new_invite_entry = array(
-        'id'            => $new_invite_id,
-        'display_name'  => sanitize_text_field( $display_name ),
-        'email'         => sanitize_email( $email ),
-        'token'         => $token,
-        'status'        => sanitize_key( $final_status ), 
-        'invited_on'    => time() // GMT Unix timestamp (replaces deprecated current_time( 'timestamp', true ))
-    );
+	$new_invite_entry = array(
+		'id'           => $new_invite_id,
+		'display_name' => sanitize_text_field( $display_name ),
+		'email'        => sanitize_email( $email ),
+		'token'        => $token,
+		'status'       => sanitize_key( $final_status ),
+		'invited_on'   => time(), // GMT Unix timestamp (replaces deprecated current_time( 'timestamp', true ))
+	);
 
-    $invitations[] = $new_invite_entry;
-    if ( update_post_meta( $artist_id, '_pending_invitations', $invitations ) ) {
-        return $new_invite_entry;
-    }
-    return false; // General failure to save meta
+	$invitations[] = $new_invite_entry;
+	if ( update_post_meta( $artist_id, '_pending_invitations', $invitations ) ) {
+		return $new_invite_entry;
+	}
+	return false; // General failure to save meta
 }
 
 /**
  * Removes a pending invitation.
- * @param int $artist_id
+ *
+ * @param int    $artist_id
  * @param string $pending_invite_id The unique ID of the invitation entry.
  * @return bool True on success, false on failure.
  */
 function ec_remove_pending_invitation( $artist_id, $pending_invite_id ) {
-    $invitations = ec_get_pending_invitations( $artist_id );
-    $updated_invitations = array();
-    $found = false;
-    foreach ( $invitations as $invite ) {
-        if ( isset( $invite['id'] ) && $invite['id'] === $pending_invite_id ) {
-            $found = true;
-            continue; // Skip this invitation
-        }
-        $updated_invitations[] = $invite;
-    }
-    if ( $found ) {
-        return update_post_meta( $artist_id, '_pending_invitations', $updated_invitations );
-    }
-    return false;
+	$invitations         = ec_get_pending_invitations( $artist_id );
+	$updated_invitations = array();
+	$found               = false;
+	foreach ( $invitations as $invite ) {
+		if ( isset( $invite['id'] ) && $invite['id'] === $pending_invite_id ) {
+			$found = true;
+			continue; // Skip this invitation
+		}
+		$updated_invitations[] = $invite;
+	}
+	if ( $found ) {
+		return update_post_meta( $artist_id, '_pending_invitations', $updated_invitations );
+	}
+	return false;
 }

--- a/inc/artist-profiles/roster/roster-filter-handlers.php
+++ b/inc/artist-profiles/roster/roster-filter-handlers.php
@@ -1,15 +1,15 @@
 <?php
 /**
  * Artist Roster Filter Handlers
- * 
+ *
  * Handles REST API filter requests for artist member invitation system.
  * Provides invitation creation, email sending, and roster operations.
  */
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . '/roster-data-functions.php';
-require_once dirname( __FILE__ ) . '/artist-invitation-emails.php';
+require_once __DIR__ . '/roster-data-functions.php';
+require_once __DIR__ . '/artist-invitation-emails.php';
 
 /**
  * Handle artist member invitation via REST API filter

--- a/inc/artist-profiles/subscribe-data-functions.php
+++ b/inc/artist-profiles/subscribe-data-functions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Artist Profile Subscriber Data Functions
- * 
+ *
  * Backend functions for fetching and managing artist profile subscriber data.
  * Handles subscriber management and CSV exports for artist profiles.
  */
@@ -11,62 +11,62 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Fetches subscriber data for a given artist profile ID.
  *
- * @param int $artist_id The ID of the artist profile.
+ * @param int   $artist_id The ID of the artist profile.
  * @param array $args Optional arguments for querying.
  * @return array List of subscriber objects or empty array.
  */
 function extrachill_artist_get_artist_subscribers( $artist_id, $args = array() ) {
-    global $wpdb;
-    $table_name = $wpdb->prefix . 'artist_subscribers';
-    $artist_id = absint( $artist_id );
+	global $wpdb;
+	$table_name = $wpdb->prefix . 'artist_subscribers';
+	$artist_id  = absint( $artist_id );
 
-    if ( empty( $artist_id ) ) {
-        return array();
-    }
+	if ( empty( $artist_id ) ) {
+		return array();
+	}
 
-    // Default arguments
-    $defaults = array(
-        'orderby' => 'subscribed_at',
-        'order' => 'DESC',
-        'limit' => -1, // -1 for no limit, fetch all
-        'offset' => 0,
-        'exported' => null, // null means include all, 0 for not exported, 1 for exported
-    );
-    $args = wp_parse_args( $args, $defaults );
+	// Default arguments
+	$defaults = array(
+		'orderby'  => 'subscribed_at',
+		'order'    => 'DESC',
+		'limit'    => -1, // -1 for no limit, fetch all
+		'offset'   => 0,
+		'exported' => null, // null means include all, 0 for not exported, 1 for exported
+	);
+	$args     = wp_parse_args( $args, $defaults );
 
-    $sql = "SELECT * FROM $table_name WHERE artist_profile_id = %d";
-    $sql_args = array( $artist_id );
+	$sql      = "SELECT * FROM $table_name WHERE artist_profile_id = %d";
+	$sql_args = array( $artist_id );
 
-    // Filter by exported status if specified
-    if ( $args['exported'] !== null ) {
-        $sql .= " AND exported = %d";
-        $sql_args[] = absint( $args['exported'] );
-    }
+	// Filter by exported status if specified
+	if ( $args['exported'] !== null ) {
+		$sql       .= ' AND exported = %d';
+		$sql_args[] = absint( $args['exported'] );
+	}
 
-    // Add order by clause
-    $orderby = sanitize_sql_orderby( $args['orderby'] ); // Sanitize orderby input
-    $order = ( strtoupper( $args['order'] ) === 'ASC' ) ? 'ASC' : 'DESC';
-    if ( $orderby ) {
-         // Ensure ordering by a valid column to prevent SQL errors
-         $valid_orderby = array('subscriber_id', 'artist_profile_id', 'subscriber_email', 'username', 'subscribed_at', 'exported');
-         if ( in_array( $orderby, $valid_orderby ) ) {
-            $sql .= " ORDER BY " . $orderby . " " . $order;
-         }
-    }
+	// Add order by clause
+	$orderby = sanitize_sql_orderby( $args['orderby'] ); // Sanitize orderby input
+	$order   = ( strtoupper( $args['order'] ) === 'ASC' ) ? 'ASC' : 'DESC';
+	if ( $orderby ) {
+		// Ensure ordering by a valid column to prevent SQL errors
+		$valid_orderby = array( 'subscriber_id', 'artist_profile_id', 'subscriber_email', 'username', 'subscribed_at', 'exported' );
+		if ( in_array( $orderby, $valid_orderby ) ) {
+			$sql .= ' ORDER BY ' . $orderby . ' ' . $order;
+		}
+	}
 
-    // Add limit and offset
-    if ( $args['limit'] > 0 ) {
-        $sql .= " LIMIT %d";
-        $sql_args[] = absint( $args['limit'] );
-        if ( $args['offset'] >= 0 ) {
-            $sql .= " OFFSET %d";
-            $sql_args[] = absint( $args['offset'] );
-        }
-    }
+	// Add limit and offset
+	if ( $args['limit'] > 0 ) {
+		$sql       .= ' LIMIT %d';
+		$sql_args[] = absint( $args['limit'] );
+		if ( $args['offset'] >= 0 ) {
+			$sql       .= ' OFFSET %d';
+			$sql_args[] = absint( $args['offset'] );
+		}
+	}
 
-    // Prepare and execute the query
-    $query = $wpdb->prepare( $sql, $sql_args );
-    $subscribers = $wpdb->get_results( $query );
+	// Prepare and execute the query
+	$query       = $wpdb->prepare( $sql, $sql_args );
+	$subscribers = $wpdb->get_results( $query );
 
-    return is_array( $subscribers ) ? $subscribers : array();
+	return is_array( $subscribers ) ? $subscribers : array();
 }

--- a/inc/core/actions/add.php
+++ b/inc/core/actions/add.php
@@ -96,7 +96,7 @@ function ec_action_artist_add_link( $link_page_id, $link_data, $user_id ) {
 
 	// Get current data via existing centralized function
 	$current_data = ec_get_link_page_data( $artist_id, $link_page_id );
-	$links = $current_data['links'] ?? array();
+	$links        = $current_data['links'] ?? array();
 
 	// Determine section (default: first section)
 	$section_index = isset( $link_data['section_index'] ) ? absint( $link_data['section_index'] ) : 0;
@@ -105,7 +105,7 @@ function ec_action_artist_add_link( $link_page_id, $link_data, $user_id ) {
 	if ( ! isset( $links[ $section_index ] ) ) {
 		$links[ $section_index ] = array(
 			'section_title' => '',
-			'links' => array()
+			'links'         => array(),
 		);
 	}
 
@@ -119,7 +119,7 @@ function ec_action_artist_add_link( $link_page_id, $link_data, $user_id ) {
 
 	// Save via existing centralized function
 	$save_data = array( 'links' => $links );
-	$result = ec_handle_link_page_save( $link_page_id, $save_data );
+	$result    = ec_handle_link_page_save( $link_page_id, $save_data );
 
 	if ( is_wp_error( $result ) ) {
 		do_action( 'ec_artist_link_add_failed', $link_page_id, $clean_data, $result, $user_id );
@@ -130,12 +130,12 @@ function ec_action_artist_add_link( $link_page_id, $link_data, $user_id ) {
 	do_action( 'ec_artist_link_added', $link_page_id, $clean_data, $section_index, $position, $user_id );
 
 	return array(
-		'success' => true,
-		'link_id' => $clean_data['id'],
+		'success'       => true,
+		'link_id'       => $clean_data['id'],
 		'section_index' => $section_index,
-		'position' => $position,
-		'link_page_id' => $link_page_id,
-		'artist_id' => $artist_id
+		'position'      => $position,
+		'link_page_id'  => $link_page_id,
+		'artist_id'     => $artist_id,
 	);
 }
 

--- a/inc/core/actions/delete.php
+++ b/inc/core/actions/delete.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Delete Actions - Centralized cleanup operations
- * 
+ *
  * Handles all delete/cleanup side effects triggered by custom actions.
  * Keeps the filter system pure for data reading only.
- * 
+ *
  * @package ExtraChillArtistPlatform
  */
 
@@ -16,9 +16,9 @@ defined( 'ABSPATH' ) || exit;
  * @param int $old_image_id The attachment ID to delete
  */
 function extrachill_artist_cleanup_background_image( $old_image_id ) {
-    if ( $old_image_id && is_numeric( $old_image_id ) ) {
-        wp_delete_attachment( $old_image_id, true );
-    }
+	if ( $old_image_id && is_numeric( $old_image_id ) ) {
+		wp_delete_attachment( $old_image_id, true );
+	}
 }
 add_action( 'ec_delete_old_bg_image', 'extrachill_artist_cleanup_background_image' );
 
@@ -28,8 +28,8 @@ add_action( 'ec_delete_old_bg_image', 'extrachill_artist_cleanup_background_imag
  * @param int $old_image_id The attachment ID to delete
  */
 function extrachill_artist_cleanup_profile_image( $old_image_id ) {
-    if ( $old_image_id && is_numeric( $old_image_id ) ) {
-        wp_delete_attachment( $old_image_id, true );
-    }
+	if ( $old_image_id && is_numeric( $old_image_id ) ) {
+		wp_delete_attachment( $old_image_id, true );
+	}
 }
 add_action( 'ec_delete_old_profile_image', 'extrachill_artist_cleanup_profile_image' );

--- a/inc/core/actions/save.php
+++ b/inc/core/actions/save.php
@@ -14,134 +14,134 @@ require_once plugin_dir_path( __FILE__ ) . '../filters/upload.php';
  * Handle link page save operations (links, CSS, settings, files)
  */
 function ec_handle_link_page_save( $link_page_id, $save_data = array(), $files_data = array() ) {
-    
-    if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
-        return new WP_Error( 'invalid_link_page', 'Invalid link page ID' );
-    }
 
-    // Core link page data
-    if ( isset( $save_data['links'] ) && is_array( $save_data['links'] ) ) {
-        update_post_meta( $link_page_id, '_link_page_links', $save_data['links'] );
-    }
+	if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+		return new WP_Error( 'invalid_link_page', 'Invalid link page ID' );
+	}
 
-    if ( isset( $save_data['css_vars'] ) && is_array( $save_data['css_vars'] ) ) {
-        // Prevent card background color from being stored as configurable
-        unset( $save_data['css_vars']['--link-page-card-bg-color'] );
-        update_post_meta( $link_page_id, '_link_page_custom_css_vars', $save_data['css_vars'] );
-        
-    }
+	// Core link page data
+	if ( isset( $save_data['links'] ) && is_array( $save_data['links'] ) ) {
+		update_post_meta( $link_page_id, '_link_page_links', $save_data['links'] );
+	}
 
-    // Short bio displayed on the public link page.
-    if ( array_key_exists( 'bio', $save_data ) ) {
-        if ( $save_data['bio'] === '' || $save_data['bio'] === null ) {
-            delete_post_meta( $link_page_id, '_link_page_bio_text' );
-        } else {
-            update_post_meta( $link_page_id, '_link_page_bio_text', $save_data['bio'] );
-        }
-    }
+	if ( isset( $save_data['css_vars'] ) && is_array( $save_data['css_vars'] ) ) {
+		// Prevent card background color from being stored as configurable
+		unset( $save_data['css_vars']['--link-page-card-bg-color'] );
+		update_post_meta( $link_page_id, '_link_page_custom_css_vars', $save_data['css_vars'] );
 
-    // Advanced settings (Advanced tab fields only)
-    $advanced_fields = array(
-        'link_expiration_enabled' => '_link_expiration_enabled',
-        'redirect_enabled' => '_link_page_redirect_enabled',
-        'redirect_target_url' => '_link_page_redirect_target_url',
-        'youtube_embed_enabled' => '_enable_youtube_inline_embed',
-        'meta_pixel_id' => '_link_page_meta_pixel_id',
-        'google_tag_id' => '_link_page_google_tag_id',
-        'google_tag_manager_id' => '_link_page_google_tag_manager_id',
-        'subscribe_display_mode' => '_link_page_subscribe_display_mode',
-        'subscribe_description' => '_link_page_subscribe_description',
-        'social_icons_position' => '_link_page_social_icons_position',
-        'profile_image_shape' => '_link_page_profile_img_shape',
-    );
+	}
 
-    foreach ( $advanced_fields as $key => $meta_key ) {
-        if ( array_key_exists( $key, $save_data ) ) {
-            if ( $save_data[$key] === '' || $save_data[$key] === null ) {
-                delete_post_meta( $link_page_id, $meta_key );
-            } else {
-                update_post_meta( $link_page_id, $meta_key, $save_data[$key] );
-            }
-        }
-    }
+	// Short bio displayed on the public link page.
+	if ( array_key_exists( 'bio', $save_data ) ) {
+		if ( $save_data['bio'] === '' || $save_data['bio'] === null ) {
+			delete_post_meta( $link_page_id, '_link_page_bio_text' );
+		} else {
+			update_post_meta( $link_page_id, '_link_page_bio_text', $save_data['bio'] );
+		}
+	}
 
-    // Handle file uploads and removal if present
-    if ( ! empty( $files_data ) || isset( $save_data['remove_profile_image'] ) ) {
-        $upload_error = ec_handle_link_page_file_uploads( $link_page_id, $files_data, $save_data );
-        if ( $upload_error ) {
-            return new WP_Error( 'upload_error', 'File upload error', array( 'error_code' => $upload_error ) );
-        }
-    }
+	// Advanced settings (Advanced tab fields only)
+	$advanced_fields = array(
+		'link_expiration_enabled' => '_link_expiration_enabled',
+		'redirect_enabled'        => '_link_page_redirect_enabled',
+		'redirect_target_url'     => '_link_page_redirect_target_url',
+		'youtube_embed_enabled'   => '_enable_youtube_inline_embed',
+		'meta_pixel_id'           => '_link_page_meta_pixel_id',
+		'google_tag_id'           => '_link_page_google_tag_id',
+		'google_tag_manager_id'   => '_link_page_google_tag_manager_id',
+		'subscribe_display_mode'  => '_link_page_subscribe_display_mode',
+		'subscribe_description'   => '_link_page_subscribe_description',
+		'social_icons_position'   => '_link_page_social_icons_position',
+		'profile_image_shape'     => '_link_page_profile_img_shape',
+	);
 
-    // Handle social icons if present
-    if ( isset( $save_data['social_icons'] ) && is_array( $save_data['social_icons'] ) ) {
-        $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-        if ( $artist_id ) {
-            $social_manager = extrachill_artist_platform_social_links();
-            $social_result = $social_manager->save( $artist_id, $save_data['social_icons'] );
-            
-            if ( is_wp_error( $social_result ) ) {
-                // Don't fail entire save for social issues
-            }
-        }
-    }
+	foreach ( $advanced_fields as $key => $meta_key ) {
+		if ( array_key_exists( $key, $save_data ) ) {
+			if ( $save_data[ $key ] === '' || $save_data[ $key ] === null ) {
+				delete_post_meta( $link_page_id, $meta_key );
+			} else {
+				update_post_meta( $link_page_id, $meta_key, $save_data[ $key ] );
+			}
+		}
+	}
 
-    // Handle background image ID assignment (REST API - no file upload)
-    if ( isset( $save_data['background_image_id'] ) ) {
-        $bg_id = absint( $save_data['background_image_id'] );
-        if ( $bg_id > 0 ) {
-            update_post_meta( $link_page_id, '_link_page_background_image_id', $bg_id );
-        } else {
-            delete_post_meta( $link_page_id, '_link_page_background_image_id' );
-        }
-    }
+	// Handle file uploads and removal if present
+	if ( ! empty( $files_data ) || isset( $save_data['remove_profile_image'] ) ) {
+		$upload_error = ec_handle_link_page_file_uploads( $link_page_id, $files_data, $save_data );
+		if ( $upload_error ) {
+			return new WP_Error( 'upload_error', 'File upload error', array( 'error_code' => $upload_error ) );
+		}
+	}
 
-    // Handle profile image ID assignment (REST API - stored on artist as thumbnail)
-    if ( isset( $save_data['profile_image_id'] ) ) {
-        $artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
-        if ( $artist_id ) {
-            $profile_id = absint( $save_data['profile_image_id'] );
-            if ( $profile_id > 0 ) {
-                set_post_thumbnail( $artist_id, $profile_id );
-            } else {
-                delete_post_thumbnail( $artist_id );
-            }
-        }
-    }
+	// Handle social icons if present
+	if ( isset( $save_data['social_icons'] ) && is_array( $save_data['social_icons'] ) ) {
+		$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+		if ( $artist_id ) {
+			$social_manager = extrachill_artist_platform_social_links();
+			$social_result  = $social_manager->save( $artist_id, $save_data['social_icons'] );
 
-    /**
-     * Fires when a link page needs post-save processing.
-     * 
-     * This action hook triggers essential post-save operations like data
-     * synchronization. Other plugins and theme functions can also hook in
-     * to perform additional operations after the link page data is saved.
-     * 
-     * Hooked functions should check for errors and may prevent save completion
-     * by returning WP_Error or throwing exceptions.
-     * 
-     * @since 1.0.0
-     * 
-     * @param int $link_page_id The ID of the link page that was saved.
-     */
-    do_action( 'ec_link_page_save', $link_page_id );
+			if ( is_wp_error( $social_result ) ) {
+				// Don't fail entire save for social issues
+			}
+		}
+	}
 
-    return true;
+	// Handle background image ID assignment (REST API - no file upload)
+	if ( isset( $save_data['background_image_id'] ) ) {
+		$bg_id = absint( $save_data['background_image_id'] );
+		if ( $bg_id > 0 ) {
+			update_post_meta( $link_page_id, '_link_page_background_image_id', $bg_id );
+		} else {
+			delete_post_meta( $link_page_id, '_link_page_background_image_id' );
+		}
+	}
+
+	// Handle profile image ID assignment (REST API - stored on artist as thumbnail)
+	if ( isset( $save_data['profile_image_id'] ) ) {
+		$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+		if ( $artist_id ) {
+			$profile_id = absint( $save_data['profile_image_id'] );
+			if ( $profile_id > 0 ) {
+				set_post_thumbnail( $artist_id, $profile_id );
+			} else {
+				delete_post_thumbnail( $artist_id );
+			}
+		}
+	}
+
+	/**
+	 * Fires when a link page needs post-save processing.
+	 *
+	 * This action hook triggers essential post-save operations like data
+	 * synchronization. Other plugins and theme functions can also hook in
+	 * to perform additional operations after the link page data is saved.
+	 *
+	 * Hooked functions should check for errors and may prevent save completion
+	 * by returning WP_Error or throwing exceptions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $link_page_id The ID of the link page that was saved.
+	 */
+	do_action( 'ec_link_page_save', $link_page_id );
+
+	return true;
 }
 
 /**
  * Link page save completion handler
- * 
+ *
  * Triggered by ec_link_page_save action to complete the save process
  * by triggering the sync action for associated artist profile.
- * 
+ *
  * @param int $link_page_id The saved link page ID
  * @return void
  */
 function ec_handle_link_page_save_completion( $link_page_id ) {
-    $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-    if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
-        do_action( 'ec_artist_platform_sync', $artist_id );
-    }
+	$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+	if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
+		do_action( 'ec_artist_platform_sync', $artist_id );
+	}
 }
 add_action( 'ec_link_page_save', 'ec_handle_link_page_save_completion', 10, 1 );
 
@@ -152,22 +152,22 @@ add_action( 'ec_link_page_save', 'ec_handle_link_page_save_completion', 10, 1 );
  * @return string[] Public link page URLs.
  */
 function ec_get_link_page_public_urls( $link_page_id ) {
-    if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
-        return array();
-    }
+	if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+		return array();
+	}
 
-    $slug = get_post_field( 'post_name', $link_page_id );
-    if ( ! $slug ) {
-        return array();
-    }
+	$slug = get_post_field( 'post_name', $link_page_id );
+	if ( ! $slug ) {
+		return array();
+	}
 
-    $urls = array( 'https://extrachill.link/' . rawurlencode( $slug ) . '/' );
+	$urls = array( 'https://extrachill.link/' . rawurlencode( $slug ) . '/' );
 
-    if ( 'extra-chill' === $slug ) {
-        $urls[] = 'https://extrachill.link/';
-    }
+	if ( 'extra-chill' === $slug ) {
+		$urls[] = 'https://extrachill.link/';
+	}
 
-    return $urls;
+	return $urls;
 }
 
 /**
@@ -179,11 +179,11 @@ function ec_get_link_page_public_urls( $link_page_id ) {
  * @return string[] URLs queued for purge.
  */
 function ec_add_link_page_urls_to_breeze_purge( $urls, $post_id, $context ) {
-    if ( get_post_type( $post_id ) !== 'artist_link_page' ) {
-        return $urls;
-    }
+	if ( get_post_type( $post_id ) !== 'artist_link_page' ) {
+		return $urls;
+	}
 
-    return array_merge( $urls, ec_get_link_page_public_urls( $post_id ) );
+	return array_merge( $urls, ec_get_link_page_public_urls( $post_id ) );
 }
 add_filter( 'breeze_purge_post_cache_urls', 'ec_add_link_page_urls_to_breeze_purge', 10, 3 );
 
@@ -193,33 +193,33 @@ add_filter( 'breeze_purge_post_cache_urls', 'ec_add_link_page_urls_to_breeze_pur
  * @param int $link_page_id The saved link page ID.
  */
 function ec_purge_link_page_cache( $link_page_id ) {
-    $urls = ec_get_link_page_public_urls( $link_page_id );
-    if ( empty( $urls ) ) {
-        return;
-    }
+	$urls = ec_get_link_page_public_urls( $link_page_id );
+	if ( empty( $urls ) ) {
+		return;
+	}
 
-    if ( function_exists( 'breeze_get_filesystem' ) && function_exists( 'breeze_get_cache_base_path' ) ) {
-        $wp_filesystem = breeze_get_filesystem();
-        foreach ( $urls as $url ) {
-            $cache_path = breeze_get_cache_base_path() . hash( 'sha512', $url );
-            if ( $wp_filesystem->exists( $cache_path ) ) {
-                $wp_filesystem->rmdir( $cache_path, true );
-            }
-        }
-    }
+	if ( function_exists( 'breeze_get_filesystem' ) && function_exists( 'breeze_get_cache_base_path' ) ) {
+		$wp_filesystem = breeze_get_filesystem();
+		foreach ( $urls as $url ) {
+			$cache_path = breeze_get_cache_base_path() . hash( 'sha512', $url );
+			if ( $wp_filesystem->exists( $cache_path ) ) {
+				$wp_filesystem->rmdir( $cache_path, true );
+			}
+		}
+	}
 
-    if ( class_exists( 'Breeze_CloudFlare_Helper' ) && method_exists( 'Breeze_CloudFlare_Helper', 'purge_cloudflare_cache_urls' ) ) {
-        Breeze_CloudFlare_Helper::purge_cloudflare_cache_urls( $urls );
-    }
+	if ( class_exists( 'Breeze_CloudFlare_Helper' ) && method_exists( 'Breeze_CloudFlare_Helper', 'purge_cloudflare_cache_urls' ) ) {
+		Breeze_CloudFlare_Helper::purge_cloudflare_cache_urls( $urls );
+	}
 
-    if ( class_exists( 'Breeze_PurgeVarnish' ) ) {
-        $varnish = new Breeze_PurgeVarnish();
-        foreach ( $urls as $url ) {
-            $varnish->purge_cache( untrailingslashit( $url ) . '/?breeze' );
-        }
-    }
+	if ( class_exists( 'Breeze_PurgeVarnish' ) ) {
+		$varnish = new Breeze_PurgeVarnish();
+		foreach ( $urls as $url ) {
+			$varnish->purge_cache( untrailingslashit( $url ) . '/?breeze' );
+		}
+	}
 
-    do_action( 'ec_link_page_cache_purged', $link_page_id, $urls );
+	do_action( 'ec_link_page_cache_purged', $link_page_id, $urls );
 }
 add_action( 'ec_link_page_save', 'ec_purge_link_page_cache', 20, 1 );
 
@@ -228,31 +228,31 @@ add_action( 'ec_link_page_save', 'ec_purge_link_page_cache', 20, 1 );
  * Process social icon form fields (social_type[], social_url[]) into structured array
  */
 function ec_process_social_form_fields( $post_data ) {
-    $social_data = array();
+	$social_data = array();
 
-    $social_types = isset( $post_data['social_type'] ) ? $post_data['social_type'] : array();
-    $social_urls = isset( $post_data['social_url'] ) ? $post_data['social_url'] : array();
-    
-    // Process each social icon - use foreach to preserve DOM/submission order
-    foreach ( $social_types as $social_idx => $social_type ) {
-        $social_type = sanitize_text_field( $social_type );
-        $social_url = isset( $social_urls[$social_idx] ) ? esc_url_raw( wp_unslash( $social_urls[$social_idx] ) ) : '';
-        
-        // Skip empty social icons
-        if ( empty( $social_type ) && empty( $social_url ) ) {
-            continue;
-        }
-        
-        // Only add if we have both type and URL
-        if ( ! empty( $social_type ) && ! empty( $social_url ) ) {
-            $social_data[] = array(
-                'type' => $social_type,
-                'url' => $social_url
-            );
-        }
-    }
-    
-    return $social_data;
+	$social_types = isset( $post_data['social_type'] ) ? $post_data['social_type'] : array();
+	$social_urls  = isset( $post_data['social_url'] ) ? $post_data['social_url'] : array();
+
+	// Process each social icon - use foreach to preserve DOM/submission order
+	foreach ( $social_types as $social_idx => $social_type ) {
+		$social_type = sanitize_text_field( $social_type );
+		$social_url  = isset( $social_urls[ $social_idx ] ) ? esc_url_raw( wp_unslash( $social_urls[ $social_idx ] ) ) : '';
+
+		// Skip empty social icons
+		if ( empty( $social_type ) && empty( $social_url ) ) {
+			continue;
+		}
+
+		// Only add if we have both type and URL
+		if ( ! empty( $social_type ) && ! empty( $social_url ) ) {
+			$social_data[] = array(
+				'type' => $social_type,
+				'url'  => $social_url,
+			);
+		}
+	}
+
+	return $social_data;
 }
 
 /**
@@ -266,214 +266,213 @@ function ec_process_social_form_fields( $post_data ) {
  * @return array Structured links array with sections and links
  */
 function ec_process_link_form_fields( $post_data ) {
-    $links_data = array();
-    
-    // Check for section titles
-    $section_titles = isset( $post_data['link_section_title'] ) ? $post_data['link_section_title'] : array();
-    
-    // Check for link texts and URLs
-    $link_texts = isset( $post_data['link_text'] ) ? $post_data['link_text'] : array();
-    $link_urls = isset( $post_data['link_url'] ) ? $post_data['link_url'] : array();
-    $link_expires = isset( $post_data['link_expires_at'] ) ? $post_data['link_expires_at'] : array();
-    $link_ids = isset( $post_data['link_id'] ) ? $post_data['link_id'] : array();
-    
-    // Process each section - use foreach to preserve DOM/submission order
-    foreach ( $section_titles as $section_idx => $section_title_value ) {
-        $section_data = array(
-            'section_title' => sanitize_text_field( wp_unslash( $section_title_value ) ),
-            'links' => array()
-        );
-        
-        // Process links for this section
-        if ( isset( $link_texts[$section_idx] ) && is_array( $link_texts[$section_idx] ) ) {
-            foreach ( $link_texts[$section_idx] as $link_idx => $link_text ) {
-                $link_url = isset( $link_urls[$section_idx][$link_idx] ) ? esc_url_raw( wp_unslash( $link_urls[$section_idx][$link_idx] ) ) : '';
-                $link_text = sanitize_text_field( wp_unslash( $link_text ) );
-                
-                // Skip empty links
-                if ( empty( $link_text ) && empty( $link_url ) ) {
-                    continue;
-                }
-                
-                $link_data = array(
-                    'link_text' => $link_text,
-                    'link_url' => $link_url,
-                    'id' => isset( $link_ids[$section_idx][$link_idx] ) ? sanitize_text_field( $link_ids[$section_idx][$link_idx] ) : 'link_' . time() . '_' . wp_rand()
-                );
-                
-                // Add expiration if available
-                if ( isset( $link_expires[$section_idx][$link_idx] ) ) {
-                    $expires_at = sanitize_text_field( wp_unslash( $link_expires[$section_idx][$link_idx] ) );
-                    if ( ! empty( $expires_at ) ) {
-                        $link_data['expires_at'] = $expires_at;
-                    }
-                }
-                
-                $section_data['links'][] = $link_data;
-            }
-        }
-        
-        // Only add section if it has content
-        if ( ! empty( $section_data['section_title'] ) || ! empty( $section_data['links'] ) ) {
-            $links_data[] = $section_data;
-        }
-    }
-    
-    return $links_data;
+	$links_data = array();
+
+	// Check for section titles
+	$section_titles = isset( $post_data['link_section_title'] ) ? $post_data['link_section_title'] : array();
+
+	// Check for link texts and URLs
+	$link_texts   = isset( $post_data['link_text'] ) ? $post_data['link_text'] : array();
+	$link_urls    = isset( $post_data['link_url'] ) ? $post_data['link_url'] : array();
+	$link_expires = isset( $post_data['link_expires_at'] ) ? $post_data['link_expires_at'] : array();
+	$link_ids     = isset( $post_data['link_id'] ) ? $post_data['link_id'] : array();
+
+	// Process each section - use foreach to preserve DOM/submission order
+	foreach ( $section_titles as $section_idx => $section_title_value ) {
+		$section_data = array(
+			'section_title' => sanitize_text_field( wp_unslash( $section_title_value ) ),
+			'links'         => array(),
+		);
+
+		// Process links for this section
+		if ( isset( $link_texts[ $section_idx ] ) && is_array( $link_texts[ $section_idx ] ) ) {
+			foreach ( $link_texts[ $section_idx ] as $link_idx => $link_text ) {
+				$link_url  = isset( $link_urls[ $section_idx ][ $link_idx ] ) ? esc_url_raw( wp_unslash( $link_urls[ $section_idx ][ $link_idx ] ) ) : '';
+				$link_text = sanitize_text_field( wp_unslash( $link_text ) );
+
+				// Skip empty links
+				if ( empty( $link_text ) && empty( $link_url ) ) {
+					continue;
+				}
+
+				$link_data = array(
+					'link_text' => $link_text,
+					'link_url'  => $link_url,
+					'id'        => isset( $link_ids[ $section_idx ][ $link_idx ] ) ? sanitize_text_field( $link_ids[ $section_idx ][ $link_idx ] ) : 'link_' . time() . '_' . wp_rand(),
+				);
+
+				// Add expiration if available
+				if ( isset( $link_expires[ $section_idx ][ $link_idx ] ) ) {
+					$expires_at = sanitize_text_field( wp_unslash( $link_expires[ $section_idx ][ $link_idx ] ) );
+					if ( ! empty( $expires_at ) ) {
+						$link_data['expires_at'] = $expires_at;
+					}
+				}
+
+				$section_data['links'][] = $link_data;
+			}
+		}
+
+		// Only add section if it has content
+		if ( ! empty( $section_data['section_title'] ) || ! empty( $section_data['links'] ) ) {
+			$links_data[] = $section_data;
+		}
+	}
+
+	return $links_data;
 }
 
 /**
  * Prepare save data from POST array for link pages
- * 
+ *
  * Sanitizes and validates all form data for link page saves.
  * Processes links, social icons, CSS variables, advanced settings,
  * and converts form values to appropriate storage formats.
- * 
+ *
  * @param array $post_data $_POST array from form submission
  * @return array Prepared and sanitized save data
  */
 function ec_prepare_link_page_save_data( $post_data ) {
-    $save_data = array();
+	$save_data = array();
 
-    // Links data - Process individual form fields instead of JSON
-    $save_data['links'] = ec_process_link_form_fields( $post_data );
+	// Links data - Process individual form fields instead of JSON
+	$save_data['links'] = ec_process_link_form_fields( $post_data );
 
-    // Social icons data - Process individual form fields instead of JSON
-    $save_data['social_icons'] = ec_process_social_form_fields( $post_data );
+	// Social icons data - Process individual form fields instead of JSON
+	$save_data['social_icons'] = ec_process_social_form_fields( $post_data );
 
-    // CSS variables - Read directly from form inputs (no JSON intermediary)
-    $css_vars = array();
-    
-    // Colors
-    if ( isset( $post_data['link_page_button_color'] ) ) {
-        $css_vars['--link-page-button-bg-color'] = sanitize_hex_color( $post_data['link_page_button_color'] );
-    }
-    if ( isset( $post_data['link_page_text_color'] ) ) {
-        $css_vars['--link-page-text-color'] = sanitize_hex_color( $post_data['link_page_text_color'] );
-    }
-    if ( isset( $post_data['link_page_link_text_color'] ) ) {
-        $css_vars['--link-page-link-text-color'] = sanitize_hex_color( $post_data['link_page_link_text_color'] );
-    }
-    if ( isset( $post_data['link_page_hover_color'] ) ) {
-        $css_vars['--link-page-button-hover-bg-color'] = sanitize_hex_color( $post_data['link_page_hover_color'] );
-    }
-    if ( isset( $post_data['link_page_button_border_color'] ) ) {
-        $css_vars['--link-page-button-border-color'] = sanitize_hex_color( $post_data['link_page_button_border_color'] );
-    }
-    
-    // Background
-    if ( isset( $post_data['link_page_background_type'] ) ) {
-        $bg_type = sanitize_text_field( $post_data['link_page_background_type'] );
-        if ( in_array( $bg_type, array( 'color', 'gradient', 'image' ) ) ) {
-            $css_vars['--link-page-background-type'] = $bg_type;
-        }
-    }
-    if ( isset( $post_data['link_page_background_color'] ) ) {
-        $css_vars['--link-page-background-color'] = sanitize_hex_color( $post_data['link_page_background_color'] );
-    }
-    if ( isset( $post_data['link_page_background_gradient_start'] ) ) {
-        $css_vars['--link-page-background-gradient-start'] = sanitize_hex_color( $post_data['link_page_background_gradient_start'] );
-    }
-    if ( isset( $post_data['link_page_background_gradient_end'] ) ) {
-        $css_vars['--link-page-background-gradient-end'] = sanitize_hex_color( $post_data['link_page_background_gradient_end'] );
-    }
-    if ( isset( $post_data['link_page_background_gradient_direction'] ) ) {
-        $direction = sanitize_text_field( $post_data['link_page_background_gradient_direction'] );
-        if ( in_array( $direction, array( 'to right', 'to bottom', '135deg' ) ) ) {
-            $css_vars['--link-page-background-gradient-direction'] = $direction;
-        }
-    }
-    
-    
-    // Typography
-    if ( isset( $post_data['link_page_title_font_family'] ) ) {
-        $css_vars['--link-page-title-font-family'] = sanitize_text_field( $post_data['link_page_title_font_family'] );
-    }
-    if ( isset( $post_data['link_page_title_font_size'] ) ) {
-        // Convert slider value (0-100) to em using original formula
-        $slider_percentage = absint( $post_data['link_page_title_font_size'] );
-        $font_size_min_em = 0.8;
-        $font_size_max_em = 3.5;
-        $em_value = $font_size_min_em + ($font_size_max_em - $font_size_min_em) * ($slider_percentage / 100);
-        $css_vars['--link-page-title-font-size'] = round($em_value, 2) . 'em';
-    }
-    if ( isset( $post_data['link_page_body_font_family'] ) ) {
-        $css_vars['--link-page-body-font-family'] = sanitize_text_field( $post_data['link_page_body_font_family'] );
-    }
-    // Removed body font size processing - uses theme default font size
-    
-    // Button styling
-    if ( isset( $post_data['link_page_button_radius'] ) ) {
-        $button_radius = absint( $post_data['link_page_button_radius'] );
-        $css_vars['--link-page-button-radius'] = $button_radius . 'px';
-    }
-    
-    // Profile image settings
-    if ( isset( $post_data['link_page_profile_img_size'] ) ) {
-        $profile_size = absint( $post_data['link_page_profile_img_size'] );
-        $css_vars['--link-page-profile-img-size'] = $profile_size . '%';
-    }
-    if ( isset( $post_data['link_page_profile_img_shape'] ) ) {
-        $profile_shape = sanitize_text_field( $post_data['link_page_profile_img_shape'] );
-        if ( in_array( $profile_shape, array( 'circle', 'square', 'rectangle' ) ) ) {
-            $css_vars['--link-page-profile-img-shape'] = $profile_shape;
-        }
-    }
-    
-    // Overlay
-    if ( isset( $post_data['link_page_overlay_toggle_present'] ) ) {
-        $css_vars['overlay'] = isset( $post_data['link_page_overlay_toggle'] ) && $post_data['link_page_overlay_toggle'] === '1' ? '1' : '0';
-    }
-    
-    if ( ! empty( $css_vars ) ) {
-        $save_data['css_vars'] = $css_vars;
-    }
+	// CSS variables - Read directly from form inputs (no JSON intermediary)
+	$css_vars = array();
 
-    // Advanced settings
-    $save_data['link_expiration_enabled'] = isset( $post_data['link_expiration_enabled_advanced'] ) && $post_data['link_expiration_enabled_advanced'] == '1' ? '1' : '0';
-    $save_data['redirect_enabled'] = isset( $post_data['link_page_redirect_enabled'] ) && $post_data['link_page_redirect_enabled'] == '1' ? '1' : '0';
-    
-    if ( $save_data['redirect_enabled'] === '1' && isset( $post_data['link_page_redirect_target_url'] ) ) {
-        $save_data['redirect_target_url'] = esc_url_raw( wp_unslash( $post_data['link_page_redirect_target_url'] ) );
-    }
+	// Colors
+	if ( isset( $post_data['link_page_button_color'] ) ) {
+		$css_vars['--link-page-button-bg-color'] = sanitize_hex_color( $post_data['link_page_button_color'] );
+	}
+	if ( isset( $post_data['link_page_text_color'] ) ) {
+		$css_vars['--link-page-text-color'] = sanitize_hex_color( $post_data['link_page_text_color'] );
+	}
+	if ( isset( $post_data['link_page_link_text_color'] ) ) {
+		$css_vars['--link-page-link-text-color'] = sanitize_hex_color( $post_data['link_page_link_text_color'] );
+	}
+	if ( isset( $post_data['link_page_hover_color'] ) ) {
+		$css_vars['--link-page-button-hover-bg-color'] = sanitize_hex_color( $post_data['link_page_hover_color'] );
+	}
+	if ( isset( $post_data['link_page_button_border_color'] ) ) {
+		$css_vars['--link-page-button-border-color'] = sanitize_hex_color( $post_data['link_page_button_border_color'] );
+	}
 
-    // YouTube embed (inverted logic - checkbox disables feature)
-    $save_data['youtube_embed_enabled'] = isset( $post_data['disable_youtube_inline_embed'] ) && $post_data['disable_youtube_inline_embed'] == '1' ? '0' : '1';
+	// Background
+	if ( isset( $post_data['link_page_background_type'] ) ) {
+		$bg_type = sanitize_text_field( $post_data['link_page_background_type'] );
+		if ( in_array( $bg_type, array( 'color', 'gradient', 'image' ) ) ) {
+			$css_vars['--link-page-background-type'] = $bg_type;
+		}
+	}
+	if ( isset( $post_data['link_page_background_color'] ) ) {
+		$css_vars['--link-page-background-color'] = sanitize_hex_color( $post_data['link_page_background_color'] );
+	}
+	if ( isset( $post_data['link_page_background_gradient_start'] ) ) {
+		$css_vars['--link-page-background-gradient-start'] = sanitize_hex_color( $post_data['link_page_background_gradient_start'] );
+	}
+	if ( isset( $post_data['link_page_background_gradient_end'] ) ) {
+		$css_vars['--link-page-background-gradient-end'] = sanitize_hex_color( $post_data['link_page_background_gradient_end'] );
+	}
+	if ( isset( $post_data['link_page_background_gradient_direction'] ) ) {
+		$direction = sanitize_text_field( $post_data['link_page_background_gradient_direction'] );
+		if ( in_array( $direction, array( 'to right', 'to bottom', '135deg' ) ) ) {
+			$css_vars['--link-page-background-gradient-direction'] = $direction;
+		}
+	}
 
-    // Tracking IDs
-    if ( isset( $post_data['link_page_meta_pixel_id'] ) ) {
-        $meta_pixel = trim( wp_unslash( $post_data['link_page_meta_pixel_id'] ) );
-        $save_data['meta_pixel_id'] = empty( $meta_pixel ) ? '' : ( ctype_digit( $meta_pixel ) ? $meta_pixel : '' );
-    }
+	// Typography
+	if ( isset( $post_data['link_page_title_font_family'] ) ) {
+		$css_vars['--link-page-title-font-family'] = sanitize_text_field( $post_data['link_page_title_font_family'] );
+	}
+	if ( isset( $post_data['link_page_title_font_size'] ) ) {
+		// Convert slider value (0-100) to em using original formula
+		$slider_percentage                       = absint( $post_data['link_page_title_font_size'] );
+		$font_size_min_em                        = 0.8;
+		$font_size_max_em                        = 3.5;
+		$em_value                                = $font_size_min_em + ( $font_size_max_em - $font_size_min_em ) * ( $slider_percentage / 100 );
+		$css_vars['--link-page-title-font-size'] = round( $em_value, 2 ) . 'em';
+	}
+	if ( isset( $post_data['link_page_body_font_family'] ) ) {
+		$css_vars['--link-page-body-font-family'] = sanitize_text_field( $post_data['link_page_body_font_family'] );
+	}
+	// Removed body font size processing - uses theme default font size
 
-    if ( isset( $post_data['link_page_google_tag_id'] ) ) {
-        $google_tag = trim( wp_unslash( $post_data['link_page_google_tag_id'] ) );
-        $save_data['google_tag_id'] = empty( $google_tag ) ? '' : ( preg_match( '/^(G|AW)-[a-zA-Z0-9]+$/', $google_tag ) ? $google_tag : '' );
-    }
+	// Button styling
+	if ( isset( $post_data['link_page_button_radius'] ) ) {
+		$button_radius                         = absint( $post_data['link_page_button_radius'] );
+		$css_vars['--link-page-button-radius'] = $button_radius . 'px';
+	}
 
-    // UI settings
-    if ( isset( $post_data['link_page_social_icons_position'] ) ) {
-        $position = sanitize_text_field( $post_data['link_page_social_icons_position'] );
-        $save_data['social_icons_position'] = in_array( $position, array( 'above', 'below' ), true ) ? $position : 'above';
-    }
+	// Profile image settings
+	if ( isset( $post_data['link_page_profile_img_size'] ) ) {
+		$profile_size                             = absint( $post_data['link_page_profile_img_size'] );
+		$css_vars['--link-page-profile-img-size'] = $profile_size . '%';
+	}
+	if ( isset( $post_data['link_page_profile_img_shape'] ) ) {
+		$profile_shape = sanitize_text_field( $post_data['link_page_profile_img_shape'] );
+		if ( in_array( $profile_shape, array( 'circle', 'square', 'rectangle' ) ) ) {
+			$css_vars['--link-page-profile-img-shape'] = $profile_shape;
+		}
+	}
 
-    // Subscription settings
-    if ( isset( $post_data['link_page_subscribe_display_mode'] ) ) {
-        $mode = sanitize_text_field( $post_data['link_page_subscribe_display_mode'] );
-        $save_data['subscribe_display_mode'] = in_array( $mode, array( 'icon_modal', 'inline_form', 'disabled' ), true ) ? $mode : '';
-    }
+	// Overlay
+	if ( isset( $post_data['link_page_overlay_toggle_present'] ) ) {
+		$css_vars['overlay'] = isset( $post_data['link_page_overlay_toggle'] ) && $post_data['link_page_overlay_toggle'] === '1' ? '1' : '0';
+	}
 
-    if ( isset( $post_data['link_page_subscribe_description'] ) ) {
-        $description = trim( wp_unslash( $post_data['link_page_subscribe_description'] ) );
-        $save_data['subscribe_description'] = $description !== '' ? $description : '';
-    }
+	if ( ! empty( $css_vars ) ) {
+		$save_data['css_vars'] = $css_vars;
+	}
 
-    // Profile image removal
-    if ( isset( $post_data['remove_link_page_profile_image'] ) ) {
-        $save_data['remove_profile_image'] = $post_data['remove_link_page_profile_image'] === '1';
-    }
+	// Advanced settings
+	$save_data['link_expiration_enabled'] = isset( $post_data['link_expiration_enabled_advanced'] ) && $post_data['link_expiration_enabled_advanced'] == '1' ? '1' : '0';
+	$save_data['redirect_enabled']        = isset( $post_data['link_page_redirect_enabled'] ) && $post_data['link_page_redirect_enabled'] == '1' ? '1' : '0';
 
-    return $save_data;
+	if ( $save_data['redirect_enabled'] === '1' && isset( $post_data['link_page_redirect_target_url'] ) ) {
+		$save_data['redirect_target_url'] = esc_url_raw( wp_unslash( $post_data['link_page_redirect_target_url'] ) );
+	}
+
+	// YouTube embed (inverted logic - checkbox disables feature)
+	$save_data['youtube_embed_enabled'] = isset( $post_data['disable_youtube_inline_embed'] ) && $post_data['disable_youtube_inline_embed'] == '1' ? '0' : '1';
+
+	// Tracking IDs
+	if ( isset( $post_data['link_page_meta_pixel_id'] ) ) {
+		$meta_pixel                 = trim( wp_unslash( $post_data['link_page_meta_pixel_id'] ) );
+		$save_data['meta_pixel_id'] = empty( $meta_pixel ) ? '' : ( ctype_digit( $meta_pixel ) ? $meta_pixel : '' );
+	}
+
+	if ( isset( $post_data['link_page_google_tag_id'] ) ) {
+		$google_tag                 = trim( wp_unslash( $post_data['link_page_google_tag_id'] ) );
+		$save_data['google_tag_id'] = empty( $google_tag ) ? '' : ( preg_match( '/^(G|AW)-[a-zA-Z0-9]+$/', $google_tag ) ? $google_tag : '' );
+	}
+
+	// UI settings
+	if ( isset( $post_data['link_page_social_icons_position'] ) ) {
+		$position                           = sanitize_text_field( $post_data['link_page_social_icons_position'] );
+		$save_data['social_icons_position'] = in_array( $position, array( 'above', 'below' ), true ) ? $position : 'above';
+	}
+
+	// Subscription settings
+	if ( isset( $post_data['link_page_subscribe_display_mode'] ) ) {
+		$mode                                = sanitize_text_field( $post_data['link_page_subscribe_display_mode'] );
+		$save_data['subscribe_display_mode'] = in_array( $mode, array( 'icon_modal', 'inline_form', 'disabled' ), true ) ? $mode : '';
+	}
+
+	if ( isset( $post_data['link_page_subscribe_description'] ) ) {
+		$description                        = trim( wp_unslash( $post_data['link_page_subscribe_description'] ) );
+		$save_data['subscribe_description'] = $description !== '' ? $description : '';
+	}
+
+	// Profile image removal
+	if ( isset( $post_data['remove_link_page_profile_image'] ) ) {
+		$save_data['remove_profile_image'] = $post_data['remove_link_page_profile_image'] === '1';
+	}
+
+	return $save_data;
 }
 
 /**
@@ -483,228 +482,228 @@ function ec_prepare_link_page_save_data( $post_data ) {
  * meta fields, file uploads, and member management. Triggers post-save
  * synchronization via action hooks.
  *
- * @param int $artist_id The artist profile ID
+ * @param int   $artist_id The artist profile ID
  * @param array $save_data Array of prepared save data
  * @param array $files_data $_FILES array if applicable
  * @return bool|WP_Error True on success, WP_Error on failure
  */
 function ec_handle_artist_profile_save( $artist_id, $save_data = array(), $files_data = array() ) {
-    
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID' );
-    }
 
-    // Prepare post update data
-    $post_data = array( 'ID' => $artist_id );
-    $perform_post_update = false;
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID' );
+	}
 
-    // Handle title update
-    if ( isset( $save_data['post_title'] ) && ! empty( $save_data['post_title'] ) ) {
-        $current_title = get_the_title( $artist_id );
-        if ( $current_title !== $save_data['post_title'] ) {
-            $post_data['post_title'] = $save_data['post_title'];
-            $perform_post_update = true;
-        }
-    }
+	// Prepare post update data
+	$post_data           = array( 'ID' => $artist_id );
+	$perform_post_update = false;
 
-    // Handle content (bio) update
-    if ( isset( $save_data['post_content'] ) ) {
-        $current_content = get_post_field( 'post_content', $artist_id );
-        if ( $current_content !== $save_data['post_content'] ) {
-            $post_data['post_content'] = $save_data['post_content'];
-            $perform_post_update = true;
-        }
-    }
+	// Handle title update
+	if ( isset( $save_data['post_title'] ) && ! empty( $save_data['post_title'] ) ) {
+		$current_title = get_the_title( $artist_id );
+		if ( $current_title !== $save_data['post_title'] ) {
+			$post_data['post_title'] = $save_data['post_title'];
+			$perform_post_update     = true;
+		}
+	}
 
-    // Perform post update if needed
-    if ( $perform_post_update ) {
-        $update_result = wp_update_post( $post_data, true );
-        if ( is_wp_error( $update_result ) ) {
-            return $update_result;
-        }
-    }
+	// Handle content (bio) update
+	if ( isset( $save_data['post_content'] ) ) {
+		$current_content = get_post_field( 'post_content', $artist_id );
+		if ( $current_content !== $save_data['post_content'] ) {
+			$post_data['post_content'] = $save_data['post_content'];
+			$perform_post_update       = true;
+		}
+	}
 
-    // Handle meta data updates
-    $meta_fields = array(
-        'genre' => '_genre',
-        'local_city' => '_local_city'
-    );
+	// Perform post update if needed
+	if ( $perform_post_update ) {
+		$update_result = wp_update_post( $post_data, true );
+		if ( is_wp_error( $update_result ) ) {
+			return $update_result;
+		}
+	}
 
-    foreach ( $meta_fields as $key => $meta_key ) {
-        if ( array_key_exists( $key, $save_data ) ) {
-            if ( $save_data[$key] === '' || $save_data[$key] === null ) {
-                delete_post_meta( $artist_id, $meta_key );
-            } else {
-                update_post_meta( $artist_id, $meta_key, $save_data[$key] );
-            }
-        }
-    }
+	// Handle meta data updates
+	$meta_fields = array(
+		'genre'      => '_genre',
+		'local_city' => '_local_city',
+	);
 
-    // Handle file uploads if present
-    if ( ! empty( $files_data ) ) {
-        ec_handle_artist_profile_file_uploads( $artist_id, $files_data );
-    }
+	foreach ( $meta_fields as $key => $meta_key ) {
+		if ( array_key_exists( $key, $save_data ) ) {
+			if ( $save_data[ $key ] === '' || $save_data[ $key ] === null ) {
+				delete_post_meta( $artist_id, $meta_key );
+			} else {
+				update_post_meta( $artist_id, $meta_key, $save_data[ $key ] );
+			}
+		}
+	}
 
-    // Handle member management
-    if ( isset( $save_data['remove_member_ids'] ) && ! empty( $save_data['remove_member_ids'] ) ) {
-        $current_user_id = get_current_user_id();
-        $user_ids_to_remove = array_filter( array_map( 'absint', explode( ',', $save_data['remove_member_ids'] ) ) );
-        
-        foreach ( $user_ids_to_remove as $user_id_to_remove ) {
-            if ( $user_id_to_remove > 0 && $user_id_to_remove !== $current_user_id ) { 
-                if ( function_exists( 'ec_remove_artist_membership' ) ) {
-                    ec_remove_artist_membership( $user_id_to_remove, $artist_id );
-                }
-            }
-        }
-    }
+	// Handle file uploads if present
+	if ( ! empty( $files_data ) ) {
+		ec_handle_artist_profile_file_uploads( $artist_id, $files_data );
+	}
 
-    /**
-     * Fires when an artist profile needs post-save processing.
-     * 
-     * This action hook triggers essential post-save operations like data
-     * synchronization. Other plugins and theme functions can also hook in
-     * to perform additional operations after the artist profile data is saved.
-     * 
-     * Hooked functions should check for errors and may prevent save completion
-     * by returning WP_Error or throwing exceptions.
-     * 
-     * @since 1.0.0
-     * 
-     * @param int $artist_id The ID of the artist profile that was saved.
-     */
-    do_action( 'ec_artist_profile_save', $artist_id );
+	// Handle member management
+	if ( isset( $save_data['remove_member_ids'] ) && ! empty( $save_data['remove_member_ids'] ) ) {
+		$current_user_id    = get_current_user_id();
+		$user_ids_to_remove = array_filter( array_map( 'absint', explode( ',', $save_data['remove_member_ids'] ) ) );
 
-    return true;
+		foreach ( $user_ids_to_remove as $user_id_to_remove ) {
+			if ( $user_id_to_remove > 0 && $user_id_to_remove !== $current_user_id ) {
+				if ( function_exists( 'ec_remove_artist_membership' ) ) {
+					ec_remove_artist_membership( $user_id_to_remove, $artist_id );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Fires when an artist profile needs post-save processing.
+	 *
+	 * This action hook triggers essential post-save operations like data
+	 * synchronization. Other plugins and theme functions can also hook in
+	 * to perform additional operations after the artist profile data is saved.
+	 *
+	 * Hooked functions should check for errors and may prevent save completion
+	 * by returning WP_Error or throwing exceptions.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $artist_id The ID of the artist profile that was saved.
+	 */
+	do_action( 'ec_artist_profile_save', $artist_id );
+
+	return true;
 }
 
 /**
  * Artist profile save completion handler
- * 
+ *
  * Triggered by ec_artist_profile_save action to complete the save process
  * by triggering cross-system synchronization.
- * 
+ *
  * @param int $artist_id The saved artist profile ID
  * @return void
  */
 function ec_handle_artist_profile_save_completion( $artist_id ) {
-    // Trigger sync action directly
-    do_action( 'ec_artist_platform_sync', $artist_id );
+	// Trigger sync action directly
+	do_action( 'ec_artist_platform_sync', $artist_id );
 }
 add_action( 'ec_artist_profile_save', 'ec_handle_artist_profile_save_completion', 10, 1 );
 
 
 /**
  * Prepare save data from POST array for artist profiles
- * 
+ *
  * Sanitizes and validates all form data for artist profile saves.
  * Handles title, bio, genre, location, forum settings, and member
  * management data with proper sanitization.
- * 
+ *
  * @param array $post_data $_POST array from form submission
  * @return array Prepared and sanitized save data
  */
 function ec_prepare_artist_profile_save_data( $post_data ) {
-    $save_data = array();
+	$save_data = array();
 
-    // Title (required)
-    if ( isset( $post_data['artist_title'] ) ) {
-        $save_data['post_title'] = sanitize_text_field( $post_data['artist_title'] );
-    }
+	// Title (required)
+	if ( isset( $post_data['artist_title'] ) ) {
+		$save_data['post_title'] = sanitize_text_field( $post_data['artist_title'] );
+	}
 
-    // Bio (Content)
-    if ( isset( $post_data['artist_bio'] ) ) {
-        $save_data['post_content'] = wp_kses_post( wp_unslash( $post_data['artist_bio'] ) );
-    }
+	// Bio (Content)
+	if ( isset( $post_data['artist_bio'] ) ) {
+		$save_data['post_content'] = wp_kses_post( wp_unslash( $post_data['artist_bio'] ) );
+	}
 
-    // Genre
-    if ( isset( $post_data['genre'] ) ) {
-        $save_data['genre'] = sanitize_text_field( $post_data['genre'] );
-    }
+	// Genre
+	if ( isset( $post_data['genre'] ) ) {
+		$save_data['genre'] = sanitize_text_field( $post_data['genre'] );
+	}
 
-    // Local Scene (City)
-    if ( isset( $post_data['local_city'] ) ) {
-        $save_data['local_city'] = sanitize_text_field( $post_data['local_city'] );
-    }
+	// Local Scene (City)
+	if ( isset( $post_data['local_city'] ) ) {
+		$save_data['local_city'] = sanitize_text_field( $post_data['local_city'] );
+	}
 
-    // Member Management
-    if ( isset( $post_data['remove_member_ids'] ) ) {
-        $save_data['remove_member_ids'] = sanitize_text_field( $post_data['remove_member_ids'] );
-    }
+	// Member Management
+	if ( isset( $post_data['remove_member_ids'] ) ) {
+		$save_data['remove_member_ids'] = sanitize_text_field( $post_data['remove_member_ids'] );
+	}
 
-    return $save_data;
+	return $save_data;
 }
 
 /**
  * Admin post handler for link page form submissions
- * 
+ *
  * Handles secure form submission processing with nonce verification,
  * permission checks, data preparation, and save execution. Redirects
  * back to management interface with appropriate feedback.
- * 
+ *
  * @return void Dies on error, redirects on success
  */
 function ec_admin_post_save_link_page() {
-    // Verify nonce
-    if ( ! isset( $_POST['ec_save_link_page_nonce'] ) ||
-         ! wp_verify_nonce( $_POST['ec_save_link_page_nonce'], 'ec_save_link_page_action' ) ) {
-        wp_die( __( 'Security check failed.', 'extrachill-artist-platform' ) );
-    }
-    
-    // Check user is logged in
-    if ( ! is_user_logged_in() ) {
-        wp_die( __( 'Permission denied: You must be logged in to save changes.', 'extrachill-artist-platform' ) );
-    }
-    
-    // Get link page and artist IDs directly from form data
-    $link_page_id = absint($_POST['link_page_id']);
-    $artist_id = absint($_POST['artist_id']);
-    
-    if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
-        wp_die( __( 'Invalid link page.', 'extrachill-artist-platform' ) );
-    }
-    
-    // Check user permissions
-    if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-        wp_die( __( 'Permission denied: You do not have access to manage this artist.', 'extrachill-artist-platform' ) );
-    }
-    
-    // Prepare and save data using centralized functions
-    $save_data = ec_prepare_link_page_save_data( $_POST );
-    $result = ec_handle_link_page_save( $link_page_id, $save_data, $_FILES );
-    
-    if ( is_wp_error( $result ) ) {
-        // Handle upload errors with centralized notice system
-        $error_data = $result->get_error_data();
-        $error_messages = array(
-            'background_image_size' => __( 'Background image file size exceeds the 5MB limit.', 'extrachill-artist-platform' ),
-            'profile_image_size'    => __( 'Profile image file size exceeds the 5MB limit.', 'extrachill-artist-platform' ),
-            'upload_failed'         => __( 'Profile image upload failed. Please try again.', 'extrachill-artist-platform' ),
-            'general'               => __( 'An error occurred while saving. Please try again.', 'extrachill-artist-platform' ),
-        );
-        $error_code = isset( $error_data['error_code'] ) ? $error_data['error_code'] : 'general';
-        $message = isset( $error_messages[ $error_code ] ) ? $error_messages[ $error_code ] : $error_messages['general'];
-        extrachill_set_notice( $message, 'error' );
-        
-        $manage_page = get_page_by_path( 'manage-link-page' );
-        $base_url = $manage_page ? get_permalink( $manage_page ) : home_url( '/manage-link-page/' );
-        wp_safe_redirect( $base_url );
-        exit;
-    }
-    
-    // Success - set notice and redirect
-    extrachill_set_notice( __( 'Link page updated successfully!', 'extrachill-artist-platform' ), 'success' );
-    $manage_page = get_page_by_path( 'manage-link-page' );
-    $base_url = $manage_page ? get_permalink( $manage_page ) : home_url( '/manage-link-page/' );
-    wp_safe_redirect( $base_url );
-    exit;
+	// Verify nonce
+	if ( ! isset( $_POST['ec_save_link_page_nonce'] ) ||
+		! wp_verify_nonce( $_POST['ec_save_link_page_nonce'], 'ec_save_link_page_action' ) ) {
+		wp_die( __( 'Security check failed.', 'extrachill-artist-platform' ) );
+	}
+
+	// Check user is logged in
+	if ( ! is_user_logged_in() ) {
+		wp_die( __( 'Permission denied: You must be logged in to save changes.', 'extrachill-artist-platform' ) );
+	}
+
+	// Get link page and artist IDs directly from form data
+	$link_page_id = absint( $_POST['link_page_id'] );
+	$artist_id    = absint( $_POST['artist_id'] );
+
+	if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+		wp_die( __( 'Invalid link page.', 'extrachill-artist-platform' ) );
+	}
+
+	// Check user permissions
+	if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+		wp_die( __( 'Permission denied: You do not have access to manage this artist.', 'extrachill-artist-platform' ) );
+	}
+
+	// Prepare and save data using centralized functions
+	$save_data = ec_prepare_link_page_save_data( $_POST );
+	$result    = ec_handle_link_page_save( $link_page_id, $save_data, $_FILES );
+
+	if ( is_wp_error( $result ) ) {
+		// Handle upload errors with centralized notice system
+		$error_data     = $result->get_error_data();
+		$error_messages = array(
+			'background_image_size' => __( 'Background image file size exceeds the 5MB limit.', 'extrachill-artist-platform' ),
+			'profile_image_size'    => __( 'Profile image file size exceeds the 5MB limit.', 'extrachill-artist-platform' ),
+			'upload_failed'         => __( 'Profile image upload failed. Please try again.', 'extrachill-artist-platform' ),
+			'general'               => __( 'An error occurred while saving. Please try again.', 'extrachill-artist-platform' ),
+		);
+		$error_code     = isset( $error_data['error_code'] ) ? $error_data['error_code'] : 'general';
+		$message        = isset( $error_messages[ $error_code ] ) ? $error_messages[ $error_code ] : $error_messages['general'];
+		extrachill_set_notice( $message, 'error' );
+
+		$manage_page = get_page_by_path( 'manage-link-page' );
+		$base_url    = $manage_page ? get_permalink( $manage_page ) : home_url( '/manage-link-page/' );
+		wp_safe_redirect( $base_url );
+		exit;
+	}
+
+	// Success - set notice and redirect
+	extrachill_set_notice( __( 'Link page updated successfully!', 'extrachill-artist-platform' ), 'success' );
+	$manage_page = get_page_by_path( 'manage-link-page' );
+	$base_url    = $manage_page ? get_permalink( $manage_page ) : home_url( '/manage-link-page/' );
+	wp_safe_redirect( $base_url );
+	exit;
 }
 add_action( 'template_redirect', 'ec_handle_link_page_form_submission' );
 
 function ec_handle_link_page_form_submission() {
-    if ( $_SERVER['REQUEST_METHOD'] === 'POST' && 
-         isset($_POST['action']) && 
-         $_POST['action'] === 'ec_save_link_page' ) {
-        ec_admin_post_save_link_page();
-    }
+	if ( $_SERVER['REQUEST_METHOD'] === 'POST' &&
+		isset( $_POST['action'] ) &&
+		$_POST['action'] === 'ec_save_link_page' ) {
+		ec_admin_post_save_link_page();
+	}
 }

--- a/inc/core/actions/sync.php
+++ b/inc/core/actions/sync.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Centralized Artist Platform Sync Operations
- * 
+ *
  * Handles complete bidirectional synchronization between artist profiles and link pages.
  * One unified sync action handles ALL data - no granular sync types needed.
  *
@@ -14,19 +14,19 @@ defined( 'ABSPATH' ) || exit;
  * Manages a flag to prevent recursive synchronization.
  */
 class ArtistDataSyncManager {
-    private static $is_syncing = false;
+	private static $is_syncing = false;
 
-    public static function is_syncing() {
-        return self::$is_syncing;
-    }
+	public static function is_syncing() {
+		return self::$is_syncing;
+	}
 
-    public static function start_sync() {
-        self::$is_syncing = true;
-    }
+	public static function start_sync() {
+		self::$is_syncing = true;
+	}
 
-    public static function stop_sync() {
-        self::$is_syncing = false;
-    }
+	public static function stop_sync() {
+		self::$is_syncing = false;
+	}
 }
 
 /**
@@ -36,62 +36,62 @@ class ArtistDataSyncManager {
  * @return bool|WP_Error True on success, WP_Error on failure
  */
 function ec_handle_artist_platform_sync( $artist_id ) {
-    
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for sync' );
-    }
 
-    // Check if sync is already in progress to prevent recursion
-    if ( class_exists( 'ArtistDataSyncManager' ) && ArtistDataSyncManager::is_syncing() ) {
-        return true; // Skip if already syncing
-    }
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for sync' );
+	}
 
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
-        return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
-    }
+	// Check if sync is already in progress to prevent recursion
+	if ( class_exists( 'ArtistDataSyncManager' ) && ArtistDataSyncManager::is_syncing() ) {
+		return true; // Skip if already syncing
+	}
 
-    // Get associated link page - sync skips if null
-    $link_page_id = apply_filters('ec_get_link_page_id', $artist_id);
-    if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
-        return true; // Skip sync - no link page to sync with
-    }
+	$artist_post = get_post( $artist_id );
+	if ( ! $artist_post ) {
+		return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
+	}
 
-    // Start sync protection
-    if ( class_exists( 'ArtistDataSyncManager' ) ) {
-        ArtistDataSyncManager::start_sync();
-    }
+	// Get associated link page - sync skips if null
+	$link_page_id = apply_filters( 'ec_get_link_page_id', $artist_id );
+	if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
+		return true; // Skip sync - no link page to sync with
+	}
 
-    try {
-        // Perform complete bidirectional sync
-        $sync_result = ec_perform_complete_sync( $artist_id, $link_page_id );
-        
-        if ( is_wp_error( $sync_result ) ) {
-            return $sync_result;
-        }
+	// Start sync protection
+	if ( class_exists( 'ArtistDataSyncManager' ) ) {
+		ArtistDataSyncManager::start_sync();
+	}
 
-        /**
-         * Fires after artist platform sync is completed successfully.
-         * 
-         * This action hook allows other plugins and theme functions to perform
-         * additional operations after the bidirectional sync between an artist
-         * profile and link page is complete. Commonly used for cache clearing,
-         * search index updates, or triggering external API synchronization.
-         * 
-         * @since 1.0.0
-         * 
-         * @param int $artist_id The ID of the artist profile that was synced.
-         */
-        do_action( 'ec_artist_platform_sync_complete', $artist_id );
+	try {
+		// Perform complete bidirectional sync
+		$sync_result = ec_perform_complete_sync( $artist_id, $link_page_id );
 
-        return true;
+		if ( is_wp_error( $sync_result ) ) {
+			return $sync_result;
+		}
 
-    } finally {
-        // Always stop sync protection
-        if ( class_exists( 'ArtistDataSyncManager' ) ) {
-            ArtistDataSyncManager::stop_sync();
-        }
-    }
+		/**
+		 * Fires after artist platform sync is completed successfully.
+		 *
+		 * This action hook allows other plugins and theme functions to perform
+		 * additional operations after the bidirectional sync between an artist
+		 * profile and link page is complete. Commonly used for cache clearing,
+		 * search index updates, or triggering external API synchronization.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int $artist_id The ID of the artist profile that was synced.
+		 */
+		do_action( 'ec_artist_platform_sync_complete', $artist_id );
+
+		return true;
+
+	} finally {
+		// Always stop sync protection
+		if ( class_exists( 'ArtistDataSyncManager' ) ) {
+			ArtistDataSyncManager::stop_sync();
+		}
+	}
 }
 
 /**
@@ -102,105 +102,105 @@ function ec_handle_artist_platform_sync( $artist_id ) {
  * @return bool|WP_Error True on success, WP_Error on failure
  */
 function ec_perform_complete_sync( $artist_id, $link_page_id ) {
-    
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
-        return new WP_Error( 'artist_not_found', 'Artist profile not found during sync' );
-    }
 
-    // --- ARTIST PROFILE → LINK PAGE SYNC ---
-    // Use centralized data system (single source of truth)
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    
-    // Sync Title
-    $artist_title = $artist_post->post_title;
-    $current_link_title = $data['display_title'] ?? '';
-    if ( $current_link_title !== $artist_title ) {
-        update_post_meta( $link_page_id, '_link_page_display_title', $artist_title );
-    }
+	$artist_post = get_post( $artist_id );
+	if ( ! $artist_post ) {
+		return new WP_Error( 'artist_not_found', 'Artist profile not found during sync' );
+	}
 
-    // Sync Profile Picture (Featured Image)
-    $artist_thumbnail_id = get_post_thumbnail_id( $artist_id );
-    $current_link_thumbnail_id = $data['settings']['profile_image_id'] ?? '';
-    
-    if ( $artist_thumbnail_id ) {
-        if ( $current_link_thumbnail_id != $artist_thumbnail_id ) {
-            update_post_meta( $link_page_id, '_link_page_profile_image_id', $artist_thumbnail_id );
-        }
-    } elseif ( $current_link_thumbnail_id ) {
-        // Artist has no thumbnail, remove from link page
-        delete_post_meta( $link_page_id, '_link_page_profile_image_id' );
-    }
+	// --- ARTIST PROFILE → LINK PAGE SYNC ---
+	// Use centralized data system (single source of truth)
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
 
-    // --- LINK PAGE → ARTIST PROFILE SYNC ---
-    
-    // Use centralized data that might have been updated independently (already retrieved above)
-    $link_page_title = $data['display_title'] ?? '';
-    $link_page_thumbnail_id = $data['settings']['profile_image_id'] ?? '';
+	// Sync Title
+	$artist_title       = $artist_post->post_title;
+	$current_link_title = $data['display_title'] ?? '';
+	if ( $current_link_title !== $artist_title ) {
+		update_post_meta( $link_page_id, '_link_page_display_title', $artist_title );
+	}
 
-    $artist_update_data = array( 'ID' => $artist_id );
-    $needs_artist_update = false;
+	// Sync Profile Picture (Featured Image)
+	$artist_thumbnail_id       = get_post_thumbnail_id( $artist_id );
+	$current_link_thumbnail_id = $data['settings']['profile_image_id'] ?? '';
 
-    // Sync title back to artist profile if link page has different data
-    if ( ! empty( $link_page_title ) && $link_page_title !== $artist_post->post_title ) {
-        $artist_update_data['post_title'] = $link_page_title;
-        $needs_artist_update = true;
-    }
+	if ( $artist_thumbnail_id ) {
+		if ( $current_link_thumbnail_id != $artist_thumbnail_id ) {
+			update_post_meta( $link_page_id, '_link_page_profile_image_id', $artist_thumbnail_id );
+		}
+	} elseif ( $current_link_thumbnail_id ) {
+		// Artist has no thumbnail, remove from link page
+		delete_post_meta( $link_page_id, '_link_page_profile_image_id' );
+	}
 
-    // Update artist profile if needed
-    if ( $needs_artist_update ) {
-        $update_result = wp_update_post( $artist_update_data, true );
-        if ( is_wp_error( $update_result ) ) {
-            return $update_result;
-        }
-    }
+	// --- LINK PAGE → ARTIST PROFILE SYNC ---
 
-    // Sync profile picture back to artist if link page has different image
-    if ( ! empty( $link_page_thumbnail_id ) && absint( $link_page_thumbnail_id ) > 0 ) {
-        if ( absint( $artist_thumbnail_id ) !== absint( $link_page_thumbnail_id ) ) {
-            set_post_thumbnail( $artist_id, absint( $link_page_thumbnail_id ) );
-        }
-    }
+	// Use centralized data that might have been updated independently (already retrieved above)
+	$link_page_title        = $data['display_title'] ?? '';
+	$link_page_thumbnail_id = $data['settings']['profile_image_id'] ?? '';
 
-    return true;
+	$artist_update_data  = array( 'ID' => $artist_id );
+	$needs_artist_update = false;
+
+	// Sync title back to artist profile if link page has different data
+	if ( ! empty( $link_page_title ) && $link_page_title !== $artist_post->post_title ) {
+		$artist_update_data['post_title'] = $link_page_title;
+		$needs_artist_update              = true;
+	}
+
+	// Update artist profile if needed
+	if ( $needs_artist_update ) {
+		$update_result = wp_update_post( $artist_update_data, true );
+		if ( is_wp_error( $update_result ) ) {
+			return $update_result;
+		}
+	}
+
+	// Sync profile picture back to artist if link page has different image
+	if ( ! empty( $link_page_thumbnail_id ) && absint( $link_page_thumbnail_id ) > 0 ) {
+		if ( absint( $artist_thumbnail_id ) !== absint( $link_page_thumbnail_id ) ) {
+			set_post_thumbnail( $artist_id, absint( $link_page_thumbnail_id ) );
+		}
+	}
+
+	return true;
 }
 
 /**
  * Hook meta updates to trigger unified sync
  *
- * @param int $meta_id ID of the metadata entry
- * @param int $object_id ID of the object (post ID) 
+ * @param int    $meta_id ID of the metadata entry
+ * @param int    $object_id ID of the object (post ID)
  * @param string $meta_key Meta key being updated
- * @param mixed $meta_value New meta value
+ * @param mixed  $meta_value New meta value
  */
 function ec_sync_on_meta_update( $meta_id, $object_id, $meta_key, $meta_value ) {
-    // Suppress unused parameter warnings - we need all 4 parameters for the hook signature
-    unset( $meta_id, $meta_value );
-    // Only sync on relevant link page meta keys
-    $sync_keys = array(
-        '_link_page_display_title',
-        '_link_page_profile_image_id'
-    );
-    
-    if ( get_post_type( $object_id ) === 'artist_link_page' && 
-         in_array( $meta_key, $sync_keys, true ) ) {
-        
-        $artist_id = apply_filters('ec_get_artist_id', $object_id);
-        if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
-            ec_handle_artist_platform_sync( $artist_id );
-        }
-    }
+	// Suppress unused parameter warnings - we need all 4 parameters for the hook signature
+	unset( $meta_id, $meta_value );
+	// Only sync on relevant link page meta keys
+	$sync_keys = array(
+		'_link_page_display_title',
+		'_link_page_profile_image_id',
+	);
+
+	if ( get_post_type( $object_id ) === 'artist_link_page' &&
+		in_array( $meta_key, $sync_keys, true ) ) {
+
+		$artist_id = apply_filters( 'ec_get_artist_id', $object_id );
+		if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
+			ec_handle_artist_platform_sync( $artist_id );
+		}
+	}
 }
 add_action( 'updated_post_meta', 'ec_sync_on_meta_update', 10, 4 );
 add_action( 'added_post_meta', 'ec_sync_on_meta_update', 10, 4 );
 
 /**
  * Sync action handler
- * 
+ *
  * Triggered by ec_artist_platform_sync action to perform the actual sync.
  */
 function ec_handle_sync_action( $artist_id ) {
-    ec_handle_artist_platform_sync( $artist_id );
+	ec_handle_artist_platform_sync( $artist_id );
 }
 add_action( 'ec_artist_platform_sync', 'ec_handle_sync_action', 10, 1 );
 
@@ -211,5 +211,5 @@ add_action( 'ec_artist_platform_sync', 'ec_handle_sync_action', 10, 1 );
  * @return bool|WP_Error True on success, WP_Error on failure
  */
 function ec_sync_artist_platform( $artist_id ) {
-    return ec_handle_artist_platform_sync( $artist_id );
+	return ec_handle_artist_platform_sync( $artist_id );
 }

--- a/inc/core/artist-platform-assets.php
+++ b/inc/core/artist-platform-assets.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * ExtraChill Artist Platform Assets Class
- * 
+ *
  * Handles CSS and JavaScript asset loading with context-aware loading,
  * proper dependency management, and file existence checks. Provides
  * conditional asset loading based on page template context.
@@ -11,361 +11,364 @@ defined( 'ABSPATH' ) || exit;
 
 class ExtraChillArtistPlatform_Assets {
 
-    private static $instance = null;
+	private static $instance = null;
 
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    private function __construct() {
-        $this->init_hooks();
-    }
+	private function __construct() {
+		$this->init_hooks();
+	}
 
-    private function init_hooks() {
-        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
-        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_join_flow_assets' ) );
-        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
-        add_action( 'wp_head', array( $this, 'add_custom_styles' ) );
-    }
+	private function init_hooks() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_join_flow_assets' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+		add_action( 'wp_head', array( $this, 'add_custom_styles' ) );
+	}
 
-    /**
-     * Conditionally loads CSS and JavaScript assets based on page context
-     * (link pages, management interfaces, artist profiles) with cache busting via filemtime()
-     */
-    public function enqueue_frontend_assets() {
-        $plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
-        $plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
+	/**
+	 * Conditionally loads CSS and JavaScript assets based on page context
+	 * (link pages, management interfaces, artist profiles) with cache busting via filemtime()
+	 */
+	public function enqueue_frontend_assets() {
+		$plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
+		$plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
 
-        if ( $this->is_link_page_context() ) {
-            return;
-        }
+		if ( $this->is_link_page_context() ) {
+			return;
+		}
 
-        if ( $this->is_artist_profile_page() ) {
-            wp_enqueue_style(
-                'extrachill-artist-profile',
-                $plugin_url . 'assets/css/artist-profile.css',
-                array(),
-                $this->get_asset_version( 'assets/css/artist-profile.css' )
-            );
-        }
+		if ( $this->is_artist_profile_page() ) {
+			wp_enqueue_style(
+				'extrachill-artist-profile',
+				$plugin_url . 'assets/css/artist-profile.css',
+				array(),
+				$this->get_asset_version( 'assets/css/artist-profile.css' )
+			);
+		}
 
-        if ( $this->is_artist_directory_page() ) {
-            wp_enqueue_style(
-                'extrachill-artist-card',
-                $plugin_url . 'assets/css/artist-card.css',
-                array(),
-                $this->get_asset_version( 'assets/css/artist-card.css' )
-            );
+		if ( $this->is_artist_directory_page() ) {
+			wp_enqueue_style(
+				'extrachill-artist-card',
+				$plugin_url . 'assets/css/artist-card.css',
+				array(),
+				$this->get_asset_version( 'assets/css/artist-card.css' )
+			);
 
-            wp_enqueue_style(
-                'extrachill-artist-platform-home',
-                $plugin_url . 'assets/css/artist-platform-home.css',
-                array( 'extrachill-artist-card' ),
-                $this->get_asset_version( 'assets/css/artist-platform-home.css' )
-            );
-        }
+			wp_enqueue_style(
+				'extrachill-artist-platform-home',
+				$plugin_url . 'assets/css/artist-platform-home.css',
+				array( 'extrachill-artist-card' ),
+				$this->get_asset_version( 'assets/css/artist-platform-home.css' )
+			);
+		}
 
-        if ( $this->should_load_hero_card_styles() ) {
-            wp_enqueue_style( 'dashicons' );
-            wp_enqueue_style(
-                'extrachill-artist-card',
-                $plugin_url . 'assets/css/artist-card.css',
-                array(),
-                $this->get_asset_version( 'assets/css/artist-card.css' )
-            );
+		if ( $this->should_load_hero_card_styles() ) {
+			wp_enqueue_style( 'dashicons' );
+			wp_enqueue_style(
+				'extrachill-artist-card',
+				$plugin_url . 'assets/css/artist-card.css',
+				array(),
+				$this->get_asset_version( 'assets/css/artist-card.css' )
+			);
 
-            wp_enqueue_style(
-                'extrachill-artist-platform-home',
-                $plugin_url . 'assets/css/artist-platform-home.css',
-                array( 'extrachill-artist-platform', 'extrachill-artist-card' ),
-                $this->get_asset_version( 'assets/css/artist-platform-home.css' )
-            );
+			wp_enqueue_style(
+				'extrachill-artist-platform-home',
+				$plugin_url . 'assets/css/artist-platform-home.css',
+				array( 'extrachill-artist-platform', 'extrachill-artist-card' ),
+				$this->get_asset_version( 'assets/css/artist-platform-home.css' )
+			);
 
-            wp_enqueue_script(
-                'extrachill-artist-platform-home',
-                $plugin_url . 'assets/js/artist-platform-home.js',
-                array(),
-                $this->get_asset_version( 'assets/js/artist-platform-home.js' ),
-                true
-            );
-        }
+			wp_enqueue_script(
+				'extrachill-artist-platform-home',
+				$plugin_url . 'assets/js/artist-platform-home.js',
+				array(),
+				$this->get_asset_version( 'assets/js/artist-platform-home.js' ),
+				true
+			);
+		}
 
-        wp_enqueue_style( 
-            'extrachill-artist-platform', 
-            $plugin_url . 'assets/css/artist-platform.css', 
-            array(), 
-            $this->get_asset_version( 'assets/css/artist-platform.css' )
-        );
+		wp_enqueue_style(
+			'extrachill-artist-platform',
+			$plugin_url . 'assets/css/artist-platform.css',
+			array(),
+			$this->get_asset_version( 'assets/css/artist-platform.css' )
+		);
 
-        wp_enqueue_script( 
-            'extrachill-artist-platform', 
-            $plugin_url . 'assets/js/artist-platform.js', 
-            array(), 
-            $this->get_asset_version( 'assets/js/artist-platform.js' ), 
-            true
-        );
+		wp_enqueue_script(
+			'extrachill-artist-platform',
+			$plugin_url . 'assets/js/artist-platform.js',
+			array(),
+			$this->get_asset_version( 'assets/js/artist-platform.js' ),
+			true
+		);
 
-        $current_artist_id = apply_filters('ec_get_artist_id', $_GET);
-        $link_page_data = $current_artist_id > 0 ? ec_get_link_page_data( $current_artist_id ) : array();
+		$current_artist_id = apply_filters( 'ec_get_artist_id', $_GET );
+		$link_page_data    = $current_artist_id > 0 ? ec_get_link_page_data( $current_artist_id ) : array();
 
-        $artist_slug = '';
-        if ( $current_artist_id > 0 ) {
-            $artist_post = get_post( $current_artist_id );
-            if ( $artist_post ) {
-                $artist_slug = $artist_post->post_name;
-            }
-        }
+		$artist_slug = '';
+		if ( $current_artist_id > 0 ) {
+			$artist_post = get_post( $current_artist_id );
+			if ( $artist_post ) {
+				$artist_slug = $artist_post->post_name;
+			}
+		}
 
-        $fonts_data = array();
-        if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
-            $font_manager = ExtraChillArtistPlatform_Fonts::instance();
-            $fonts_data = $font_manager->get_supported_fonts();
-        }
+		$fonts_data = array();
+		if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
+			$font_manager = ExtraChillArtistPlatform_Fonts::instance();
+			$fonts_data   = $font_manager->get_supported_fonts();
+		}
 
-        wp_localize_script( 'extrachill-artist-platform', 'extraChillArtistPlatform', array(
-            'restUrl' => rest_url( 'extrachill/v1' ),
-            'artistSlug' => $artist_slug,
-            'restNonce' => wp_create_nonce( 'wp_rest' ),
-            'linkPageData' => $link_page_data,
-            'fonts' => $fonts_data,
-            'linkExpirationEnabled' => $link_page_data['settings']['link_expiration_enabled'] ?? false,
-            'nonces' => array(),
-            'analyticsConfig' => array(
-                'trackingEnabled' => true,
-                'trackingEndpoint' => rest_url( 'extrachill/v1/analytics' )
-            )
-        ) );
-    }
+		wp_localize_script(
+			'extrachill-artist-platform',
+			'extraChillArtistPlatform',
+			array(
+				'restUrl'               => rest_url( 'extrachill/v1' ),
+				'artistSlug'            => $artist_slug,
+				'restNonce'             => wp_create_nonce( 'wp_rest' ),
+				'linkPageData'          => $link_page_data,
+				'fonts'                 => $fonts_data,
+				'linkExpirationEnabled' => $link_page_data['settings']['link_expiration_enabled'] ?? false,
+				'nonces'                => array(),
+				'analyticsConfig'       => array(
+					'trackingEnabled'  => true,
+					'trackingEndpoint' => rest_url( 'extrachill/v1/analytics' ),
+				),
+			)
+		);
+	}
 
-    public function enqueue_admin_assets( $hook ) {
-        $plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
-        $plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
+	public function enqueue_admin_assets( $hook ) {
+		$plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
+		$plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
 
-        if ( $this->is_artist_platform_admin_page( $hook ) ) {
-            $admin_css = 'assets/css/admin.css';
-            if ( file_exists( $plugin_dir . $admin_css ) ) {
-                wp_enqueue_style( 
-                    'extrachill-artist-platform-admin', 
-                    $plugin_url . $admin_css, 
-                    array(), 
-                    $this->get_asset_version( $admin_css )
-                );
-            }
+		if ( $this->is_artist_platform_admin_page( $hook ) ) {
+			$admin_css = 'assets/css/admin.css';
+			if ( file_exists( $plugin_dir . $admin_css ) ) {
+				wp_enqueue_style(
+					'extrachill-artist-platform-admin',
+					$plugin_url . $admin_css,
+					array(),
+					$this->get_asset_version( $admin_css )
+				);
+			}
 
-            $admin_js = 'assets/js/admin.js';
-            if ( file_exists( $plugin_dir . $admin_js ) ) {
-                wp_enqueue_script( 
-                    'extrachill-artist-platform-admin', 
-                    $plugin_url . $admin_js, 
-                    array( 'jquery' ), 
-                    $this->get_asset_version( $admin_js ), 
-                    true 
-                );
-            }
-        }
-    }
+			$admin_js = 'assets/js/admin.js';
+			if ( file_exists( $plugin_dir . $admin_js ) ) {
+				wp_enqueue_script(
+					'extrachill-artist-platform-admin',
+					$plugin_url . $admin_js,
+					array( 'jquery' ),
+					$this->get_asset_version( $admin_js ),
+					true
+				);
+			}
+		}
+	}
 
-    private function enqueue_link_page_assets() {
-        $plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
+	private function enqueue_link_page_assets() {
+		$plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
 
-        wp_enqueue_style(
-            'extrachill-link-page',
-            $plugin_url . 'assets/css/extrch-links.css',
-            array(),
-            $this->get_asset_version( 'assets/css/extrch-links.css' )
-        );
+		wp_enqueue_style(
+			'extrachill-link-page',
+			$plugin_url . 'assets/css/extrch-links.css',
+			array(),
+			$this->get_asset_version( 'assets/css/extrch-links.css' )
+		);
 
-        wp_enqueue_style(
-            'extrachill-custom-social-icons',
-            $plugin_url . 'assets/css/custom-social-icons.css',
-            array( 'extrachill-link-page' ),
-            $this->get_asset_version( 'assets/css/custom-social-icons.css' )
-        );
+		wp_enqueue_style(
+			'extrachill-custom-social-icons',
+			$plugin_url . 'assets/css/custom-social-icons.css',
+			array( 'extrachill-link-page' ),
+			$this->get_asset_version( 'assets/css/custom-social-icons.css' )
+		);
 
-        wp_enqueue_style(
-            'extrachill-share-modal',
-            $plugin_url . 'assets/css/extrch-share-modal.css',
-            array(),
-            $this->get_asset_version( 'assets/css/extrch-share-modal.css' )
-        );
+		wp_enqueue_style(
+			'extrachill-share-modal',
+			$plugin_url . 'assets/css/extrch-share-modal.css',
+			array(),
+			$this->get_asset_version( 'assets/css/extrch-share-modal.css' )
+		);
 
-        wp_enqueue_script(
-            'extrachill-link-tracking',
-            $plugin_url . 'inc/link-pages/live/assets/js/link-page-public-tracking.js',
-            array(),
-            $this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-public-tracking.js' ),
-            true
-        );
+		wp_enqueue_script(
+			'extrachill-link-tracking',
+			$plugin_url . 'inc/link-pages/live/assets/js/link-page-public-tracking.js',
+			array(),
+			$this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-public-tracking.js' ),
+			true
+		);
 
-        wp_enqueue_script(
-            'extrachill-share-modal',
-            $plugin_url . 'inc/link-pages/live/assets/js/extrch-share-modal.js',
-            array(),
-            $this->get_asset_version( 'inc/link-pages/live/assets/js/extrch-share-modal.js' ),
-            true
-        );
+		wp_enqueue_script(
+			'extrachill-share-modal',
+			$plugin_url . 'inc/link-pages/live/assets/js/extrch-share-modal.js',
+			array(),
+			$this->get_asset_version( 'inc/link-pages/live/assets/js/extrch-share-modal.js' ),
+			true
+		);
 
-        wp_enqueue_script(
-            'extrachill-subscribe',
-            $plugin_url . 'inc/link-pages/live/assets/js/link-page-subscribe.js',
-            array(),
-            $this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-subscribe.js' ),
-            true
-        );
+		wp_enqueue_script(
+			'extrachill-subscribe',
+			$plugin_url . 'inc/link-pages/live/assets/js/link-page-subscribe.js',
+			array(),
+			$this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-subscribe.js' ),
+			true
+		);
 
-        wp_enqueue_script(
-            'extrachill-youtube-embed',
-            $plugin_url . 'inc/link-pages/live/assets/js/link-page-youtube-embed.js',
-            array(),
-            $this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-youtube-embed.js' ),
-            true
-        );
+		wp_enqueue_script(
+			'extrachill-youtube-embed',
+			$plugin_url . 'inc/link-pages/live/assets/js/link-page-youtube-embed.js',
+			array(),
+			$this->get_asset_version( 'inc/link-pages/live/assets/js/link-page-youtube-embed.js' ),
+			true
+		);
+	}
 
-    }
+	private function enqueue_link_page_google_fonts() {
+		// Get current artist and link page IDs
+		$artist_id = apply_filters( 'ec_get_artist_id', $_GET );
+		if ( ! $artist_id ) {
+			return;
+		}
 
-    private function enqueue_link_page_google_fonts() {
-        // Get current artist and link page IDs
-        $artist_id = apply_filters('ec_get_artist_id', $_GET);
-        if ( ! $artist_id ) {
-            return;
-        }
-        
-        $link_page_id = apply_filters('ec_get_link_page_id', $artist_id);
-        if ( ! $link_page_id ) {
-            return;
-        }
-        
-        // Get link page data with font settings using centralized data provider
-        $link_page_data = ec_get_link_page_data( $artist_id, $link_page_id );
-        $custom_vars = $link_page_data['css_vars'] ?? array();
-        
-        $fonts_manager = ExtraChillArtistPlatform_Fonts::instance();
-        
-        // Enqueue title font
-        if ( ! empty( $custom_vars['--link-page-title-font-family'] ) ) {
-            $title_font_stack = $custom_vars['--link-page-title-font-family'];
-            $title_font_value = trim( explode( ',', trim( $title_font_stack ), 2 )[0], " '" );
-            $google_font_param = $fonts_manager->get_google_font_param( $title_font_value );
-            
-            if ( $google_font_param ) {
-                wp_enqueue_style( 
-                    'extrachill-link-page-title-font', 
-                    'https://fonts.googleapis.com/css2?family=' . $google_font_param . '&display=swap',
-                    array(),
-                    null // Google Fonts don't need versioning
-                );
-            }
-        }
-        
-        // Enqueue body font
-        if ( ! empty( $custom_vars['--link-page-body-font-family'] ) ) {
-            $body_font_stack = $custom_vars['--link-page-body-font-family'];
-            $body_font_value = trim( explode( ',', trim( $body_font_stack ), 2 )[0], " '" );
-            $google_font_param = $fonts_manager->get_google_font_param( $body_font_value );
-            
-            if ( $google_font_param ) {
-                wp_enqueue_style( 
-                    'extrachill-link-page-body-font', 
-                    'https://fonts.googleapis.com/css2?family=' . $google_font_param . '&display=swap',
-                    array(),
-                    null // Google Fonts don't need versioning
-                );
-            }
-        }
-    }
+		$link_page_id = apply_filters( 'ec_get_link_page_id', $artist_id );
+		if ( ! $link_page_id ) {
+			return;
+		}
 
-    /**
-     * CSS variables now generated by link-page-head.php and preview.php only
-     * via centralized ec_get_link_page_data() function
-     */
-    public function add_custom_styles() {
-        // CSS variables are now generated by link-page-head.php and preview.php only
-        // This removes duplication and maintains centralized control
-    }
+		// Get link page data with font settings using centralized data provider
+		$link_page_data = ec_get_link_page_data( $artist_id, $link_page_id );
+		$custom_vars    = $link_page_data['css_vars'] ?? array();
 
-    private function is_link_page_context() {
-        return is_singular( 'artist_link_page' ) || 
-               ( isset( $_GET['artist_link_page'] ) && ! empty( $_GET['artist_link_page'] ) );
-    }
+		$fonts_manager = ExtraChillArtistPlatform_Fonts::instance();
 
-    private function is_artist_directory_page() {
-        return is_page() && 
-               ( get_page_template_slug() === 'artist-directory.php' || 
-                 strpos( get_page_template_slug(), 'artist-directory' ) !== false );
-    }
+		// Enqueue title font
+		if ( ! empty( $custom_vars['--link-page-title-font-family'] ) ) {
+			$title_font_stack  = $custom_vars['--link-page-title-font-family'];
+			$title_font_value  = trim( explode( ',', trim( $title_font_stack ), 2 )[0], " '" );
+			$google_font_param = $fonts_manager->get_google_font_param( $title_font_value );
 
-    private function is_artist_profile_page() {
-        return is_singular( 'artist_profile' );
-    }
+			if ( $google_font_param ) {
+				wp_enqueue_style(
+					'extrachill-link-page-title-font',
+					'https://fonts.googleapis.com/css2?family=' . $google_font_param . '&display=swap',
+					array(),
+					null // Google Fonts don't need versioning
+				);
+			}
+		}
 
-    private function should_load_hero_card_styles() {
-        // Artist platform homepage on artist.extrachill.com (site #4)
-        $is_home_page = false;
-        if ( is_front_page() || is_home() ) {
-            $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-            $is_home_page   = $artist_blog_id && get_current_blog_id() === $artist_blog_id;
-        }
+		// Enqueue body font
+		if ( ! empty( $custom_vars['--link-page-body-font-family'] ) ) {
+			$body_font_stack   = $custom_vars['--link-page-body-font-family'];
+			$body_font_value   = trim( explode( ',', trim( $body_font_stack ), 2 )[0], " '" );
+			$google_font_param = $fonts_manager->get_google_font_param( $body_font_value );
 
-        // Artist profiles archive page (/artists)
-        $is_artist_archive = is_post_type_archive( 'artist_profile' );
+			if ( $google_font_param ) {
+				wp_enqueue_style(
+					'extrachill-link-page-body-font',
+					'https://fonts.googleapis.com/css2?family=' . $google_font_param . '&display=swap',
+					array(),
+					null // Google Fonts don't need versioning
+				);
+			}
+		}
+	}
 
-        return $is_home_page || $is_artist_archive;
-    }
+	/**
+	 * CSS variables now generated by link-page-head.php and preview.php only
+	 * via centralized ec_get_link_page_data() function
+	 */
+	public function add_custom_styles() {
+		// CSS variables are now generated by link-page-head.php and preview.php only
+		// This removes duplication and maintains centralized control
+	}
 
+	private function is_link_page_context() {
+		return is_singular( 'artist_link_page' ) ||
+				( isset( $_GET['artist_link_page'] ) && ! empty( $_GET['artist_link_page'] ) );
+	}
+
+	private function is_artist_directory_page() {
+		return is_page() &&
+				( get_page_template_slug() === 'artist-directory.php' ||
+				strpos( get_page_template_slug(), 'artist-directory' ) !== false );
+	}
+
+	private function is_artist_profile_page() {
+		return is_singular( 'artist_profile' );
+	}
+
+	private function should_load_hero_card_styles() {
+		// Artist platform homepage on artist.extrachill.com (site #4)
+		$is_home_page = false;
+		if ( is_front_page() || is_home() ) {
+			$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+			$is_home_page   = $artist_blog_id && get_current_blog_id() === $artist_blog_id;
+		}
+
+		// Artist profiles archive page (/artists)
+		$is_artist_archive = is_post_type_archive( 'artist_profile' );
+
+		return $is_home_page || $is_artist_archive;
+	}
 
 
-    private function is_artist_platform_admin_page( $hook ) {
-        global $post_type;
-        
-        return in_array( $post_type, array( 'artist_profile', 'artist_link_page' ) ) ||
-               in_array( $hook, array( 'edit.php', 'post.php', 'post-new.php' ) );
-    }
 
-    /**
-     * Enqueues join flow assets on login/register page
-     *
-     * Loads modal styling and JavaScript for the join flow system
-     * with dependencies on community plugin's login/register interface.
-     */
-    public function enqueue_join_flow_assets() {
-        if ( ! isset( $_GET['from_join'] ) || $_GET['from_join'] !== 'true' ) {
-            return;
-        }
+	private function is_artist_platform_admin_page( $hook ) {
+		global $post_type;
 
-        $css_path = 'inc/join/assets/css/join-flow.css';
-        $js_path = 'inc/join/assets/js/join-flow-ui.js';
-        $plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
+		return in_array( $post_type, array( 'artist_profile', 'artist_link_page' ) ) ||
+				in_array( $hook, array( 'edit.php', 'post.php', 'post-new.php' ) );
+	}
 
-        if ( file_exists( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $css_path ) ) {
-            wp_enqueue_style(
-                'ec-join-flow',
-                $plugin_url . $css_path,
-                array(),
-                $this->get_asset_version( $css_path )
-            );
-        }
+	/**
+	 * Enqueues join flow assets on login/register page
+	 *
+	 * Loads modal styling and JavaScript for the join flow system
+	 * with dependencies on community plugin's login/register interface.
+	 */
+	public function enqueue_join_flow_assets() {
+		if ( ! isset( $_GET['from_join'] ) || $_GET['from_join'] !== 'true' ) {
+			return;
+		}
 
-        if ( file_exists( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $js_path ) ) {
-            wp_enqueue_script(
-                'ec-join-flow-ui',
-                $plugin_url . $js_path,
-                array(),
-                $this->get_asset_version( $js_path ),
-                true
-            );
-        }
-    }
+		$css_path   = 'inc/join/assets/css/join-flow.css';
+		$js_path    = 'inc/join/assets/js/join-flow-ui.js';
+		$plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
 
-    private function get_asset_version( $asset_path ) {
-        $full_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $asset_path;
+		if ( file_exists( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $css_path ) ) {
+			wp_enqueue_style(
+				'ec-join-flow',
+				$plugin_url . $css_path,
+				array(),
+				$this->get_asset_version( $css_path )
+			);
+		}
 
-        if ( file_exists( $full_path ) ) {
-            return filemtime( $full_path );
-        }
+		if ( file_exists( EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $js_path ) ) {
+			wp_enqueue_script(
+				'ec-join-flow-ui',
+				$plugin_url . $js_path,
+				array(),
+				$this->get_asset_version( $js_path ),
+				true
+			);
+		}
+	}
 
-        return EXTRACHILL_ARTIST_PLATFORM_VERSION;
-    }
+	private function get_asset_version( $asset_path ) {
+		$full_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $asset_path;
+
+		if ( file_exists( $full_path ) ) {
+			return filemtime( $full_path );
+		}
+
+		return EXTRACHILL_ARTIST_PLATFORM_VERSION;
+	}
 }

--- a/inc/core/artist-platform-post-types.php
+++ b/inc/core/artist-platform-post-types.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Artist Platform Custom Post Types
- * 
+ *
  * Centralized registration of all custom post types for the artist platform.
  * Registers artist_profile and artist_link_page CPTs with appropriate settings.
  *
@@ -12,63 +12,66 @@
 defined( 'ABSPATH' ) || exit;
 
 function extrachill_register_artist_profile_cpt() {
-    if ( ! function_exists( 'register_post_type' ) ) {
-        return;
-    }
+	if ( ! function_exists( 'register_post_type' ) ) {
+		return;
+	}
 
-    $labels = array(
-        'name'                  => _x( 'Artist Profiles', 'Post Type General Name', 'extrachill-artist-platform' ),
-        'singular_name'         => _x( 'Artist Profile', 'Post Type Singular Name', 'extrachill-artist-platform' ),
-        'menu_name'             => __( 'Artist Profiles', 'extrachill-artist-platform' ),
-        'name_admin_bar'        => __( 'Artist Profile', 'extrachill-artist-platform' ),
-        'archives'              => __( 'Artist Profile Archives', 'extrachill-artist-platform' ),
-        'attributes'            => __( 'Artist Profile Attributes', 'extrachill-artist-platform' ),
-        'parent_item_colon'     => __( 'Parent Artist Profile:', 'extrachill-artist-platform' ),
-        'all_items'             => __( 'All Artist Profiles', 'extrachill-artist-platform' ),
-        'add_new_item'          => __( 'Add New Artist Profile', 'extrachill-artist-platform' ),
-        'add_new'               => __( 'Add New', 'extrachill-artist-platform' ),
-        'new_item'              => __( 'New Artist Profile', 'extrachill-artist-platform' ),
-        'edit_item'             => __( 'Edit Artist Profile', 'extrachill-artist-platform' ),
-        'update_item'           => __( 'Update Artist Profile', 'extrachill-artist-platform' ),
-        'view_item'             => __( 'View Artist Profile', 'extrachill-artist-platform' ),
-        'view_items'            => __( 'View Artist Profiles', 'extrachill-artist-platform' ),
-        'search_items'          => __( 'Search Artist Profile', 'extrachill-artist-platform' ),
-        'not_found'             => __( 'Not found', 'extrachill-artist-platform' ),
-        'not_found_in_trash'    => __( 'Not found in Trash', 'extrachill-artist-platform' ),
-        'featured_image'        => __( 'Featured Image', 'extrachill-artist-platform' ),
-        'set_featured_image'    => __( 'Set featured image', 'extrachill-artist-platform' ),
-        'remove_featured_image' => __( 'Remove featured image', 'extrachill-artist-platform' ),
-        'use_featured_image'    => __( 'Use as featured image', 'extrachill-artist-platform' ),
-        'insert_into_item'      => __( 'Insert into artist profile', 'extrachill-artist-platform' ),
-        'uploaded_to_this_item' => __( 'Uploaded to this artist profile', 'extrachill-artist-platform' ),
-        'items_list'            => __( 'Artist Profiles list', 'extrachill-artist-platform' ),
-        'items_list_navigation' => __( 'Artist Profiles list navigation', 'extrachill-artist-platform' ),
-        'filter_items_list'     => __( 'Filter artist profiles list', 'extrachill-artist-platform' ),
-    );
+	$labels = array(
+		'name'                  => _x( 'Artist Profiles', 'Post Type General Name', 'extrachill-artist-platform' ),
+		'singular_name'         => _x( 'Artist Profile', 'Post Type Singular Name', 'extrachill-artist-platform' ),
+		'menu_name'             => __( 'Artist Profiles', 'extrachill-artist-platform' ),
+		'name_admin_bar'        => __( 'Artist Profile', 'extrachill-artist-platform' ),
+		'archives'              => __( 'Artist Profile Archives', 'extrachill-artist-platform' ),
+		'attributes'            => __( 'Artist Profile Attributes', 'extrachill-artist-platform' ),
+		'parent_item_colon'     => __( 'Parent Artist Profile:', 'extrachill-artist-platform' ),
+		'all_items'             => __( 'All Artist Profiles', 'extrachill-artist-platform' ),
+		'add_new_item'          => __( 'Add New Artist Profile', 'extrachill-artist-platform' ),
+		'add_new'               => __( 'Add New', 'extrachill-artist-platform' ),
+		'new_item'              => __( 'New Artist Profile', 'extrachill-artist-platform' ),
+		'edit_item'             => __( 'Edit Artist Profile', 'extrachill-artist-platform' ),
+		'update_item'           => __( 'Update Artist Profile', 'extrachill-artist-platform' ),
+		'view_item'             => __( 'View Artist Profile', 'extrachill-artist-platform' ),
+		'view_items'            => __( 'View Artist Profiles', 'extrachill-artist-platform' ),
+		'search_items'          => __( 'Search Artist Profile', 'extrachill-artist-platform' ),
+		'not_found'             => __( 'Not found', 'extrachill-artist-platform' ),
+		'not_found_in_trash'    => __( 'Not found in Trash', 'extrachill-artist-platform' ),
+		'featured_image'        => __( 'Featured Image', 'extrachill-artist-platform' ),
+		'set_featured_image'    => __( 'Set featured image', 'extrachill-artist-platform' ),
+		'remove_featured_image' => __( 'Remove featured image', 'extrachill-artist-platform' ),
+		'use_featured_image'    => __( 'Use as featured image', 'extrachill-artist-platform' ),
+		'insert_into_item'      => __( 'Insert into artist profile', 'extrachill-artist-platform' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this artist profile', 'extrachill-artist-platform' ),
+		'items_list'            => __( 'Artist Profiles list', 'extrachill-artist-platform' ),
+		'items_list_navigation' => __( 'Artist Profiles list navigation', 'extrachill-artist-platform' ),
+		'filter_items_list'     => __( 'Filter artist profiles list', 'extrachill-artist-platform' ),
+	);
 
-    $args = array(
-        'label'                 => __( 'Artist Profile', 'extrachill-artist-platform' ),
-        'description'           => __( 'Custom Post Type for Artist Profiles', 'extrachill-artist-platform' ),
-        'labels'                => $labels,
-        'supports'              => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
-        'hierarchical'          => false,
-        'public'                => true,
-        'show_ui'               => true,
-        'show_in_menu'          => true,
-        'menu_position'         => 5,
-        'menu_icon'             => 'dashicons-groups',
-        'show_in_admin_bar'     => true,
-        'show_in_nav_menus'     => true,
-        'can_export'            => true,
-        'has_archive'           => 'artists',
-        'exclude_from_search'   => false,
-        'publicly_queryable'    => true,
-        'rewrite'               => array( 'slug' => 'artists', 'with_front' => false ),
-        'map_meta_cap'          => true,
-        'show_in_rest'          => true,
-    );
+	$args = array(
+		'label'               => __( 'Artist Profile', 'extrachill-artist-platform' ),
+		'description'         => __( 'Custom Post Type for Artist Profiles', 'extrachill-artist-platform' ),
+		'labels'              => $labels,
+		'supports'            => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+		'hierarchical'        => false,
+		'public'              => true,
+		'show_ui'             => true,
+		'show_in_menu'        => true,
+		'menu_position'       => 5,
+		'menu_icon'           => 'dashicons-groups',
+		'show_in_admin_bar'   => true,
+		'show_in_nav_menus'   => true,
+		'can_export'          => true,
+		'has_archive'         => 'artists',
+		'exclude_from_search' => false,
+		'publicly_queryable'  => true,
+		'rewrite'             => array(
+			'slug'       => 'artists',
+			'with_front' => false,
+		),
+		'map_meta_cap'        => true,
+		'show_in_rest'        => true,
+	);
 
-    register_post_type( 'artist_profile', $args );
+	register_post_type( 'artist_profile', $args );
 }
 
 /**
@@ -76,68 +79,68 @@ function extrachill_register_artist_profile_cpt() {
  */
 function extrachill_register_artist_link_page_cpt() {
 
-    $labels = array(
-        'name'                  => _x( 'Link Pages', 'Post Type General Name', 'extrachill-artist-platform' ),
-        'singular_name'         => _x( 'Link Page', 'Post Type Singular Name', 'extrachill-artist-platform' ),
-        'menu_name'             => __( 'Link Pages', 'extrachill-artist-platform' ),
-        'name_admin_bar'        => __( 'Link Page', 'extrachill-artist-platform' ),
-        'archives'              => __( 'Link Page Archives', 'extrachill-artist-platform' ),
-        'attributes'            => __( 'Link Page Attributes', 'extrachill-artist-platform' ),
-        'parent_item_colon'     => __( 'Parent Link Page:', 'extrachill-artist-platform' ),
-        'all_items'             => __( 'All Link Pages', 'extrachill-artist-platform' ),
-        'add_new_item'          => __( 'Add New Link Page', 'extrachill-artist-platform' ),
-        'add_new'               => __( 'Add New', 'extrachill-artist-platform' ),
-        'new_item'              => __( 'New Link Page', 'extrachill-artist-platform' ),
-        'edit_item'             => __( 'Edit Link Page', 'extrachill-artist-platform' ),
-        'update_item'           => __( 'Update Link Page', 'extrachill-artist-platform' ),
-        'view_item'             => __( 'View Link Page', 'extrachill-artist-platform' ),
-        'view_items'            => __( 'View Link Pages', 'extrachill-artist-platform' ),
-        'search_items'          => __( 'Search Link Page', 'extrachill-artist-platform' ),
-        'not_found'             => __( 'Not found', 'extrachill-artist-platform' ),
-        'not_found_in_trash'    => __( 'Not found in Trash', 'extrachill-artist-platform' ),
-        'featured_image'        => __( 'Featured Image', 'extrachill-artist-platform' ),
-        'set_featured_image'    => __( 'Set featured image', 'extrachill-artist-platform' ),
-        'remove_featured_image' => __( 'Remove featured image', 'extrachill-artist-platform' ),
-        'use_featured_image'    => __( 'Use as featured image', 'extrachill-artist-platform' ),
-        'insert_into_item'      => __( 'Insert into link page', 'extrachill-artist-platform' ),
-        'uploaded_to_this_item' => __( 'Uploaded to this link page', 'extrachill-artist-platform' ),
-        'items_list'            => __( 'Link Pages list', 'extrachill-artist-platform' ),
-        'items_list_navigation' => __( 'Link Pages list navigation', 'extrachill-artist-platform' ),
-        'filter_items_list'     => __( 'Filter link pages list', 'extrachill-artist-platform' ),
-    );
+	$labels = array(
+		'name'                  => _x( 'Link Pages', 'Post Type General Name', 'extrachill-artist-platform' ),
+		'singular_name'         => _x( 'Link Page', 'Post Type Singular Name', 'extrachill-artist-platform' ),
+		'menu_name'             => __( 'Link Pages', 'extrachill-artist-platform' ),
+		'name_admin_bar'        => __( 'Link Page', 'extrachill-artist-platform' ),
+		'archives'              => __( 'Link Page Archives', 'extrachill-artist-platform' ),
+		'attributes'            => __( 'Link Page Attributes', 'extrachill-artist-platform' ),
+		'parent_item_colon'     => __( 'Parent Link Page:', 'extrachill-artist-platform' ),
+		'all_items'             => __( 'All Link Pages', 'extrachill-artist-platform' ),
+		'add_new_item'          => __( 'Add New Link Page', 'extrachill-artist-platform' ),
+		'add_new'               => __( 'Add New', 'extrachill-artist-platform' ),
+		'new_item'              => __( 'New Link Page', 'extrachill-artist-platform' ),
+		'edit_item'             => __( 'Edit Link Page', 'extrachill-artist-platform' ),
+		'update_item'           => __( 'Update Link Page', 'extrachill-artist-platform' ),
+		'view_item'             => __( 'View Link Page', 'extrachill-artist-platform' ),
+		'view_items'            => __( 'View Link Pages', 'extrachill-artist-platform' ),
+		'search_items'          => __( 'Search Link Page', 'extrachill-artist-platform' ),
+		'not_found'             => __( 'Not found', 'extrachill-artist-platform' ),
+		'not_found_in_trash'    => __( 'Not found in Trash', 'extrachill-artist-platform' ),
+		'featured_image'        => __( 'Featured Image', 'extrachill-artist-platform' ),
+		'set_featured_image'    => __( 'Set featured image', 'extrachill-artist-platform' ),
+		'remove_featured_image' => __( 'Remove featured image', 'extrachill-artist-platform' ),
+		'use_featured_image'    => __( 'Use as featured image', 'extrachill-artist-platform' ),
+		'insert_into_item'      => __( 'Insert into link page', 'extrachill-artist-platform' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this link page', 'extrachill-artist-platform' ),
+		'items_list'            => __( 'Link Pages list', 'extrachill-artist-platform' ),
+		'items_list_navigation' => __( 'Link Pages list navigation', 'extrachill-artist-platform' ),
+		'filter_items_list'     => __( 'Filter link pages list', 'extrachill-artist-platform' ),
+	);
 
-    $args = array(
-        'label'                 => __( 'Link Page', 'extrachill-artist-platform' ),
-        'description'           => __( 'Custom Post Type for Artist Link Pages', 'extrachill-artist-platform' ),
-        'labels'                => $labels,
-        'supports'              => array( 'title', 'custom-fields', 'author' ),
-        'hierarchical'          => false,
-        'public'                => true,
-        'show_ui'               => true,
-        'show_in_menu'          => true,
-        'menu_position'         => 6,
-        'menu_icon'             => 'dashicons-admin-links',
-        'show_in_admin_bar'     => true,
-        'show_in_nav_menus'     => true,
-        'can_export'            => true,
-        'has_archive'           => false,
-        'exclude_from_search'   => false,
-        'publicly_queryable'    => true,
-        'rewrite'               => array('slug' => 'link-page'),
-        'capability_type'       => 'post',
-        'map_meta_cap'          => true,
-        'show_in_rest'          => true,
-    );
+	$args = array(
+		'label'               => __( 'Link Page', 'extrachill-artist-platform' ),
+		'description'         => __( 'Custom Post Type for Artist Link Pages', 'extrachill-artist-platform' ),
+		'labels'              => $labels,
+		'supports'            => array( 'title', 'custom-fields', 'author' ),
+		'hierarchical'        => false,
+		'public'              => true,
+		'show_ui'             => true,
+		'show_in_menu'        => true,
+		'menu_position'       => 6,
+		'menu_icon'           => 'dashicons-admin-links',
+		'show_in_admin_bar'   => true,
+		'show_in_nav_menus'   => true,
+		'can_export'          => true,
+		'has_archive'         => false,
+		'exclude_from_search' => false,
+		'publicly_queryable'  => true,
+		'rewrite'             => array( 'slug' => 'link-page' ),
+		'capability_type'     => 'post',
+		'map_meta_cap'        => true,
+		'show_in_rest'        => true,
+	);
 
-    register_post_type( 'artist_link_page', $args );
+	register_post_type( 'artist_link_page', $args );
 }
 
 /**
  * Initialize post type registration
  */
 function extrachill_init_post_types() {
-    extrachill_register_artist_profile_cpt();
-    extrachill_register_artist_link_page_cpt();
+	extrachill_register_artist_profile_cpt();
+	extrachill_register_artist_link_page_cpt();
 }
 
 // Hook to init with proper priority for post type registration

--- a/inc/core/artist-platform-rewrite-rules.php
+++ b/inc/core/artist-platform-rewrite-rules.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Artist Platform Rewrite Rules
- * 
+ *
  * Centralized management of all URL rewrite rules, query variables, and routing
  * for the artist platform functionality including artist profiles and link pages.
  *
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
  * @see extrachill_artist_platform_maybe_flush_rewrite_rules()
  */
 if ( ! defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
-    define( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION', '20260704' );
+	define( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION', '20260704' );
 }
 
 /**
@@ -33,33 +33,35 @@ if ( ! defined( 'EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION' ) ) {
  * @return array Array of slugs to exclude from artist link page rewrite rules
  */
 function extrachill_get_excluded_slugs() {
-    // Get all published WordPress pages dynamically
-    $pages = get_posts(array(
-        'post_type' => 'page',
-        'post_status' => 'publish',
-        'numberposts' => -1,
-        'fields' => 'ids'
-    ));
+	// Get all published WordPress pages dynamically
+	$pages = get_posts(
+		array(
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'numberposts' => -1,
+			'fields'      => 'ids',
+		)
+	);
 
-    $page_slugs = array();
-    foreach ($pages as $page_id) {
-        $slug = get_post_field('post_name', $page_id);
-        if ($slug) {
-            $page_slugs[] = $slug;
-        }
-    }
+	$page_slugs = array();
+	foreach ( $pages as $page_id ) {
+		$slug = get_post_field( 'post_name', $page_id );
+		if ( $slug ) {
+			$page_slugs[] = $slug;
+		}
+	}
 
-    // Keep critical hardcoded exclusions for non-page URLs and plugin paths
-    $static_exclusions = array(
-        'manage-artist',           // Management interface
-        'manage-link-page',        // Link page management
-        'join',                    // Join flow redirect (handled separately)
-        'wp-login',
-        'wp-admin',
-        'admin'
-    );
+	// Keep critical hardcoded exclusions for non-page URLs and plugin paths
+	$static_exclusions = array(
+		'manage-artist',           // Management interface
+		'manage-link-page',        // Link page management
+		'join',                    // Join flow redirect (handled separately)
+		'wp-login',
+		'wp-admin',
+		'admin',
+	);
 
-    return array_merge($static_exclusions, $page_slugs);
+	return array_merge( $static_exclusions, $page_slugs );
 }
 
 /**
@@ -69,40 +71,40 @@ function extrachill_get_excluded_slugs() {
  * Artist profiles use native WordPress rewrite via CPT registration.
  */
 function extrachill_add_rewrite_rules() {
-    // Only add rewrite rules for extrachill.link domain
-    // Template routing handles all other domains via REQUEST_URI parsing
-    $current_host = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
-    $is_link_domain = ( stripos( $current_host, 'extrachill.link' ) !== false );
+	// Only add rewrite rules for extrachill.link domain
+	// Template routing handles all other domains via REQUEST_URI parsing
+	$current_host   = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
+	$is_link_domain = ( stripos( $current_host, 'extrachill.link' ) !== false );
 
-    if ( ! $is_link_domain ) {
-        // Still register the query var for consistency, but no rewrite rules
-        add_rewrite_tag( '%artist_link_page%', '([^&]+)' );
-        return;
-    }
+	if ( ! $is_link_domain ) {
+		// Still register the query var for consistency, but no rewrite rules
+		add_rewrite_tag( '%artist_link_page%', '([^&]+)' );
+		return;
+	}
 
-    // Artist link page rewrite rules - only on extrachill.link domain
-    $excluded_slugs = extrachill_get_excluded_slugs();
-    $excluded_pattern = '(?!' . implode('|', $excluded_slugs) . ')';
-    add_rewrite_rule( '^' . $excluded_pattern . '([^/]+)/?$', 'index.php?artist_link_page=$matches[1]', 'top' );
-    add_rewrite_tag( '%artist_link_page%', '([^&]+)' );
+	// Artist link page rewrite rules - only on extrachill.link domain
+	$excluded_slugs   = extrachill_get_excluded_slugs();
+	$excluded_pattern = '(?!' . implode( '|', $excluded_slugs ) . ')';
+	add_rewrite_rule( '^' . $excluded_pattern . '([^/]+)/?$', 'index.php?artist_link_page=$matches[1]', 'top' );
+	add_rewrite_tag( '%artist_link_page%', '([^&]+)' );
 }
 
 /**
  * Add custom query variables for artist platform
- * 
+ *
  * @param array $vars Existing query variables
  * @return array Modified query variables
  */
 function extrachill_add_query_vars( $vars ) {
-    $vars[] = 'artist_link_page';
-    $vars[] = 'dev_view_link_page';
-    $vars[] = 'artist_id';
-    return $vars;
+	$vars[] = 'artist_link_page';
+	$vars[] = 'dev_view_link_page';
+	$vars[] = 'artist_id';
+	return $vars;
 }
 
 /**
  * Prevent canonical redirection for extrachill.link domain
- * 
+ *
  * This allows our custom template_include logic to handle routing for the link domain
  * without WordPress trying to redirect to "correct" URLs.
  *
@@ -111,11 +113,11 @@ function extrachill_add_query_vars( $vars ) {
  * @return string|false The redirect URL, or false to prevent redirection
  */
 function extrachill_prevent_canonical_redirect_for_link_domain( $redirect_url, $requested_url ) {
-    $current_host = strtolower( $_SERVER['SERVER_NAME'] ?? '' );
-    if ( $current_host === 'extrachill.link' ) {
-        return false; 
-    }
-    return $redirect_url;
+	$current_host = strtolower( $_SERVER['SERVER_NAME'] ?? '' );
+	if ( $current_host === 'extrachill.link' ) {
+		return false;
+	}
+	return $redirect_url;
 }
 
 /**
@@ -132,82 +134,84 @@ function extrachill_prevent_canonical_redirect_for_link_domain( $redirect_url, $
  * @since 1.7.0
  */
 function extrachill_resolve_link_domain_query() {
-    // Skip if in development mode.
-    if ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV ) {
-        return;
-    }
+	// Skip if in development mode.
+	if ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV ) {
+		return;
+	}
 
-    $current_host = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
-    if ( stripos( $current_host, 'extrachill.link' ) === false ) {
-        return;
-    }
+	$current_host = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
+	if ( stripos( $current_host, 'extrachill.link' ) === false ) {
+		return;
+	}
 
-    global $wp_query;
-    $request_uri  = $_SERVER['REQUEST_URI'] ?? '';
-    $request_path = trim( (string) parse_url( $request_uri, PHP_URL_PATH ), '/' );
+	global $wp_query;
+	$request_uri  = $_SERVER['REQUEST_URI'] ?? '';
+	$request_path = trim( (string) parse_url( $request_uri, PHP_URL_PATH ), '/' );
 
-    // Handle join redirect.
-    if ( $request_path === 'join' ) {
-        $redirect_url = ec_get_site_url( 'artist' ) . '/login/?from_join=true';
-        if ( ! headers_sent() ) {
-            wp_redirect( esc_url_raw( $redirect_url ), 301 );
-            exit;
-        }
-        return;
-    }
+	// Handle join redirect.
+	if ( $request_path === 'join' ) {
+		$redirect_url = ec_get_site_url( 'artist' ) . '/login/?from_join=true';
+		if ( ! headers_sent() ) {
+			wp_redirect( esc_url_raw( $redirect_url ), 301 );
+			exit;
+		}
+		return;
+	}
 
-    // Determine slug to look up.
-    $is_root_or_extra_chill = ( empty( $request_path ) || $request_path === 'extra-chill' );
+	// Determine slug to look up.
+	$is_root_or_extra_chill = ( empty( $request_path ) || $request_path === 'extra-chill' );
 
-    if ( $is_root_or_extra_chill ) {
-        // Redirect /extra-chill to root.
-        if ( $request_path === 'extra-chill' ) {
-            if ( ! headers_sent() ) {
-                wp_redirect( esc_url_raw( 'https://extrachill.link/' ), 301 );
-                exit;
-            }
-        }
-        $slug = 'extra-chill';
-    } else {
-        $slug = $request_path;
-    }
+	if ( $is_root_or_extra_chill ) {
+		// Redirect /extra-chill to root.
+		if ( $request_path === 'extra-chill' ) {
+			if ( ! headers_sent() ) {
+				wp_redirect( esc_url_raw( 'https://extrachill.link/' ), 301 );
+				exit;
+			}
+		}
+		$slug = 'extra-chill';
+	} else {
+		$slug = $request_path;
+	}
 
-    // Look up the link page.
-    $link_pages = get_posts( array(
-        'name'        => $slug,
-        'post_type'   => 'artist_link_page',
-        'post_status' => 'publish',
-        'numberposts' => 1,
-        'fields'      => 'ids',
-    ) );
+	// Look up the link page.
+	$link_pages = get_posts(
+		array(
+			'name'        => $slug,
+			'post_type'   => 'artist_link_page',
+			'post_status' => 'publish',
+			'numberposts' => 1,
+			'fields'      => 'ids',
+		)
+	);
 
-    if ( ! empty( $link_pages ) ) {
-        $link_page_id = $link_pages[0];
-        $link_page    = get_post( $link_page_id );
+	if ( ! empty( $link_pages ) ) {
+		$link_page_id = $link_pages[0];
+		$link_page    = get_post( $link_page_id );
 
-        // Override the main query so WordPress treats this as a found singular post.
-        $wp_query->posts             = array( $link_page );
-        $wp_query->post_count        = 1;
-        $wp_query->found_posts       = 1;
-        $wp_query->max_num_pages     = 1;
-        $wp_query->is_single         = true;
-        $wp_query->is_singular       = true;
-        $wp_query->is_404            = false;
-        $wp_query->query_vars['name']      = $slug;
-        $wp_query->query_vars['post_type'] = 'artist_link_page';
-        $wp_query->queried_object_id = $link_page_id;
-        $wp_query->queried_object    = $link_page;
-        status_header( 200 );
-    } elseif ( $is_root_or_extra_chill ) {
-        // Root domain but no default link page — genuine 404.
-        status_header( 404 );
-    } else {
-        // No link page found — redirect to root.
-        if ( ! headers_sent() ) {
-            wp_redirect( esc_url_raw( 'https://extrachill.link/' ), 301 );
-            exit;
-        }
-    }
+		// Override the main query so WordPress treats this as a found singular post.
+		$wp_query->posts                   = array( $link_page );
+		$wp_query->post_count              = 1;
+		$wp_query->found_posts             = 1;
+		$wp_query->max_num_pages           = 1;
+		$wp_query->is_single               = true;
+		$wp_query->is_singular             = true;
+		$wp_query->is_404                  = false;
+		$wp_query->query_vars['name']      = $slug;
+		$wp_query->query_vars['post_type'] = 'artist_link_page';
+		$wp_query->queried_object_id       = $link_page_id;
+		$wp_query->queried_object          = $link_page;
+		status_header( 200 );
+	} elseif ( $is_root_or_extra_chill ) {
+		// Root domain but no default link page — genuine 404.
+		status_header( 404 );
+	} else {
+		// No link page found — redirect to root.
+		if ( ! headers_sent() ) {
+			wp_redirect( esc_url_raw( 'https://extrachill.link/' ), 301 );
+			exit;
+		}
+	}
 }
 
 /**
@@ -222,33 +226,33 @@ function extrachill_resolve_link_domain_query() {
  * @return string The template to actually load.
  */
 function extrachill_handle_link_domain_routing( $template ) {
-    if ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV ) {
-        return $template;
-    }
+	if ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV ) {
+		return $template;
+	}
 
-    $current_host = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
-    if ( stripos( $current_host, 'extrachill.link' ) === false ) {
-        return $template;
-    }
+	$current_host = strtolower( $_SERVER['HTTP_HOST'] ?? '' );
+	if ( stripos( $current_host, 'extrachill.link' ) === false ) {
+		return $template;
+	}
 
-    // If the query was resolved to a link page, load the template.
-    global $wp_query;
-    if ( ! empty( $wp_query->posts ) && isset( $wp_query->posts[0] ) && 'artist_link_page' === get_post_type( $wp_query->posts[0] ) ) {
-        $template_to_load = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/single-artist_link_page.php';
-        if ( file_exists( $template_to_load ) ) {
-            return $template_to_load;
-        }
-    }
+	// If the query was resolved to a link page, load the template.
+	global $wp_query;
+	if ( ! empty( $wp_query->posts ) && isset( $wp_query->posts[0] ) && 'artist_link_page' === get_post_type( $wp_query->posts[0] ) ) {
+		$template_to_load = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/single-artist_link_page.php';
+		if ( file_exists( $template_to_load ) ) {
+			return $template_to_load;
+		}
+	}
 
-    // Genuinely not found — let WordPress handle the 404 template.
-    return $template;
+	// Genuinely not found — let WordPress handle the 404 template.
+	return $template;
 }
 
 /**
  * Initialize all rewrite rules and routing
  */
 function extrachill_init_rewrite_rules() {
-    extrachill_add_rewrite_rules();
+	extrachill_add_rewrite_rules();
 }
 
 /**
@@ -272,68 +276,68 @@ function extrachill_init_rewrite_rules() {
  * add_rewrite_rule() calls.
  */
 function extrachill_artist_platform_maybe_flush_rewrite_rules() {
-    $stored_version = get_option( 'ec_artist_platform_rewrite_version' );
+	$stored_version = get_option( 'ec_artist_platform_rewrite_version' );
 
-    if ( $stored_version === EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION ) {
-        return;
-    }
+	if ( $stored_version === EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION ) {
+		return;
+	}
 
-    // Soft flush: rebuild the rewrite_rules option only. Passing false means we
-    // do NOT regenerate .htaccess / server config on every version bump — the
-    // rules we care about live in the WP option, not the static server config.
-    flush_rewrite_rules( false );
-    update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
+	// Soft flush: rebuild the rewrite_rules option only. Passing false means we
+	// do NOT regenerate .htaccess / server config on every version bump — the
+	// rules we care about live in the WP option, not the static server config.
+	flush_rewrite_rules( false );
+	update_option( 'ec_artist_platform_rewrite_version', EXTRCH_ARTIST_PLATFORM_REWRITE_VERSION );
 }
 
 /**
  * Redirect direct CPT access to extrachill.link domain
- * 
+ *
  * Redirects direct access to 'artist_link_page' CPT posts (via their WordPress permalinks)
  * to their canonical URL on the extrachill.link domain.
  */
 function extrachill_redirect_artist_link_page_cpt_to_custom_domain() {
-    $is_dev_mode = ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV );
-    $is_extrachill_link_host = ( strpos( strtolower( $_SERVER['HTTP_HOST'] ?? '' ), 'extrachill.link' ) !== false );
+	$is_dev_mode             = ( defined( 'EXTRCH_LINKPAGE_DEV' ) && EXTRCH_LINKPAGE_DEV );
+	$is_extrachill_link_host = ( strpos( strtolower( $_SERVER['HTTP_HOST'] ?? '' ), 'extrachill.link' ) !== false );
 
-    if ( is_singular( 'artist_link_page' ) ) {
-        $current_link_page_post = get_queried_object();
-        if ( $current_link_page_post && $current_link_page_post->ID ) {
-            $link_page_id = $current_link_page_post->ID;
+	if ( is_singular( 'artist_link_page' ) ) {
+		$current_link_page_post = get_queried_object();
+		if ( $current_link_page_post && $current_link_page_post->ID ) {
+			$link_page_id = $current_link_page_post->ID;
 
-            // Use centralized data source for redirect settings (single source of truth)
-            $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-            $data = ec_get_link_page_data( $artist_id, $link_page_id );
-            $temp_redirect_enabled = $data['settings']['redirect_enabled'] ?? false;
-            $target_redirect_url = $data['settings']['redirect_target_url'] ?? '';
-            
-            if ( $temp_redirect_enabled ) {
-                if ( ! empty( $target_redirect_url ) && filter_var( $target_redirect_url, FILTER_VALIDATE_URL ) ) {
-                    if ( ! headers_sent() ) {
-                        wp_redirect( esc_url_raw( $target_redirect_url ), 302 );
-                        exit;
-                    }
-                }
-            }
-            if ( ! $is_dev_mode && ! $is_extrachill_link_host ) {
-                // Use already retrieved artist_id (avoid duplicate query)
-                if ( $artist_id ) {
-                    $artist_profile_post = get_post( $artist_id );
-                    if ( $artist_profile_post && ! empty( $artist_profile_post->post_name ) ) {
-                        $artist_slug = $artist_profile_post->post_name;
-                        $target_url_path = '/' . $artist_slug . '/';
-                        $target_url = 'https://extrachill.link' . $target_url_path;
-                        if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
-                            $target_url .= '?' . $_SERVER['QUERY_STRING'];
-                        }
-                        if ( ! headers_sent() ) {
-                            wp_safe_redirect( esc_url_raw( $target_url ), 301 );
-                            exit;
-                        }
-                    }
-                }
-            }
-        }
-    }
+			// Use centralized data source for redirect settings (single source of truth)
+			$artist_id             = apply_filters( 'ec_get_artist_id', $link_page_id );
+			$data                  = ec_get_link_page_data( $artist_id, $link_page_id );
+			$temp_redirect_enabled = $data['settings']['redirect_enabled'] ?? false;
+			$target_redirect_url   = $data['settings']['redirect_target_url'] ?? '';
+
+			if ( $temp_redirect_enabled ) {
+				if ( ! empty( $target_redirect_url ) && filter_var( $target_redirect_url, FILTER_VALIDATE_URL ) ) {
+					if ( ! headers_sent() ) {
+						wp_redirect( esc_url_raw( $target_redirect_url ), 302 );
+						exit;
+					}
+				}
+			}
+			if ( ! $is_dev_mode && ! $is_extrachill_link_host ) {
+				// Use already retrieved artist_id (avoid duplicate query)
+				if ( $artist_id ) {
+					$artist_profile_post = get_post( $artist_id );
+					if ( $artist_profile_post && ! empty( $artist_profile_post->post_name ) ) {
+						$artist_slug     = $artist_profile_post->post_name;
+						$target_url_path = '/' . $artist_slug . '/';
+						$target_url      = 'https://extrachill.link' . $target_url_path;
+						if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
+							$target_url .= '?' . $_SERVER['QUERY_STRING'];
+						}
+						if ( ! headers_sent() ) {
+							wp_safe_redirect( esc_url_raw( $target_url ), 301 );
+							exit;
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 // Hook into WordPress

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -35,50 +35,50 @@ defined( 'ABSPATH' ) || exit;
  * @return int Main-blog `artist` term_id, or 0 if none can be resolved.
  */
 function ec_get_artist_term_id( $profile_id ) {
-    $profile_id = (int) $profile_id;
-    if ( $profile_id <= 0 ) {
-        return 0;
-    }
+	$profile_id = (int) $profile_id;
+	if ( $profile_id <= 0 ) {
+		return 0;
+	}
 
-    // 1. Stored binding wins.
-    $stored = (int) get_post_meta( $profile_id, '_artist_term_id', true );
-    if ( $stored > 0 ) {
-        return $stored;
-    }
+	// 1. Stored binding wins.
+	$stored = (int) get_post_meta( $profile_id, '_artist_term_id', true );
+	if ( $stored > 0 ) {
+		return $stored;
+	}
 
-    // 2. Slug fallback. The profile lives on the artist blog; resolve its slug
-    //    there, then look the term up on the main blog.
-    $slug = get_post_field( 'post_name', $profile_id );
-    if ( empty( $slug ) ) {
-        return 0;
-    }
+	// 2. Slug fallback. The profile lives on the artist blog; resolve its slug
+	// there, then look the term up on the main blog.
+	$slug = get_post_field( 'post_name', $profile_id );
+	if ( empty( $slug ) ) {
+		return 0;
+	}
 
-    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    if ( ! $main_blog_id ) {
-        return 0;
-    }
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		return 0;
+	}
 
-    $term_id   = 0;
-    $term_slug = '';
-    switch_to_blog( $main_blog_id );
-    try {
-        $term = get_term_by( 'slug', $slug, 'artist' );
-        if ( $term && ! is_wp_error( $term ) ) {
-            $term_id   = (int) $term->term_id;
-            $term_slug = $term->slug;
-        }
-    } finally {
-        restore_current_blog();
-    }
+	$term_id   = 0;
+	$term_slug = '';
+	switch_to_blog( $main_blog_id );
+	try {
+		$term = get_term_by( 'slug', $slug, 'artist' );
+		if ( $term && ! is_wp_error( $term ) ) {
+			$term_id   = (int) $term->term_id;
+			$term_slug = $term->slug;
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    if ( $term_id <= 0 ) {
-        return 0;
-    }
+	if ( $term_id <= 0 ) {
+		return 0;
+	}
 
-    // 3. Self-heal: persist both sides of the binding.
-    ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
+	// 3. Self-heal: persist both sides of the binding.
+	ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
 
-    return $term_id;
+	return $term_id;
 }
 
 /**
@@ -92,72 +92,74 @@ function ec_get_artist_term_id( $profile_id ) {
  * @return int Artist profile post ID (on the artist blog), or 0 if none.
  */
 function ec_get_artist_profile_id( $term_id ) {
-    $term_id = (int) $term_id;
-    if ( $term_id <= 0 ) {
-        return 0;
-    }
+	$term_id = (int) $term_id;
+	if ( $term_id <= 0 ) {
+		return 0;
+	}
 
-    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    if ( ! $main_blog_id ) {
-        return 0;
-    }
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		return 0;
+	}
 
-    // 1. Stored binding wins. Term meta lives on the MAIN blog alongside the term.
-    $stored    = 0;
-    $term_slug = '';
-    switch_to_blog( $main_blog_id );
-    try {
-        $stored = (int) get_term_meta( $term_id, '_artist_profile_id', true );
-        if ( $stored <= 0 ) {
-            $term = get_term( $term_id, 'artist' );
-            if ( $term && ! is_wp_error( $term ) ) {
-                $term_slug = $term->slug;
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+	// 1. Stored binding wins. Term meta lives on the MAIN blog alongside the term.
+	$stored    = 0;
+	$term_slug = '';
+	switch_to_blog( $main_blog_id );
+	try {
+		$stored = (int) get_term_meta( $term_id, '_artist_profile_id', true );
+		if ( $stored <= 0 ) {
+			$term = get_term( $term_id, 'artist' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$term_slug = $term->slug;
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    if ( $stored > 0 ) {
-        return $stored;
-    }
+	if ( $stored > 0 ) {
+		return $stored;
+	}
 
-    if ( empty( $term_slug ) ) {
-        return 0;
-    }
+	if ( empty( $term_slug ) ) {
+		return 0;
+	}
 
-    // 2. Slug fallback. Look the profile up on the artist blog by slug.
-    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-    if ( ! $artist_blog_id ) {
-        return 0;
-    }
+	// 2. Slug fallback. Look the profile up on the artist blog by slug.
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	if ( ! $artist_blog_id ) {
+		return 0;
+	}
 
-    $profile_id = 0;
-    switch_to_blog( $artist_blog_id );
-    try {
-        $found = get_posts( array(
-            'post_type'        => 'artist_profile',
-            'name'             => $term_slug,
-            'post_status'      => 'publish',
-            'posts_per_page'   => 1,
-            'fields'           => 'ids',
-            'suppress_filters' => false,
-        ) );
-        if ( ! empty( $found ) ) {
-            $profile_id = (int) $found[0];
-        }
-    } finally {
-        restore_current_blog();
-    }
+	$profile_id = 0;
+	switch_to_blog( $artist_blog_id );
+	try {
+		$found = get_posts(
+			array(
+				'post_type'        => 'artist_profile',
+				'name'             => $term_slug,
+				'post_status'      => 'publish',
+				'posts_per_page'   => 1,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+			)
+		);
+		if ( ! empty( $found ) ) {
+			$profile_id = (int) $found[0];
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    if ( $profile_id <= 0 ) {
-        return 0;
-    }
+	if ( $profile_id <= 0 ) {
+		return 0;
+	}
 
-    // 3. Self-heal: persist both sides of the binding.
-    ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
+	// 3. Self-heal: persist both sides of the binding.
+	ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id );
 
-    return $profile_id;
+	return $profile_id;
 }
 
 /**
@@ -174,31 +176,31 @@ function ec_get_artist_profile_id( $term_id ) {
  * @return void
  */
 function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = null ) {
-    $profile_id = (int) $profile_id;
-    $term_id    = (int) $term_id;
-    if ( $profile_id <= 0 || $term_id <= 0 ) {
-        return;
-    }
+	$profile_id = (int) $profile_id;
+	$term_id    = (int) $term_id;
+	if ( $profile_id <= 0 || $term_id <= 0 ) {
+		return;
+	}
 
-    // Profile-side meta. update_post_meta targets the post on whichever blog it
-    // lives on; this binding is only ever resolved from the artist blog where
-    // the profile is the current post, so write it directly.
-    update_post_meta( $profile_id, '_artist_term_id', $term_id );
+	// Profile-side meta. update_post_meta targets the post on whichever blog it
+	// lives on; this binding is only ever resolved from the artist blog where
+	// the profile is the current post, so write it directly.
+	update_post_meta( $profile_id, '_artist_term_id', $term_id );
 
-    // Term-side meta lives on the main blog.
-    if ( null === $main_blog_id ) {
-        $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    }
-    if ( ! $main_blog_id ) {
-        return;
-    }
+	// Term-side meta lives on the main blog.
+	if ( null === $main_blog_id ) {
+		$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	}
+	if ( ! $main_blog_id ) {
+		return;
+	}
 
-    switch_to_blog( $main_blog_id );
-    try {
-        update_term_meta( $term_id, '_artist_profile_id', $profile_id );
-    } finally {
-        restore_current_blog();
-    }
+	switch_to_blog( $main_blog_id );
+	try {
+		update_term_meta( $term_id, '_artist_profile_id', $profile_id );
+	} finally {
+		restore_current_blog();
+	}
 }
 
 /**
@@ -214,54 +216,54 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
  * @return void
  */
 function ec_sync_artist_profile_term_binding( $profile_id ) {
-    $profile_id = (int) $profile_id;
-    if ( $profile_id <= 0 || get_post_type( $profile_id ) !== 'artist_profile' ) {
-        return;
-    }
+	$profile_id = (int) $profile_id;
+	if ( $profile_id <= 0 || get_post_type( $profile_id ) !== 'artist_profile' ) {
+		return;
+	}
 
-    // Already bound? Nothing to do.
-    if ( (int) get_post_meta( $profile_id, '_artist_term_id', true ) > 0 ) {
-        return;
-    }
+	// Already bound? Nothing to do.
+	if ( (int) get_post_meta( $profile_id, '_artist_term_id', true ) > 0 ) {
+		return;
+	}
 
-    // Try the slug-fallback resolver first (it self-heals on success).
-    $term_id = ec_get_artist_term_id( $profile_id );
-    if ( $term_id > 0 ) {
-        return;
-    }
+	// Try the slug-fallback resolver first (it self-heals on success).
+	$term_id = ec_get_artist_term_id( $profile_id );
+	if ( $term_id > 0 ) {
+		return;
+	}
 
-    // No matching term exists yet — create one on the main blog so the profile
-    // is always represented in the network join key.
-    $title = get_the_title( $profile_id );
-    $slug  = get_post_field( 'post_name', $profile_id );
-    if ( empty( $title ) || empty( $slug ) ) {
-        return;
-    }
+	// No matching term exists yet — create one on the main blog so the profile
+	// is always represented in the network join key.
+	$title = get_the_title( $profile_id );
+	$slug  = get_post_field( 'post_name', $profile_id );
+	if ( empty( $title ) || empty( $slug ) ) {
+		return;
+	}
 
-    $main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    if ( ! $main_blog_id ) {
-        return;
-    }
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $main_blog_id ) {
+		return;
+	}
 
-    $new_term_id = 0;
-    switch_to_blog( $main_blog_id );
-    try {
-        $existing = get_term_by( 'slug', $slug, 'artist' );
-        if ( $existing && ! is_wp_error( $existing ) ) {
-            $new_term_id = (int) $existing->term_id;
-        } else {
-            $inserted = wp_insert_term( $title, 'artist', array( 'slug' => $slug ) );
-            if ( ! is_wp_error( $inserted ) && ! empty( $inserted['term_id'] ) ) {
-                $new_term_id = (int) $inserted['term_id'];
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+	$new_term_id = 0;
+	switch_to_blog( $main_blog_id );
+	try {
+		$existing = get_term_by( 'slug', $slug, 'artist' );
+		if ( $existing && ! is_wp_error( $existing ) ) {
+			$new_term_id = (int) $existing->term_id;
+		} else {
+			$inserted = wp_insert_term( $title, 'artist', array( 'slug' => $slug ) );
+			if ( ! is_wp_error( $inserted ) && ! empty( $inserted['term_id'] ) ) {
+				$new_term_id = (int) $inserted['term_id'];
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    if ( $new_term_id > 0 ) {
-        ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $main_blog_id );
-    }
+	if ( $new_term_id > 0 ) {
+		ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $main_blog_id );
+	}
 }
 add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 1 );
 
@@ -280,78 +282,80 @@ add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 
  * @return void
  */
 function ec_backfill_artist_term_bindings() {
-    $backfill_version = '1.0.0';
-    $stored = get_option( 'extrachill_artist_platform_term_binding_backfill', '0' );
-    if ( version_compare( $stored, $backfill_version, '>=' ) ) {
-        return;
-    }
+	$backfill_version = '1.0.0';
+	$stored           = get_option( 'extrachill_artist_platform_term_binding_backfill', '0' );
+	if ( version_compare( $stored, $backfill_version, '>=' ) ) {
+		return;
+	}
 
-    $artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
-    $main_blog_id   = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
-    if ( ! $artist_blog_id || ! $main_blog_id ) {
-        // Network helpers unavailable; do not burn the version gate. Retry next load.
-        return;
-    }
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+	$main_blog_id   = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'main' ) : null;
+	if ( ! $artist_blog_id || ! $main_blog_id ) {
+		// Network helpers unavailable; do not burn the version gate. Retry next load.
+		return;
+	}
 
-    // Collect candidate profiles (id + slug) from the artist blog.
-    $profiles = array();
-    switch_to_blog( $artist_blog_id );
-    try {
-        $found = get_posts( array(
-            'post_type'        => 'artist_profile',
-            'post_status'      => 'any',
-            'posts_per_page'   => -1,
-            'fields'           => 'ids',
-            'suppress_filters' => false,
-        ) );
-        foreach ( (array) $found as $pid ) {
-            $pid = (int) $pid;
-            if ( (int) get_post_meta( $pid, '_artist_term_id', true ) > 0 ) {
-                continue; // already bound
-            }
-            $slug = get_post_field( 'post_name', $pid );
-            if ( ! empty( $slug ) ) {
-                $profiles[ $pid ] = $slug;
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+	// Collect candidate profiles (id + slug) from the artist blog.
+	$profiles = array();
+	switch_to_blog( $artist_blog_id );
+	try {
+		$found = get_posts(
+			array(
+				'post_type'        => 'artist_profile',
+				'post_status'      => 'any',
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'suppress_filters' => false,
+			)
+		);
+		foreach ( (array) $found as $pid ) {
+			$pid = (int) $pid;
+			if ( (int) get_post_meta( $pid, '_artist_term_id', true ) > 0 ) {
+				continue; // already bound
+			}
+			$slug = get_post_field( 'post_name', $pid );
+			if ( ! empty( $slug ) ) {
+				$profiles[ $pid ] = $slug;
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    if ( empty( $profiles ) ) {
-        update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
-        return;
-    }
+	if ( empty( $profiles ) ) {
+		update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
+		return;
+	}
 
-    // Resolve each slug to a term on the main blog (single switch for the batch).
-    $resolved = array();
-    switch_to_blog( $main_blog_id );
-    try {
-        foreach ( $profiles as $pid => $slug ) {
-            $term = get_term_by( 'slug', $slug, 'artist' );
-            if ( $term && ! is_wp_error( $term ) ) {
-                $term_id = (int) $term->term_id;
-                $resolved[ $pid ] = $term_id;
-                // Write the term-side meta while we are already on the main blog.
-                update_term_meta( $term_id, '_artist_profile_id', $pid );
-            }
-        }
-    } finally {
-        restore_current_blog();
-    }
+	// Resolve each slug to a term on the main blog (single switch for the batch).
+	$resolved = array();
+	switch_to_blog( $main_blog_id );
+	try {
+		foreach ( $profiles as $pid => $slug ) {
+			$term = get_term_by( 'slug', $slug, 'artist' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$term_id          = (int) $term->term_id;
+				$resolved[ $pid ] = $term_id;
+				// Write the term-side meta while we are already on the main blog.
+				update_term_meta( $term_id, '_artist_profile_id', $pid );
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
 
-    // Write the profile-side meta on the artist blog.
-    if ( ! empty( $resolved ) ) {
-        switch_to_blog( $artist_blog_id );
-        try {
-            foreach ( $resolved as $pid => $term_id ) {
-                update_post_meta( $pid, '_artist_term_id', $term_id );
-            }
-        } finally {
-            restore_current_blog();
-        }
-    }
+	// Write the profile-side meta on the artist blog.
+	if ( ! empty( $resolved ) ) {
+		switch_to_blog( $artist_blog_id );
+		try {
+			foreach ( $resolved as $pid => $term_id ) {
+				update_post_meta( $pid, '_artist_term_id', $term_id );
+			}
+		} finally {
+			restore_current_blog();
+		}
+	}
 
-    update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
+	update_option( 'extrachill_artist_platform_term_binding_backfill', $backfill_version );
 }
 add_action( 'admin_init', 'ec_backfill_artist_term_bindings' );

--- a/inc/core/class-templates.php
+++ b/inc/core/class-templates.php
@@ -8,77 +8,77 @@ defined( 'ABSPATH' ) || exit;
 
 class ExtraChillArtistPlatform_PageTemplates {
 
-    /** @var ExtraChillArtistPlatform_PageTemplates|null */
-    private static $instance = null;
+	/** @var ExtraChillArtistPlatform_PageTemplates|null */
+	private static $instance = null;
 
-    /** @return ExtraChillArtistPlatform_PageTemplates */
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	/** @return ExtraChillArtistPlatform_PageTemplates */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    /**
-     * Constructor - Sets up template filtering.
-     */
-    private function __construct() {
-        $this->init_hooks();
-    }
+	/**
+	 * Constructor - Sets up template filtering.
+	 */
+	private function __construct() {
+		$this->init_hooks();
+	}
 
-    /**
-     * Initialize template-related WordPress hooks
-     *
-     * Sets up filters for custom template loading for post types.
-     */
-    private function init_hooks() {
-        add_filter( 'template_include', array( $this, 'load_artist_link_page_template' ), 10 );
-        add_filter( 'extrachill_template_archive', array( $this, 'load_artist_profile_archive_template' ), 10 );
-    }
+	/**
+	 * Initialize template-related WordPress hooks
+	 *
+	 * Sets up filters for custom template loading for post types.
+	 */
+	private function init_hooks() {
+		add_filter( 'template_include', array( $this, 'load_artist_link_page_template' ), 10 );
+		add_filter( 'extrachill_template_archive', array( $this, 'load_artist_profile_archive_template' ), 10 );
+	}
 
-    /**
-     * Load artist link page and artist profile templates
-     * 
-     * Overrides single and archive templates for custom post types.
-     * Handles both artist_link_page and artist_profile post type templates.
-     * 
-     * @param string $template Current template path
-     * @return string Modified template path
-     */
-    public function load_artist_link_page_template( $template ) {
-        if ( is_singular( 'artist_link_page' ) ) {
-            $plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/single-artist_link_page.php';
-            if ( file_exists( $plugin_template ) ) {
-                return $plugin_template;
-            }
-        }
+	/**
+	 * Load artist link page and artist profile templates
+	 *
+	 * Overrides single and archive templates for custom post types.
+	 * Handles both artist_link_page and artist_profile post type templates.
+	 *
+	 * @param string $template Current template path
+	 * @return string Modified template path
+	 */
+	public function load_artist_link_page_template( $template ) {
+		if ( is_singular( 'artist_link_page' ) ) {
+			$plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/single-artist_link_page.php';
+			if ( file_exists( $plugin_template ) ) {
+				return $plugin_template;
+			}
+		}
 
-        if ( is_singular( 'artist_profile' ) ) {
-            $plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/single-artist_profile.php';
-            if ( file_exists( $plugin_template ) ) {
-                return $plugin_template;
-            }
-        }
+		if ( is_singular( 'artist_profile' ) ) {
+			$plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/single-artist_profile.php';
+			if ( file_exists( $plugin_template ) ) {
+				return $plugin_template;
+			}
+		}
 
-        return $template;
-    }
+		return $template;
+	}
 
-    /**
-     * Load artist profile archive template
-     *
-     * Hooks into theme's extrachill_template_archive filter to provide
-     * custom archive template for artist_profile post type.
-     *
-     * @param string $template Current template path from theme router
-     * @return string Modified template path
-     */
-    public function load_artist_profile_archive_template( $template ) {
-        if ( is_post_type_archive( 'artist_profile' ) ) {
-            $plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/archive-artist_profile.php';
-            if ( file_exists( $plugin_template ) ) {
-                return $plugin_template;
-            }
-        }
-        return $template;
-    }
+	/**
+	 * Load artist profile archive template
+	 *
+	 * Hooks into theme's extrachill_template_archive filter to provide
+	 * custom archive template for artist_profile post type.
+	 *
+	 * @param string $template Current template path from theme router
+	 * @return string Modified template path
+	 */
+	public function load_artist_profile_archive_template( $template ) {
+		if ( is_post_type_archive( 'artist_profile' ) ) {
+			$plugin_template = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/templates/archive-artist_profile.php';
+			if ( file_exists( $plugin_template ) ) {
+				return $plugin_template;
+			}
+		}
+		return $template;
+	}
 }

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Creation Filter Functions for ExtraChill Artist Platform
- * 
+ *
  * Centralized creation logic using WordPress filters for extensibility.
  * Handles creation vs editing mode distinction and prevents duplicate creation.
  */
@@ -10,86 +10,85 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Create a link page for an artist profile (centralized creation logic)
- * 
+ *
  * @param int  $artist_id The artist profile ID to create a link page for
  * @param bool $force     Force creation even if link page already exists
  * @return int|WP_Error   Link page ID on success, WP_Error on failure
  */
 function ec_create_link_page( $artist_id, $force = false ) {
-    // Validate artist profile
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for link page creation' );
-    }
+	// Validate artist profile
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for link page creation' );
+	}
 
-    // Check if link page already exists (unless forced)
-    $existing_link_page_id = apply_filters( 'ec_get_link_page_id', 0, $artist_id );
-    if ( $existing_link_page_id && ! $force ) {
-        // Link page already exists - return existing ID
-        if ( get_post_type( $existing_link_page_id ) === 'artist_link_page' ) {
-            return $existing_link_page_id;
-        }
-    }
+	// Check if link page already exists (unless forced)
+	$existing_link_page_id = apply_filters( 'ec_get_link_page_id', 0, $artist_id );
+	if ( $existing_link_page_id && ! $force ) {
+		// Link page already exists - return existing ID
+		if ( get_post_type( $existing_link_page_id ) === 'artist_link_page' ) {
+			return $existing_link_page_id;
+		}
+	}
 
-    // Get latest artist profile data
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
-        return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
-    }
+	// Get latest artist profile data
+	$artist_post = get_post( $artist_id );
+	if ( ! $artist_post ) {
+		return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
+	}
 
-    // Prepare link page data
-    $link_page_title = $artist_post->post_title;
-    $artist_profile_slug = $artist_post->post_name;
+	// Prepare link page data
+	$link_page_title     = $artist_post->post_title;
+	$artist_profile_slug = $artist_post->post_name;
 
-    // Ensure title and slug are not empty
-    if ( empty( $link_page_title ) || empty( $artist_profile_slug ) ) {
-        return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug for link page creation' );
-    }
+	// Ensure title and slug are not empty
+	if ( empty( $link_page_title ) || empty( $artist_profile_slug ) ) {
+		return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug for link page creation' );
+	}
 
-    // Create link page
-    $link_page_args = array(
-        'post_type'   => 'artist_link_page',
-        'post_title'  => $link_page_title,
-        'post_name'   => $artist_profile_slug,
-        'post_status' => 'publish',
-        'meta_input'  => array(
-            '_associated_artist_profile_id' => $artist_id,
-        ),
-    );
+	// Create link page
+	$link_page_args = array(
+		'post_type'   => 'artist_link_page',
+		'post_title'  => $link_page_title,
+		'post_name'   => $artist_profile_slug,
+		'post_status' => 'publish',
+		'meta_input'  => array(
+			'_associated_artist_profile_id' => $artist_id,
+		),
+	);
 
+	// Create the link page
+	$new_link_page_id = wp_insert_post( $link_page_args );
 
-    // Create the link page
-    $new_link_page_id = wp_insert_post( $link_page_args );
+	if ( is_wp_error( $new_link_page_id ) ) {
+		return $new_link_page_id;
+	}
 
-    if ( is_wp_error( $new_link_page_id ) ) {
-        return $new_link_page_id;
-    }
+	if ( ! $new_link_page_id ) {
+		return new WP_Error( 'creation_failed', 'Failed to create link page' );
+	}
 
-    if ( ! $new_link_page_id ) {
-        return new WP_Error( 'creation_failed', 'Failed to create link page' );
-    }
+	// Update artist profile with link page ID
+	update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
 
-    // Update artist profile with link page ID
-    update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+	// Apply default settings
+	ec_setup_default_link_page_data( $new_link_page_id, $artist_id );
 
-    // Apply default settings
-    ec_setup_default_link_page_data( $new_link_page_id, $artist_id );
+	/**
+	 * Fires after a link page has been created successfully.
+	 *
+	 * This action hook allows other plugins and theme functions to perform
+	 * additional setup operations after link page creation. The link page
+	 * and associated artist profile are both available and properly linked.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $new_link_page_id The ID of the newly created link page.
+	 * @param int $artist_id        The ID of the associated artist profile.
+	 * @param bool $force           Whether creation was forced.
+	 */
+	do_action( 'ec_link_page_created', $new_link_page_id, $artist_id, $force );
 
-    /**
-     * Fires after a link page has been created successfully.
-     *
-     * This action hook allows other plugins and theme functions to perform
-     * additional setup operations after link page creation. The link page
-     * and associated artist profile are both available and properly linked.
-     *
-     * @since 1.0.0
-     *
-     * @param int $new_link_page_id The ID of the newly created link page.
-     * @param int $artist_id        The ID of the associated artist profile.
-     * @param bool $force           Whether creation was forced.
-     */
-    do_action( 'ec_link_page_created', $new_link_page_id, $artist_id, $force );
-
-    return $new_link_page_id;
+	return $new_link_page_id;
 }
 
 /**
@@ -99,12 +98,11 @@ function ec_create_link_page( $artist_id, $force = false ) {
  * @param int $artist_id    The associated artist profile ID
  */
 function ec_setup_default_link_page_data( $link_page_id, $artist_id ) {
-    // Apply default styles using centralized filter system
-    $default_styles = ec_get_link_page_defaults_for( 'styles' );
-    if ( ! empty( $default_styles ) ) {
-        update_post_meta( $link_page_id, '_link_page_custom_css_vars', $default_styles );
-    }
-
+	// Apply default styles using centralized filter system
+	$default_styles = ec_get_link_page_defaults_for( 'styles' );
+	if ( ! empty( $default_styles ) ) {
+		update_post_meta( $link_page_id, '_link_page_custom_css_vars', $default_styles );
+	}
 }
 
 /**
@@ -117,38 +115,38 @@ function ec_setup_default_link_page_data( $link_page_id, $artist_id ) {
  * @return bool|WP_Error True if creation should proceed, WP_Error if not eligible
  */
 function ec_should_create_link_page( $artist_id ) {
-    // Validate artist profile
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID' );
-    }
+	// Validate artist profile
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID' );
+	}
 
-    // Check if link page already exists
-    $existing_link_page_id = apply_filters( 'ec_get_link_page_id', 0, $artist_id );
-    if ( $existing_link_page_id && get_post_type( $existing_link_page_id ) === 'artist_link_page' ) {
-        return new WP_Error( 'already_exists', 'Link page already exists for this artist profile' );
-    }
+	// Check if link page already exists
+	$existing_link_page_id = apply_filters( 'ec_get_link_page_id', 0, $artist_id );
+	if ( $existing_link_page_id && get_post_type( $existing_link_page_id ) === 'artist_link_page' ) {
+		return new WP_Error( 'already_exists', 'Link page already exists for this artist profile' );
+	}
 
-    // Check artist profile has required data
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
-        return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
-    }
+	// Check artist profile has required data
+	$artist_post = get_post( $artist_id );
+	if ( ! $artist_post ) {
+		return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
+	}
 
-    if ( empty( $artist_post->post_title ) || empty( $artist_post->post_name ) ) {
-        return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug' );
-    }
+	if ( empty( $artist_post->post_title ) || empty( $artist_post->post_name ) ) {
+		return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug' );
+	}
 
-    /**
-     * Filters whether a link page should be created for an artist profile.
-     *
-     * This filter allows plugins to add additional conditions for link page creation.
-     * Return WP_Error to prevent creation with a specific reason.
-     *
-     * @since 1.0.0
-     *
-     * @param bool|WP_Error $should_create True to allow creation, WP_Error to prevent.
-     * @param int           $artist_id     The artist profile ID being evaluated.
-     * @param WP_Post       $artist_post   The artist profile post object.
-     */
-    return apply_filters( 'ec_should_create_link_page', true, $artist_id, $artist_post );
+	/**
+	 * Filters whether a link page should be created for an artist profile.
+	 *
+	 * This filter allows plugins to add additional conditions for link page creation.
+	 * Return WP_Error to prevent creation with a specific reason.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool|WP_Error $should_create True to allow creation, WP_Error to prevent.
+	 * @param int           $artist_id     The artist profile ID being evaluated.
+	 * @param WP_Post       $artist_post   The artist profile post object.
+	 */
+	return apply_filters( 'ec_should_create_link_page', true, $artist_id, $artist_post );
 }

--- a/inc/core/filters/data.php
+++ b/inc/core/filters/data.php
@@ -5,56 +5,59 @@
  * Single source of truth for artist profile and link page data.
  * ec_get_link_page_data() provides complete link page data with live preview support.
  */
-
 function ec_is_user_artist_member( $user_id = null, $artist_id = null ) {
-    if ( ! $user_id ) {
-        $user_id = get_current_user_id();
-    }
+	if ( ! $user_id ) {
+		$user_id = get_current_user_id();
+	}
 
-    if ( ! $user_id || ! $artist_id ) {
-        return false;
-    }
+	if ( ! $user_id || ! $artist_id ) {
+		return false;
+	}
 
-    $user_artist_ids = ec_get_artists_for_user( $user_id );
-    return in_array( (int) $artist_id, $user_artist_ids );
+	$user_artist_ids = ec_get_artists_for_user( $user_id );
+	return in_array( (int) $artist_id, $user_artist_ids );
 }
 
 function ec_get_link_page_for_artist( $artist_id ) {
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return false;
-    }
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return false;
+	}
 
-    $link_pages = get_posts( array(
-        'post_type' => 'artist_link_page',
-        'meta_key' => '_associated_artist_profile_id',
-        'meta_value' => (string) $artist_id,
-        'posts_per_page' => 1,
-        'fields' => 'ids'
-    ) );
+	$link_pages = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'meta_key'       => '_associated_artist_profile_id',
+			'meta_value'     => (string) $artist_id,
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
 
-    return ! empty( $link_pages ) ? (int) $link_pages[0] : false;
+	return ! empty( $link_pages ) ? (int) $link_pages[0] : false;
 }
 
 function ec_get_user_artist_profiles( $user_id = null ) {
-    if ( ! $user_id ) {
-        $user_id = get_current_user_id();
-    }
+	if ( ! $user_id ) {
+		$user_id = get_current_user_id();
+	}
 
-    if ( ! $user_id ) {
-        return array();
-    }
+	if ( ! $user_id ) {
+		return array();
+	}
 
-    $artist_ids = ec_get_artists_for_user( $user_id );
-    if ( empty( $artist_ids ) ) {
-        return array();
-    }
+	$artist_ids = ec_get_artists_for_user( $user_id );
+	if ( empty( $artist_ids ) ) {
+		return array();
+	}
 
-    return get_posts( array(
-        'post_type' => 'artist_profile',
-        'post__in' => $artist_ids,
-        'posts_per_page' => -1,
-        'post_status' => 'publish'
-    ) );
+	return get_posts(
+		array(
+			'post_type'      => 'artist_profile',
+			'post__in'       => $artist_ids,
+			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+		)
+	);
 }
 
 /**
@@ -62,143 +65,153 @@ function ec_get_user_artist_profiles( $user_id = null ) {
  * Supports live preview overrides and comprehensive data validation.
  */
 function ec_get_link_page_data( $artist_id, $link_page_id = null, $overrides = array() ) {
-    if ( ! $artist_id ) {
-        return array();
-    }
+	if ( ! $artist_id ) {
+		return array();
+	}
 
-    if ( ! $link_page_id ) {
-        $link_page_id = ec_get_link_page_for_artist( $artist_id );
-    }
+	if ( ! $link_page_id ) {
+		$link_page_id = ec_get_link_page_for_artist( $artist_id );
+	}
 
-    if ( ! $link_page_id ) {
-        return array();
-    }
+	if ( ! $link_page_id ) {
+		return array();
+	}
 
-    $all_meta = get_post_meta( $link_page_id );
+	$all_meta = get_post_meta( $link_page_id );
 
-    $data = array(
-        'artist_id' => (int) $artist_id,
-        'link_page_id' => (int) $link_page_id,
-        'css_vars' => array(),
-        'links' => array(),
-        'socials' => array(),
-        'settings' => array(
-            'link_expiration_enabled' => false,
-            'redirect_enabled' => false,
-            'redirect_target_url' => '',
-            'youtube_embed_enabled' => true,
-            'meta_pixel_id' => '',
-            'google_tag_id' => '',
-            'google_tag_manager_id' => '',
-            'subscribe_display_mode' => 'icon_modal',
-            'subscribe_description' => '',
-            'social_icons_position' => 'above',
-            'profile_image_shape' => 'circle',
-            'profile_image_id' => '',
-            'overlay_enabled' => true
-        )
-    );
-    $css_vars_raw = array();
-    if ( isset( $all_meta['_link_page_custom_css_vars'][0] ) ) {
-        $css_vars_raw = maybe_unserialize( $all_meta['_link_page_custom_css_vars'][0] );
-        if ( ! is_array( $css_vars_raw ) ) {
-            $css_vars_raw = array();
-        }
-    }
+	$data         = array(
+		'artist_id'    => (int) $artist_id,
+		'link_page_id' => (int) $link_page_id,
+		'css_vars'     => array(),
+		'links'        => array(),
+		'socials'      => array(),
+		'settings'     => array(
+			'link_expiration_enabled' => false,
+			'redirect_enabled'        => false,
+			'redirect_target_url'     => '',
+			'youtube_embed_enabled'   => true,
+			'meta_pixel_id'           => '',
+			'google_tag_id'           => '',
+			'google_tag_manager_id'   => '',
+			'subscribe_display_mode'  => 'icon_modal',
+			'subscribe_description'   => '',
+			'social_icons_position'   => 'above',
+			'profile_image_shape'     => 'circle',
+			'profile_image_id'        => '',
+			'overlay_enabled'         => true,
+		),
+	);
+	$css_vars_raw = array();
+	if ( isset( $all_meta['_link_page_custom_css_vars'][0] ) ) {
+		$css_vars_raw = maybe_unserialize( $all_meta['_link_page_custom_css_vars'][0] );
+		if ( ! is_array( $css_vars_raw ) ) {
+			$css_vars_raw = array();
+		}
+	}
 
-    $default_css_vars = ec_get_link_page_defaults_for( 'styles' );
-    $data['css_vars'] = array_merge( $default_css_vars, $css_vars_raw );
+	$default_css_vars = ec_get_link_page_defaults_for( 'styles' );
+	$data['css_vars'] = array_merge( $default_css_vars, $css_vars_raw );
 
-    // Ensure card background color is always the default (not configurable)
-    $data['css_vars']['--link-page-card-bg-color'] = $default_css_vars['--link-page-card-bg-color'];
+	// Ensure card background color is always the default (not configurable)
+	$data['css_vars']['--link-page-card-bg-color'] = $default_css_vars['--link-page-card-bg-color'];
 
-    $data['css_vars']['--link-page-button-hover-text-color'] = $data['css_vars']['--link-page-link-text-color'];
+	$data['css_vars']['--link-page-button-hover-text-color'] = $data['css_vars']['--link-page-link-text-color'];
 
-    $data['raw_font_values'] = array(
-        'title_font' => $data['css_vars']['--link-page-title-font-family'] ?? '',
-        'body_font' => $data['css_vars']['--link-page-body-font-family'] ?? ''
-    );
+	$data['raw_font_values'] = array(
+		'title_font' => $data['css_vars']['--link-page-title-font-family'] ?? '',
+		'body_font'  => $data['css_vars']['--link-page-body-font-family'] ?? '',
+	);
 
-    if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
-        $font_manager = ExtraChillArtistPlatform_Fonts::instance();
-        $data['css_vars'] = $font_manager->process_font_css_vars( $data['css_vars'] );
-    }
+	if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
+		$font_manager     = ExtraChillArtistPlatform_Fonts::instance();
+		$data['css_vars'] = $font_manager->process_font_css_vars( $data['css_vars'] );
+	}
 
-    if ( isset( $all_meta['_link_page_links'][0] ) ) {
-        $links_raw = maybe_unserialize( $all_meta['_link_page_links'][0] );
-        if ( is_array( $links_raw ) ) {
-            $data['links'] = $links_raw;
-        }
-    }
+	if ( isset( $all_meta['_link_page_links'][0] ) ) {
+		$links_raw = maybe_unserialize( $all_meta['_link_page_links'][0] );
+		if ( is_array( $links_raw ) ) {
+			$data['links'] = $links_raw;
+		}
+	}
 
-    $artist_social_links = get_post_meta( $artist_id, '_artist_profile_social_links', true );
-    if ( is_array( $artist_social_links ) ) {
-        $data['socials'] = $artist_social_links;
-    }
-    $data['settings']['link_expiration_enabled'] = isset( $all_meta['_link_expiration_enabled'][0] ) && $all_meta['_link_expiration_enabled'][0] === '1';
-    $data['settings']['redirect_enabled'] = isset( $all_meta['_link_page_redirect_enabled'][0] ) && $all_meta['_link_page_redirect_enabled'][0] === '1';
-    $data['settings']['redirect_target_url'] = $all_meta['_link_page_redirect_target_url'][0] ?? '';
-    $data['settings']['youtube_embed_enabled'] = ! isset( $all_meta['_enable_youtube_inline_embed'][0] ) || $all_meta['_enable_youtube_inline_embed'][0] !== '0';
-    $data['settings']['meta_pixel_id'] = $all_meta['_link_page_meta_pixel_id'][0] ?? '';
-    $data['settings']['google_tag_id'] = $all_meta['_link_page_google_tag_id'][0] ?? '';
-    $data['settings']['google_tag_manager_id'] = $all_meta['_link_page_google_tag_manager_id'][0] ?? '';
-    $data['settings']['subscribe_display_mode'] = $all_meta['_link_page_subscribe_display_mode'][0] ?? 'icon_modal';
-    $data['settings']['subscribe_description'] = $all_meta['_link_page_subscribe_description'][0] ?? '';
-    $data['settings']['social_icons_position'] = $all_meta['_link_page_social_icons_position'][0] ?? 'above';
-    $data['settings']['profile_image_shape'] = $all_meta['_link_page_profile_img_shape'][0] ?? 'circle';
-    $data['settings']['profile_image_id'] = get_post_thumbnail_id( $artist_id ) ?: '';
-    $data['settings']['background_image_id'] = $all_meta['_link_page_background_image_id'][0] ?? '';
+	$artist_social_links = get_post_meta( $artist_id, '_artist_profile_social_links', true );
+	if ( is_array( $artist_social_links ) ) {
+		$data['socials'] = $artist_social_links;
+	}
+	$data['settings']['link_expiration_enabled'] = isset( $all_meta['_link_expiration_enabled'][0] ) && $all_meta['_link_expiration_enabled'][0] === '1';
+	$data['settings']['redirect_enabled']        = isset( $all_meta['_link_page_redirect_enabled'][0] ) && $all_meta['_link_page_redirect_enabled'][0] === '1';
+	$data['settings']['redirect_target_url']     = $all_meta['_link_page_redirect_target_url'][0] ?? '';
+	$data['settings']['youtube_embed_enabled']   = ! isset( $all_meta['_enable_youtube_inline_embed'][0] ) || $all_meta['_enable_youtube_inline_embed'][0] !== '0';
+	$data['settings']['meta_pixel_id']           = $all_meta['_link_page_meta_pixel_id'][0] ?? '';
+	$data['settings']['google_tag_id']           = $all_meta['_link_page_google_tag_id'][0] ?? '';
+	$data['settings']['google_tag_manager_id']   = $all_meta['_link_page_google_tag_manager_id'][0] ?? '';
+	$data['settings']['subscribe_display_mode']  = $all_meta['_link_page_subscribe_display_mode'][0] ?? 'icon_modal';
+	$data['settings']['subscribe_description']   = $all_meta['_link_page_subscribe_description'][0] ?? '';
+	$data['settings']['social_icons_position']   = $all_meta['_link_page_social_icons_position'][0] ?? 'above';
+	$data['settings']['profile_image_shape']     = $all_meta['_link_page_profile_img_shape'][0] ?? 'circle';
+	$data['settings']['profile_image_id']        = get_post_thumbnail_id( $artist_id ) ?: '';
+	$data['settings']['background_image_id']     = $all_meta['_link_page_background_image_id'][0] ?? '';
 
-    if ( isset( $data['css_vars']['overlay'] ) ) {
-        $data['settings']['overlay_enabled'] = $data['css_vars']['overlay'] === '1';
-    }
+	if ( isset( $data['css_vars']['overlay'] ) ) {
+		$data['settings']['overlay_enabled'] = $data['css_vars']['overlay'] === '1';
+	}
 
-    $display_data = array(
-        'display_title' => (isset($overrides['artist_profile_title']) && $overrides['artist_profile_title'] !== '') ? $overrides['artist_profile_title'] : ($artist_id ? get_the_title($artist_id) : ''),
-        'bio' => (isset($overrides['link_page_bio_text']) && $overrides['link_page_bio_text'] !== '') ? $overrides['link_page_bio_text'] : ($all_meta['_link_page_bio_text'][0] ?? ''),
-        'profile_img_url' => (isset($overrides['profile_img_url']) && $overrides['profile_img_url'] !== '') ? $overrides['profile_img_url'] : ($artist_id ? (get_the_post_thumbnail_url($artist_id, 'large') ?: '') : ''),
-        'social_links' => isset($overrides['social_links']) ? $overrides['social_links'] : $data['socials'],
-        'socials' => $data['socials'],
-        'link_sections' => isset($data['links'][0]['links']) || empty($data['links']) ? $data['links'] : array(array('section_title' => '', 'links' => $data['links'])),
-        'css_vars' => $data['css_vars'],
-        'background_type' => $data['css_vars']['--link-page-background-type'] ?? 'color',
-        'background_style' => '',
-        'powered_by' => true,
-        'artist_id' => $artist_id,
-        'link_page_id' => $link_page_id,
-        'profile_img_shape' => $data['settings']['profile_image_shape'],
-        '_link_page_social_icons_position' => $data['settings']['social_icons_position'],
-        '_link_page_subscribe_display_mode' => $data['settings']['subscribe_display_mode'],
-        '_link_page_subscribe_description' => $data['settings']['subscribe_description'],
-        '_actual_link_page_id_for_template' => $link_page_id,
-        'artist_profile' => $artist_id ? get_post($artist_id) : null,
-        'settings' => $data['settings'],
-        'links' => $data['links'],
-        'raw_font_values' => $data['raw_font_values'],
-        'background_image_id' => $data['settings']['background_image_id'],
-        'background_image_url' => !empty($data['settings']['background_image_id']) ? wp_get_attachment_url($data['settings']['background_image_id']) : '',
-    );
-    if (isset($overrides['artist_profile_social_links_json'])) {
-        $social_decoded = json_decode($overrides['artist_profile_social_links_json'], true);
-        if (is_array($social_decoded)) {
-            $display_data['social_links'] = $social_decoded;
-            $display_data['socials'] = $social_decoded;
-        }
-    }
+	$display_data = array(
+		'display_title'                     => ( isset( $overrides['artist_profile_title'] ) && $overrides['artist_profile_title'] !== '' ) ? $overrides['artist_profile_title'] : ( $artist_id ? get_the_title( $artist_id ) : '' ),
+		'bio'                               => ( isset( $overrides['link_page_bio_text'] ) && $overrides['link_page_bio_text'] !== '' ) ? $overrides['link_page_bio_text'] : ( $all_meta['_link_page_bio_text'][0] ?? '' ),
+		'profile_img_url'                   => ( isset( $overrides['profile_img_url'] ) && $overrides['profile_img_url'] !== '' ) ? $overrides['profile_img_url'] : ( $artist_id ? ( get_the_post_thumbnail_url( $artist_id, 'large' ) ?: '' ) : '' ),
+		'social_links'                      => isset( $overrides['social_links'] ) ? $overrides['social_links'] : $data['socials'],
+		'socials'                           => $data['socials'],
+		'link_sections'                     => isset( $data['links'][0]['links'] ) || empty( $data['links'] ) ? $data['links'] : array(
+			array(
+				'section_title' => '',
+				'links'         => $data['links'],
+			),
+		),
+		'css_vars'                          => $data['css_vars'],
+		'background_type'                   => $data['css_vars']['--link-page-background-type'] ?? 'color',
+		'background_style'                  => '',
+		'powered_by'                        => true,
+		'artist_id'                         => $artist_id,
+		'link_page_id'                      => $link_page_id,
+		'profile_img_shape'                 => $data['settings']['profile_image_shape'],
+		'_link_page_social_icons_position'  => $data['settings']['social_icons_position'],
+		'_link_page_subscribe_display_mode' => $data['settings']['subscribe_display_mode'],
+		'_link_page_subscribe_description'  => $data['settings']['subscribe_description'],
+		'_actual_link_page_id_for_template' => $link_page_id,
+		'artist_profile'                    => $artist_id ? get_post( $artist_id ) : null,
+		'settings'                          => $data['settings'],
+		'links'                             => $data['links'],
+		'raw_font_values'                   => $data['raw_font_values'],
+		'background_image_id'               => $data['settings']['background_image_id'],
+		'background_image_url'              => ! empty( $data['settings']['background_image_id'] ) ? wp_get_attachment_url( $data['settings']['background_image_id'] ) : '',
+	);
+	if ( isset( $overrides['artist_profile_social_links_json'] ) ) {
+		$social_decoded = json_decode( $overrides['artist_profile_social_links_json'], true );
+		if ( is_array( $social_decoded ) ) {
+			$display_data['social_links'] = $social_decoded;
+			$display_data['socials']      = $social_decoded;
+		}
+	}
 
-    if (isset($overrides['link_page_links_json'])) {
-        $links_decoded = json_decode($overrides['link_page_links_json'], true);
-        if (is_array($links_decoded)) {
-            $display_data['links'] = $links_decoded;
-            $display_data['link_sections'] = isset($links_decoded[0]['links']) || empty($links_decoded) ? $links_decoded : array(array('section_title' => '', 'links' => $links_decoded));
-        }
-    }
+	if ( isset( $overrides['link_page_links_json'] ) ) {
+		$links_decoded = json_decode( $overrides['link_page_links_json'], true );
+		if ( is_array( $links_decoded ) ) {
+			$display_data['links']         = $links_decoded;
+			$display_data['link_sections'] = isset( $links_decoded[0]['links'] ) || empty( $links_decoded ) ? $links_decoded : array(
+				array(
+					'section_title' => '',
+					'links'         => $links_decoded,
+				),
+			);
+		}
+	}
 
-    if (isset($overrides['css_vars'])) {
-        $display_data['css_vars'] = is_array($overrides['css_vars']) ? $overrides['css_vars'] : array();
-    }
+	if ( isset( $overrides['css_vars'] ) ) {
+		$display_data['css_vars'] = is_array( $overrides['css_vars'] ) ? $overrides['css_vars'] : array();
+	}
 
-    return apply_filters( 'extrachill_artist_get_link_page_data', $display_data, $artist_id, $link_page_id, $overrides );
+	return apply_filters( 'extrachill_artist_get_link_page_data', $display_data, $artist_id, $link_page_id, $overrides );
 }
 
 /**
@@ -206,111 +219,111 @@ function ec_get_link_page_data( $artist_id, $link_page_id = null, $overrides = a
  * Centralizes meta access, normalization, and derived display fields.
  */
 function ec_get_artist_profile_data( $artist_id, $overrides = array() ) {
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return array();
-    }
+	if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+		return array();
+	}
 
-    $meta = get_post_meta( $artist_id );
+	$meta = get_post_meta( $artist_id );
 
-    $social_links = $meta['_artist_profile_social_links'][0] ?? array();
-    $social_links = maybe_unserialize( $social_links );
-    if ( function_exists( 'extrachill_artist_platform_social_links' ) ) {
-        $social_links = extrachill_artist_platform_social_links()->get( $artist_id );
-    }
-    if ( ! is_array( $social_links ) ) {
-        $social_links = array();
-    }
+	$social_links = $meta['_artist_profile_social_links'][0] ?? array();
+	$social_links = maybe_unserialize( $social_links );
+	if ( function_exists( 'extrachill_artist_platform_social_links' ) ) {
+		$social_links = extrachill_artist_platform_social_links()->get( $artist_id );
+	}
+	if ( ! is_array( $social_links ) ) {
+		$social_links = array();
+	}
 
-    $header_image_id = $meta['_artist_profile_header_image_id'][0] ?? '';
-    $profile_image_id = get_post_thumbnail_id( $artist_id ) ?: '';
+	$header_image_id  = $meta['_artist_profile_header_image_id'][0] ?? '';
+	$profile_image_id = get_post_thumbnail_id( $artist_id ) ?: '';
 
-    $data = array(
-        'artist_id' => (int) $artist_id,
-        'title' => get_the_title( $artist_id ) ?: '',
-        'slug' => get_post_field( 'post_name', $artist_id ) ?: '',
-        'permalink' => get_permalink( $artist_id ) ?: '',
-        'bio' => ( get_post( $artist_id )->post_content ?? '' ),
-        'genre' => $meta['_genre'][0] ?? '',
-        'local_city' => $meta['_local_city'][0] ?? '',
-        'website_url' => $meta['_website_url'][0] ?? '',
-        'spotify_url' => $meta['_spotify_url'][0] ?? '',
-        'apple_music_url' => $meta['_apple_music_url'][0] ?? '',
-        'bandcamp_url' => $meta['_bandcamp_url'][0] ?? '',
-        'social_links' => $social_links,
-        'header_image_id' => $header_image_id,
-        'header_image_url' => $header_image_id ? wp_get_attachment_url( $header_image_id ) : '',
-        'profile_image_id' => $profile_image_id,
-        'profile_image_url' => $profile_image_id ? get_the_post_thumbnail_url( $artist_id, 'large' ) : '',
-        'link_page_id' => function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $artist_id ) : 0,
-    );
+	$data = array(
+		'artist_id'         => (int) $artist_id,
+		'title'             => get_the_title( $artist_id ) ?: '',
+		'slug'              => get_post_field( 'post_name', $artist_id ) ?: '',
+		'permalink'         => get_permalink( $artist_id ) ?: '',
+		'bio'               => ( get_post( $artist_id )->post_content ?? '' ),
+		'genre'             => $meta['_genre'][0] ?? '',
+		'local_city'        => $meta['_local_city'][0] ?? '',
+		'website_url'       => $meta['_website_url'][0] ?? '',
+		'spotify_url'       => $meta['_spotify_url'][0] ?? '',
+		'apple_music_url'   => $meta['_apple_music_url'][0] ?? '',
+		'bandcamp_url'      => $meta['_bandcamp_url'][0] ?? '',
+		'social_links'      => $social_links,
+		'header_image_id'   => $header_image_id,
+		'header_image_url'  => $header_image_id ? wp_get_attachment_url( $header_image_id ) : '',
+		'profile_image_id'  => $profile_image_id,
+		'profile_image_url' => $profile_image_id ? get_the_post_thumbnail_url( $artist_id, 'large' ) : '',
+		'link_page_id'      => function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $artist_id ) : 0,
+	);
 
-    if ( isset( $overrides['title'] ) ) {
-        $data['title'] = $overrides['title'];
-    }
-    if ( isset( $overrides['bio'] ) ) {
-        $data['bio'] = $overrides['bio'];
-    }
-    if ( isset( $overrides['header_image_id'] ) ) {
-        $data['header_image_id'] = $overrides['header_image_id'];
-        $data['header_image_url'] = $overrides['header_image_id'] ? wp_get_attachment_url( $overrides['header_image_id'] ) : '';
-    }
-    if ( isset( $overrides['profile_image_id'] ) ) {
-        $data['profile_image_id'] = $overrides['profile_image_id'];
-        $data['profile_image_url'] = $overrides['profile_image_id'] ? wp_get_attachment_url( $overrides['profile_image_id'] ) : '';
-    }
-    if ( isset( $overrides['social_links'] ) && is_array( $overrides['social_links'] ) ) {
-        $data['social_links'] = $overrides['social_links'];
-    }
+	if ( isset( $overrides['title'] ) ) {
+		$data['title'] = $overrides['title'];
+	}
+	if ( isset( $overrides['bio'] ) ) {
+		$data['bio'] = $overrides['bio'];
+	}
+	if ( isset( $overrides['header_image_id'] ) ) {
+		$data['header_image_id']  = $overrides['header_image_id'];
+		$data['header_image_url'] = $overrides['header_image_id'] ? wp_get_attachment_url( $overrides['header_image_id'] ) : '';
+	}
+	if ( isset( $overrides['profile_image_id'] ) ) {
+		$data['profile_image_id']  = $overrides['profile_image_id'];
+		$data['profile_image_url'] = $overrides['profile_image_id'] ? wp_get_attachment_url( $overrides['profile_image_id'] ) : '';
+	}
+	if ( isset( $overrides['social_links'] ) && is_array( $overrides['social_links'] ) ) {
+		$data['social_links'] = $overrides['social_links'];
+	}
 
-    $field_overrides = array( 'genre', 'local_city', 'website_url', 'spotify_url', 'apple_music_url', 'bandcamp_url' );
-    foreach ( $field_overrides as $field_key ) {
-        if ( isset( $overrides[ $field_key ] ) ) {
-            $data[ $field_key ] = $overrides[ $field_key ];
-        }
-    }
+	$field_overrides = array( 'genre', 'local_city', 'website_url', 'spotify_url', 'apple_music_url', 'bandcamp_url' );
+	foreach ( $field_overrides as $field_key ) {
+		if ( isset( $overrides[ $field_key ] ) ) {
+			$data[ $field_key ] = $overrides[ $field_key ];
+		}
+	}
 
-    return $data;
+	return $data;
 }
 
 function ec_generate_css_variables_style_block( $css_vars, $element_id = 'link-page-custom-vars' ) {
-    if ( empty( $css_vars ) || ! is_array( $css_vars ) ) {
-        return '';
-    }
+	if ( empty( $css_vars ) || ! is_array( $css_vars ) ) {
+		return '';
+	}
 
-    $output = '<style id="' . esc_attr( $element_id ) . '">:root {';
-    foreach ( $css_vars as $key => $value ) {
-        if ( $value !== null && $value !== false ) {
-            $output .= esc_html( $key ) . ':' . $value . ';';
-        }
-    }
-    $output .= '}</style>';
+	$output = '<style id="' . esc_attr( $element_id ) . '">:root {';
+	foreach ( $css_vars as $key => $value ) {
+		if ( $value !== null && $value !== false ) {
+			$output .= esc_html( $key ) . ':' . $value . ';';
+		}
+	}
+	$output .= '}</style>';
 
-    return $output;
+	return $output;
 }
 
 function ec_render_single_link( $link_data, $args = array() ) {
-    $template_args = array_merge( $args, $link_data );
-    return ec_render_template( 'single-link', $template_args );
+	$template_args = array_merge( $args, $link_data );
+	return ec_render_template( 'single-link', $template_args );
 }
 
 function ec_render_link_section( $section_data, $args = array() ) {
-    $template_args = array_merge( $args, $section_data );
-    return ec_render_template( 'link-section', $template_args );
+	$template_args = array_merge( $args, $section_data );
+	return ec_render_template( 'link-section', $template_args );
 }
 
 function ec_render_social_icon( $social_data, $social_manager = null ) {
-    $template_args = array(
-        'social_data' => $social_data,
-        'social_manager' => $social_manager
-    );
-    return ec_render_template( 'social-icon', $template_args );
+	$template_args = array(
+		'social_data'    => $social_data,
+		'social_manager' => $social_manager,
+	);
+	return ec_render_template( 'social-icon', $template_args );
 }
 
 function ec_render_social_icons_container( $social_links, $position = 'above', $social_manager = null ) {
-    $template_args = array(
-        'social_links' => $social_links,
-        'position' => $position,
-        'social_manager' => $social_manager
-    );
-    return ec_render_template( 'social-icons-container', $template_args );
+	$template_args = array(
+		'social_links'   => $social_links,
+		'position'       => $position,
+		'social_manager' => $social_manager,
+	);
+	return ec_render_template( 'social-icons-container', $template_args );
 }

--- a/inc/core/filters/defaults.php
+++ b/inc/core/filters/defaults.php
@@ -14,106 +14,105 @@ defined( 'ABSPATH' ) || exit;
  * @return array Structured array of all link page defaults
  */
 function ec_get_link_page_defaults() {
-    $defaults = array(
-        'styles' => array(
-            // Colors - Dark theme inspired
-            '--link-page-background-color'              => '#121212',
-            '--link-page-card-bg-color'                 => 'rgba(0, 0, 0, 0.4)',
-            '--link-page-text-color'                    => '#e5e5e5',
-            '--link-page-link-text-color'               => '#ffffff',
-            '--link-page-button-bg-color'               => '#0b5394',
-            '--link-page-button-border-color'           => '#0b5394',
-            '--link-page-button-hover-bg-color'         => '#53940b',
-            '--link-page-button-hover-text-color'       => '#ffffff',
-            '--link-page-muted-text-color'              => '#aaa',
-            '--link-page-overlay-color'                 => 'rgba(0, 0, 0, 0.5)',
-            '--link-page-input-bg'                      => '#181818',
-            '--link-page-accent'                        => '#888',
-            '--link-page-accent-hover'                  => '#222',
-            
-            // Background settings
-            '--link-page-background-type'               => 'color',
-            '--link-page-background-gradient-start'     => '#0b5394',
-            '--link-page-background-gradient-end'       => '#53940b',
-            '--link-page-background-gradient-direction' => 'to right',
-            '--link-page-background-image-url'          => '',
-            '--link-page-image-size'                    => 'cover',
-            '--link-page-image-position'                => 'center center',
-            '--link-page-image-repeat'                  => 'no-repeat',
-            'overlay'                                   => '1',
-            
-            // Typography
-            '--link-page-title-font-family'             => 'Loft Sans',
-            '--link-page-title-font-size'               => '2.1em',
-            '--link-page-body-font-family'              => 'Helvetica',
+	$defaults = array(
+		'styles'       => array(
+			// Colors - Dark theme inspired
+			'--link-page-background-color'              => '#121212',
+			'--link-page-card-bg-color'                 => 'rgba(0, 0, 0, 0.4)',
+			'--link-page-text-color'                    => '#e5e5e5',
+			'--link-page-link-text-color'               => '#ffffff',
+			'--link-page-button-bg-color'               => '#0b5394',
+			'--link-page-button-border-color'           => '#0b5394',
+			'--link-page-button-hover-bg-color'         => '#53940b',
+			'--link-page-button-hover-text-color'       => '#ffffff',
+			'--link-page-muted-text-color'              => '#aaa',
+			'--link-page-overlay-color'                 => 'rgba(0, 0, 0, 0.5)',
+			'--link-page-input-bg'                      => '#181818',
+			'--link-page-accent'                        => '#888',
+			'--link-page-accent-hover'                  => '#222',
 
-            // Button styling
-            '--link-page-button-radius'                 => '8px',
-            '--link-page-button-border-width'           => '0px',
-            
-            // Profile image settings
-            '--link-page-profile-img-size'              => '30%',
-            '_link_page_profile_img_shape'              => 'circle',
-        ),
-        
-        'settings' => array(
-            'subscribe_display_mode'    => 'icon_modal',
-            'social_icons_position'     => 'above',
-            'background_type'           => 'color',
-            'background_color'          => '#1a1a1a',
-            'profile_img_slider_value'  => 50,
-        ),
-        
-        
-        'subscription' => array(
-            'default_mode'        => 'icon_modal',
-            'description_template' => __( 'Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform' ),
-            'fallback_artist'     => __( 'this artist', 'extrachill-artist-platform' ),
-        ),
-    );
-    
-    /**
-     * Filters the complete set of link page default values.
-     *
-     * This filter allows themes and plugins to customize all default values
-     * used throughout the link page system. The defaults are organized by
-     * category (styles, settings, links, subscription) for easy modification.
-     *
-     * @since 1.0.0
-     *
-     * @param array $defaults {
-     *     Complete array of link page defaults organized by category.
-     *
-     *     @type array $styles {
-     *         CSS variable defaults and visual styling defaults.
-     *
-     *         @type string $--link-page-background-color        Default background color.
-     *         @type string $--link-page-text-color              Default text color.
-     *         @type string $--link-page-button-bg-color         Default button background.
-     *         @type string $--link-page-title-font-family       Default title font family.
-     *         @type string $--link-page-title-font-size         Default title font size.
-     *         @type string $--link-page-profile-img-size        Default profile image size.
-     *         ... Additional CSS variables for complete theming control.
-     *     }
-     *     @type array $settings {
-     *         Functional settings and display mode defaults.
-     *
-     *         @type string $subscribe_display_mode    Default subscription display mode.
-     *         @type string $social_icons_position     Default social icons placement.
-     *         @type string $background_type           Default background type.
-     *         @type string $background_color          Default background color value.
-     *         @type int    $profile_img_slider_value  Default profile image size slider value.
-     *     }
-     *     @type array $subscription {
-     *         Email subscription form defaults.
-     *
-     *         @type string $default_mode        Default subscription collection mode.
-     *         @type string $description_template Default description with placeholder support.
-     *         @type string $fallback_artist      Fallback text when artist name unavailable.
-     *     }
-     * }
-     */
-    return apply_filters( 'ec_link_page_defaults', $defaults );
+			// Background settings
+			'--link-page-background-type'               => 'color',
+			'--link-page-background-gradient-start'     => '#0b5394',
+			'--link-page-background-gradient-end'       => '#53940b',
+			'--link-page-background-gradient-direction' => 'to right',
+			'--link-page-background-image-url'          => '',
+			'--link-page-image-size'                    => 'cover',
+			'--link-page-image-position'                => 'center center',
+			'--link-page-image-repeat'                  => 'no-repeat',
+			'overlay'                                   => '1',
+
+			// Typography
+			'--link-page-title-font-family'             => 'Loft Sans',
+			'--link-page-title-font-size'               => '2.1em',
+			'--link-page-body-font-family'              => 'Helvetica',
+
+			// Button styling
+			'--link-page-button-radius'                 => '8px',
+			'--link-page-button-border-width'           => '0px',
+
+			// Profile image settings
+			'--link-page-profile-img-size'              => '30%',
+			'_link_page_profile_img_shape'              => 'circle',
+		),
+
+		'settings'     => array(
+			'subscribe_display_mode'   => 'icon_modal',
+			'social_icons_position'    => 'above',
+			'background_type'          => 'color',
+			'background_color'         => '#1a1a1a',
+			'profile_img_slider_value' => 50,
+		),
+
+		'subscription' => array(
+			'default_mode'         => 'icon_modal',
+			'description_template' => __( 'Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform' ),
+			'fallback_artist'      => __( 'this artist', 'extrachill-artist-platform' ),
+		),
+	);
+
+	/**
+	 * Filters the complete set of link page default values.
+	 *
+	 * This filter allows themes and plugins to customize all default values
+	 * used throughout the link page system. The defaults are organized by
+	 * category (styles, settings, links, subscription) for easy modification.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $defaults {
+	 *     Complete array of link page defaults organized by category.
+	 *
+	 *     @type array $styles {
+	 *         CSS variable defaults and visual styling defaults.
+	 *
+	 *         @type string $--link-page-background-color        Default background color.
+	 *         @type string $--link-page-text-color              Default text color.
+	 *         @type string $--link-page-button-bg-color         Default button background.
+	 *         @type string $--link-page-title-font-family       Default title font family.
+	 *         @type string $--link-page-title-font-size         Default title font size.
+	 *         @type string $--link-page-profile-img-size        Default profile image size.
+	 *         ... Additional CSS variables for complete theming control.
+	 *     }
+	 *     @type array $settings {
+	 *         Functional settings and display mode defaults.
+	 *
+	 *         @type string $subscribe_display_mode    Default subscription display mode.
+	 *         @type string $social_icons_position     Default social icons placement.
+	 *         @type string $background_type           Default background type.
+	 *         @type string $background_color          Default background color value.
+	 *         @type int    $profile_img_slider_value  Default profile image size slider value.
+	 *     }
+	 *     @type array $subscription {
+	 *         Email subscription form defaults.
+	 *
+	 *         @type string $default_mode        Default subscription collection mode.
+	 *         @type string $description_template Default description with placeholder support.
+	 *         @type string $fallback_artist      Fallback text when artist name unavailable.
+	 *     }
+	 * }
+	 */
+	return apply_filters( 'ec_link_page_defaults', $defaults );
 }
 
 /**
@@ -123,8 +122,8 @@ function ec_get_link_page_defaults() {
  * @return array|mixed Defaults for the specified category
  */
 function ec_get_link_page_defaults_for( $category ) {
-    $defaults = ec_get_link_page_defaults();
-    return isset( $defaults[ $category ] ) ? $defaults[ $category ] : array();
+	$defaults = ec_get_link_page_defaults();
+	return isset( $defaults[ $category ] ) ? $defaults[ $category ] : array();
 }
 
 /**
@@ -136,6 +135,6 @@ function ec_get_link_page_defaults_for( $category ) {
  * @return mixed The default value or fallback
  */
 function ec_get_link_page_default( $category, $key, $fallback = null ) {
-    $defaults = ec_get_link_page_defaults_for( $category );
-    return isset( $defaults[ $key ] ) ? $defaults[ $key ] : $fallback;
+	$defaults = ec_get_link_page_defaults_for( $category );
+	return isset( $defaults[ $key ] ) ? $defaults[ $key ] : $fallback;
 }

--- a/inc/core/filters/fonts.php
+++ b/inc/core/filters/fonts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * ExtraChill Artist Platform Fonts Manager
- * 
+ *
  * Centralized management system for all font functionality across the artist platform.
  * Provides single source of truth for fonts, font stack resolution, Google Font handling,
  * and JavaScript integration.
@@ -14,317 +14,317 @@ defined( 'ABSPATH' ) || exit;
 
 class ExtraChillArtistPlatform_Fonts {
 
-    /**
-     * Single instance of the class
-     * 
-     * @var ExtraChillArtistPlatform_Fonts|null
-     * @since 1.1.0
-     */
-    private static $instance = null;
+	/**
+	 * Single instance of the class
+	 *
+	 * @var ExtraChillArtistPlatform_Fonts|null
+	 * @since 1.1.0
+	 */
+	private static $instance = null;
 
-    /**
-     * Supported fonts configuration
-     * 
-     * @var array|null
-     * @since 1.1.0
-     */
-    private $supported_fonts = null;
+	/**
+	 * Supported fonts configuration
+	 *
+	 * @var array|null
+	 * @since 1.1.0
+	 */
+	private $supported_fonts = null;
 
-    /**
-     * Default font values
-     * 
-     * @since 1.1.0
-     */
-    const DEFAULT_TITLE_FONT = 'Loft Sans';
-    const DEFAULT_BODY_FONT = 'Helvetica';
-    const DEFAULT_FONT_STACK = "'Helvetica', Arial, sans-serif";
+	/**
+	 * Default font values
+	 *
+	 * @since 1.1.0
+	 */
+	const DEFAULT_TITLE_FONT = 'Loft Sans';
+	const DEFAULT_BODY_FONT  = 'Helvetica';
+	const DEFAULT_FONT_STACK = "'Helvetica', Arial, sans-serif";
 
-    /**
-     * Get single instance
-     * 
-     * @since 1.1.0
-     * @return ExtraChillArtistPlatform_Fonts The fonts manager instance
-     */
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
+	/**
+	 * Get single instance
+	 *
+	 * @since 1.1.0
+	 * @return ExtraChillArtistPlatform_Fonts The fonts manager instance
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
 
-    /**
-     * Constructor
-     * 
-     * @since 1.1.0
-     */
-    private function __construct() {
-        $this->init_hooks();
-    }
+	/**
+	 * Constructor
+	 *
+	 * @since 1.1.0
+	 */
+	private function __construct() {
+		$this->init_hooks();
+	}
 
-    /**
-     * Initialize hooks
-     * 
-     * @since 1.1.0
-     */
-    private function init_hooks() {
-        // Register the font filter to provide fonts to the system
-        add_filter( 'ec_artist_platform_fonts', array( $this, 'get_supported_fonts' ) );
-        
-        // Localize font data for JavaScript in admin
-        add_action( 'admin_enqueue_scripts', array( $this, 'localize_font_data' ) );
-    }
+	/**
+	 * Initialize hooks
+	 *
+	 * @since 1.1.0
+	 */
+	private function init_hooks() {
+		// Register the font filter to provide fonts to the system
+		add_filter( 'ec_artist_platform_fonts', array( $this, 'get_supported_fonts' ) );
 
-    /**
-     * Get supported fonts configuration
-     * 
-     * @since 1.1.0
-     * @return array Supported fonts with metadata
-     */
-    public function get_supported_fonts() {
-        if ( null === $this->supported_fonts ) {
-            // Define the default fonts - no filter recursion
-            $this->supported_fonts = array(
-                array(
-                    'value' => 'Helvetica',
-                    'label' => 'Helvetica',
-                    'stack' => "'Helvetica', Arial, sans-serif",
-                    'google_font_param' => 'local_default',
-                ),
-                array(
-                    'value' => 'Loft Sans',
-                    'label' => 'Loft Sans',
-                    'stack' => "'Loft Sans', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'local_default',
-                ),
-                array(
-                    'value' => 'Roboto',
-                    'label' => 'Roboto',
-                    'stack' => "'Roboto', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Roboto:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Open Sans',
-                    'label' => 'Open Sans',
-                    'stack' => "'Open Sans', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Open+Sans:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Lato',
-                    'label' => 'Lato',
-                    'stack' => "'Lato', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Lato:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Montserrat',
-                    'label' => 'Montserrat',
-                    'stack' => "'Montserrat', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Montserrat:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Oswald',
-                    'label' => 'Oswald',
-                    'stack' => "'Oswald', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Oswald:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Raleway',
-                    'label' => 'Raleway',
-                    'stack' => "'Raleway', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Raleway:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Poppins',
-                    'label' => 'Poppins',
-                    'stack' => "'Poppins', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Poppins:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Nunito',
-                    'label' => 'Nunito',
-                    'stack' => "'Nunito', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Nunito:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Caveat',
-                    'label' => 'Caveat',
-                    'stack' => "'Caveat', Helvetica, Arial, cursive",
-                    'google_font_param' => 'Caveat:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Space Grotesk',
-                    'label' => 'Space Grotesk',
-                    'stack' => "'Space Grotesk', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Space+Grotesk:wght@400;600;700',
-                ),
-                array(
-                    'value' => 'Bebas Neue',
-                    'label' => 'Bebas Neue',
-                    'stack' => "'Bebas Neue', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Bebas+Neue:wght@400',
-                ),
-                array(
-                    'value' => 'Inter',
-                    'label' => 'Inter',
-                    'stack' => "'Inter', Helvetica, Arial, sans-serif",
-                    'google_font_param' => 'Inter:wght@400;600;700',
-                ),
-            );
-        }
+		// Localize font data for JavaScript in admin
+		add_action( 'admin_enqueue_scripts', array( $this, 'localize_font_data' ) );
+	}
 
-        return $this->supported_fonts;
-    }
+	/**
+	 * Get supported fonts configuration
+	 *
+	 * @since 1.1.0
+	 * @return array Supported fonts with metadata
+	 */
+	public function get_supported_fonts() {
+		if ( null === $this->supported_fonts ) {
+			// Define the default fonts - no filter recursion
+			$this->supported_fonts = array(
+				array(
+					'value'             => 'Helvetica',
+					'label'             => 'Helvetica',
+					'stack'             => "'Helvetica', Arial, sans-serif",
+					'google_font_param' => 'local_default',
+				),
+				array(
+					'value'             => 'Loft Sans',
+					'label'             => 'Loft Sans',
+					'stack'             => "'Loft Sans', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'local_default',
+				),
+				array(
+					'value'             => 'Roboto',
+					'label'             => 'Roboto',
+					'stack'             => "'Roboto', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Roboto:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Open Sans',
+					'label'             => 'Open Sans',
+					'stack'             => "'Open Sans', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Open+Sans:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Lato',
+					'label'             => 'Lato',
+					'stack'             => "'Lato', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Lato:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Montserrat',
+					'label'             => 'Montserrat',
+					'stack'             => "'Montserrat', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Montserrat:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Oswald',
+					'label'             => 'Oswald',
+					'stack'             => "'Oswald', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Oswald:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Raleway',
+					'label'             => 'Raleway',
+					'stack'             => "'Raleway', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Raleway:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Poppins',
+					'label'             => 'Poppins',
+					'stack'             => "'Poppins', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Poppins:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Nunito',
+					'label'             => 'Nunito',
+					'stack'             => "'Nunito', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Nunito:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Caveat',
+					'label'             => 'Caveat',
+					'stack'             => "'Caveat', Helvetica, Arial, cursive",
+					'google_font_param' => 'Caveat:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Space Grotesk',
+					'label'             => 'Space Grotesk',
+					'stack'             => "'Space Grotesk', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Space+Grotesk:wght@400;600;700',
+				),
+				array(
+					'value'             => 'Bebas Neue',
+					'label'             => 'Bebas Neue',
+					'stack'             => "'Bebas Neue', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Bebas+Neue:wght@400',
+				),
+				array(
+					'value'             => 'Inter',
+					'label'             => 'Inter',
+					'stack'             => "'Inter', Helvetica, Arial, sans-serif",
+					'google_font_param' => 'Inter:wght@400;600;700',
+				),
+			);
+		}
 
-    /**
-     * Get font stack by font value
-     * 
-     * @since 1.1.0
-     * @param string $font_value Font value to lookup
-     * @return string Font stack CSS value
-     */
-    public function get_font_stack( $font_value ) {
-        $fonts = $this->get_supported_fonts();
-        
-        foreach ( $fonts as $font ) {
-            if ( $font['value'] === $font_value ) {
-                return $font['stack'];
-            }
-        }
-        
-        // Fallback: if not found and looks like a simple font name, wrap it
-        if ( strpos( $font_value, ',' ) === false && 
-             strpos( $font_value, "'" ) === false && 
-             strpos( $font_value, '"' ) === false ) {
-            return "'" . $font_value . "', " . self::DEFAULT_FONT_STACK;
-        }
-        
-        return $font_value ?: self::DEFAULT_FONT_STACK;
-    }
+		return $this->supported_fonts;
+	}
 
-    /**
-     * Get Google Font parameter by font value
-     * 
-     * @since 1.1.0
-     * @param string $font_value Font value to lookup
-     * @return string|null Google Font parameter or null if local font
-     */
-    public function get_google_font_param( $font_value ) {
-        $fonts = $this->get_supported_fonts();
-        
-        foreach ( $fonts as $font ) {
-            if ( $font['value'] === $font_value ) {
-                return ( $font['google_font_param'] !== 'local_default' ) ? $font['google_font_param'] : null;
-            }
-        }
-        
-        return null;
-    }
+	/**
+	 * Get font stack by font value
+	 *
+	 * @since 1.1.0
+	 * @param string $font_value Font value to lookup
+	 * @return string Font stack CSS value
+	 */
+	public function get_font_stack( $font_value ) {
+		$fonts = $this->get_supported_fonts();
 
-    /**
-     * Get Google Fonts URL for multiple fonts
-     * 
-     * @since 1.1.0
-     * @param array $font_values Array of font values
-     * @return string Google Fonts URL or empty string
-     */
-    public function get_google_fonts_url( $font_values = array() ) {
-        $google_fonts = array();
-        
-        foreach ( $font_values as $font_value ) {
-            $param = $this->get_google_font_param( $font_value );
-            if ( $param ) {
-                $google_fonts[] = $param;
-            }
-        }
-        
-        if ( empty( $google_fonts ) ) {
-            return '';
-        }
-        
-        $unique_fonts = array_unique( $google_fonts );
-        return 'https://fonts.googleapis.com/css2?family=' . implode( '&family=', $unique_fonts ) . '&display=swap';
-    }
+		foreach ( $fonts as $font ) {
+			if ( $font['value'] === $font_value ) {
+				return $font['stack'];
+			}
+		}
 
-    /**
-     * Process CSS variables for fonts
-     * 
-     * Resolves font values to proper CSS font stacks
-     * 
-     * @since 1.1.0
-     * @param array $css_vars CSS variables array
-     * @return array Processed CSS variables
-     */
-    public function process_font_css_vars( $css_vars ) {
-        // Process title font
-        if ( isset( $css_vars['--link-page-title-font-family'] ) ) {
-            $css_vars['--link-page-title-font-family'] = $this->get_font_stack( 
-                $css_vars['--link-page-title-font-family'] 
-            );
-        }
-        
-        // Process body font
-        if ( isset( $css_vars['--link-page-body-font-family'] ) ) {
-            $css_vars['--link-page-body-font-family'] = $this->get_font_stack( 
-                $css_vars['--link-page-body-font-family'] 
-            );
-        }
-        
-        return $css_vars;
-    }
+		// Fallback: if not found and looks like a simple font name, wrap it
+		if ( strpos( $font_value, ',' ) === false &&
+			strpos( $font_value, "'" ) === false &&
+			strpos( $font_value, '"' ) === false ) {
+			return "'" . $font_value . "', " . self::DEFAULT_FONT_STACK;
+		}
 
-    /**
-     * Generate @font-face CSS for local fonts
-     * 
-     * Only generates @font-face definitions for selected local fonts (not Google Fonts).
-     * Follows same dynamic pattern as Google Font loading.
-     * 
-     * @since 1.1.0
-     * @param array $font_values Array of selected font values 
-     * @return string CSS @font-face definitions for local fonts
-     */
-    public function get_local_fonts_css( $font_values ) {
-        if ( empty( $font_values ) || ! is_array( $font_values ) ) {
-            return '';
-        }
+		return $font_value ?: self::DEFAULT_FONT_STACK;
+	}
 
-        $local_fonts_css = '';
-        $fonts = $this->get_supported_fonts();
+	/**
+	 * Get Google Font parameter by font value
+	 *
+	 * @since 1.1.0
+	 * @param string $font_value Font value to lookup
+	 * @return string|null Google Font parameter or null if local font
+	 */
+	public function get_google_font_param( $font_value ) {
+		$fonts = $this->get_supported_fonts();
 
-        foreach ( $font_values as $font_value ) {
-            $normalized_value = $this->normalize_font_value( $font_value );
-            if ( empty( $normalized_value ) ) {
-                continue;
-            }
+		foreach ( $fonts as $font ) {
+			if ( $font['value'] === $font_value ) {
+				return ( $font['google_font_param'] !== 'local_default' ) ? $font['google_font_param'] : null;
+			}
+		}
 
-            $font_config = null;
-            foreach ( $fonts as $font ) {
-                if ( $font['value'] === $normalized_value ) {
-                    $font_config = $font;
-                    break;
-                }
-            }
+		return null;
+	}
 
-            if ( $font_config &&
-                 isset( $font_config['google_font_param'] ) &&
-                 $font_config['google_font_param'] === 'local_default' ) {
-                if ( $normalized_value === 'Loft Sans' ) {
-                    $local_fonts_css .= $this->get_loft_sans_font_face();
-                }
-            }
-        }
+	/**
+	 * Get Google Fonts URL for multiple fonts
+	 *
+	 * @since 1.1.0
+	 * @param array $font_values Array of font values
+	 * @return string Google Fonts URL or empty string
+	 */
+	public function get_google_fonts_url( $font_values = array() ) {
+		$google_fonts = array();
 
-        return $local_fonts_css;
-    }
+		foreach ( $font_values as $font_value ) {
+			$param = $this->get_google_font_param( $font_value );
+			if ( $param ) {
+				$google_fonts[] = $param;
+			}
+		}
 
-    /**
-     * Get @font-face definition for Loft Sans
-     *
-     * @since 1.1.0
-     * @return string CSS @font-face definition
-     */
-    private function get_loft_sans_font_face() {
-        $theme_url = get_template_directory_uri();
+		if ( empty( $google_fonts ) ) {
+			return '';
+		}
 
-        return "@font-face {
+		$unique_fonts = array_unique( $google_fonts );
+		return 'https://fonts.googleapis.com/css2?family=' . implode( '&family=', $unique_fonts ) . '&display=swap';
+	}
+
+	/**
+	 * Process CSS variables for fonts
+	 *
+	 * Resolves font values to proper CSS font stacks
+	 *
+	 * @since 1.1.0
+	 * @param array $css_vars CSS variables array
+	 * @return array Processed CSS variables
+	 */
+	public function process_font_css_vars( $css_vars ) {
+		// Process title font
+		if ( isset( $css_vars['--link-page-title-font-family'] ) ) {
+			$css_vars['--link-page-title-font-family'] = $this->get_font_stack(
+				$css_vars['--link-page-title-font-family']
+			);
+		}
+
+		// Process body font
+		if ( isset( $css_vars['--link-page-body-font-family'] ) ) {
+			$css_vars['--link-page-body-font-family'] = $this->get_font_stack(
+				$css_vars['--link-page-body-font-family']
+			);
+		}
+
+		return $css_vars;
+	}
+
+	/**
+	 * Generate @font-face CSS for local fonts
+	 *
+	 * Only generates @font-face definitions for selected local fonts (not Google Fonts).
+	 * Follows same dynamic pattern as Google Font loading.
+	 *
+	 * @since 1.1.0
+	 * @param array $font_values Array of selected font values
+	 * @return string CSS @font-face definitions for local fonts
+	 */
+	public function get_local_fonts_css( $font_values ) {
+		if ( empty( $font_values ) || ! is_array( $font_values ) ) {
+			return '';
+		}
+
+		$local_fonts_css = '';
+		$fonts           = $this->get_supported_fonts();
+
+		foreach ( $font_values as $font_value ) {
+			$normalized_value = $this->normalize_font_value( $font_value );
+			if ( empty( $normalized_value ) ) {
+				continue;
+			}
+
+			$font_config = null;
+			foreach ( $fonts as $font ) {
+				if ( $font['value'] === $normalized_value ) {
+					$font_config = $font;
+					break;
+				}
+			}
+
+			if ( $font_config &&
+				isset( $font_config['google_font_param'] ) &&
+				$font_config['google_font_param'] === 'local_default' ) {
+				if ( $normalized_value === 'Loft Sans' ) {
+					$local_fonts_css .= $this->get_loft_sans_font_face();
+				}
+			}
+		}
+
+		return $local_fonts_css;
+	}
+
+	/**
+	 * Get @font-face definition for Loft Sans
+	 *
+	 * @since 1.1.0
+	 * @return string CSS @font-face definition
+	 */
+	private function get_loft_sans_font_face() {
+		$theme_url = get_template_directory_uri();
+
+		return "@font-face {
     font-family: 'Loft Sans';
     src: url('{$theme_url}/assets/fonts/WilcoLoftSans-Treble.woff2') format('woff2'),
          url('{$theme_url}/assets/fonts/WilcoLoftSans-Treble.woff') format('woff');
@@ -332,60 +332,64 @@ class ExtraChillArtistPlatform_Fonts {
     font-style: normal;
     font-display: swap;
  }\n";
-    }
+	}
 
-    /**
-     * Normalize a raw font value for comparisons.
-     *
-     * @since 1.1.0
-     * @param mixed $font_value Font value from storage.
-     * @return string Normalized font value.
-     */
-    private function normalize_font_value( $font_value ) {
-        if ( ! is_string( $font_value ) ) {
-            return '';
-        }
+	/**
+	 * Normalize a raw font value for comparisons.
+	 *
+	 * @since 1.1.0
+	 * @param mixed $font_value Font value from storage.
+	 * @return string Normalized font value.
+	 */
+	private function normalize_font_value( $font_value ) {
+		if ( ! is_string( $font_value ) ) {
+			return '';
+		}
 
-        $font_value = trim( $font_value );
-        if ( $font_value === '' ) {
-            return '';
-        }
+		$font_value = trim( $font_value );
+		if ( $font_value === '' ) {
+			return '';
+		}
 
-        $primary = explode( ',', $font_value )[0];
-        $primary = trim( $primary );
+		$primary = explode( ',', $font_value )[0];
+		$primary = trim( $primary );
 
-        return trim( $primary, " \t\n\r\0\x0B'\"" );
-    }
+		return trim( $primary, " \t\n\r\0\x0B'\"" );
+	}
 
-    /**
-     * Localize font data for JavaScript
-     * 
-     * @since 1.1.0
-     */
-    public function localize_font_data() {
-        global $pagenow;
-        
-        // Only localize on block editors and artist contexts
-        if ( 'post.php' === $pagenow || 'page.php' === $pagenow || isset( $_GET['artist_id'] ) ) {
-            wp_localize_script( 'extrachill-manage-link-page-fonts', 'extrchFontData', array(
-                'fonts' => $this->get_supported_fonts(),
-                'restUrl' => rest_url( 'extrachill/v1' )
-            ) );
-        }
-    }
+	/**
+	 * Localize font data for JavaScript
+	 *
+	 * @since 1.1.0
+	 */
+	public function localize_font_data() {
+		global $pagenow;
 
-    /**
-     * Get default font configuration
-     * 
-     * @since 1.1.0
-     * @return array Default CSS variables for fonts
-     */
-    public function get_default_font_css_vars() {
-        return array(
-            '--link-page-title-font-family' => $this->get_font_stack( self::DEFAULT_TITLE_FONT ),
-            '--link-page-title-font-size' => '2.1em',
-            '--link-page-body-font-family' => $this->get_font_stack( self::DEFAULT_BODY_FONT ),
-            '--link-page-body-font-size' => '1em',
-        );
-    }
+		// Only localize on block editors and artist contexts
+		if ( 'post.php' === $pagenow || 'page.php' === $pagenow || isset( $_GET['artist_id'] ) ) {
+			wp_localize_script(
+				'extrachill-manage-link-page-fonts',
+				'extrchFontData',
+				array(
+					'fonts'   => $this->get_supported_fonts(),
+					'restUrl' => rest_url( 'extrachill/v1' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Get default font configuration
+	 *
+	 * @since 1.1.0
+	 * @return array Default CSS variables for fonts
+	 */
+	public function get_default_font_css_vars() {
+		return array(
+			'--link-page-title-font-family' => $this->get_font_stack( self::DEFAULT_TITLE_FONT ),
+			'--link-page-title-font-size'   => '2.1em',
+			'--link-page-body-font-family'  => $this->get_font_stack( self::DEFAULT_BODY_FONT ),
+			'--link-page-body-font-size'    => '1em',
+		);
+	}
 }

--- a/inc/core/filters/ids.php
+++ b/inc/core/filters/ids.php
@@ -1,233 +1,242 @@
 <?php
 /**
  * ID Filter Functions for Extra Chill Artist Platform
- * 
+ *
  * Single source of truth for all ID-related operations.
  * Clean, filterable functions for retrieving entity IDs throughout the system.
  */
 
 /**
  * Universal artist ID resolver - handles all context types
- * 
+ *
  * @param mixed $context Context for ID resolution (int, array, or null)
  * @return int Artist profile ID (0 if not found)
  */
 function ec_get_artist_id( $context = null ) {
-    // Handle array context ($_GET, $_POST, query vars)
-    if ( is_array( $context ) ) {
-        // Check for all artist ID key variations
-        $artist_id_keys = ['artist_id', 'artist_profile_id', 'new_artist_id', 'target_artist_id', 'created_artist_id'];
-        foreach ( $artist_id_keys as $key ) {
-            if ( isset( $context[$key] ) && $context[$key] ) {
-                $artist_id = absint( $context[$key] );
-                if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
-                    return $artist_id;
-                }
-            }
-        }
-        // Check for link_page_id in array to resolve to artist
-        if ( isset( $context['link_page_id'] ) && $context['link_page_id'] ) {
-            $link_page_id = absint( $context['link_page_id'] );
-            if ( $link_page_id && get_post_type( $link_page_id ) === 'artist_link_page' ) {
-                $artist_id = get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
-                $artist_id = $artist_id ? (int) $artist_id : 0;
-                return $artist_id;
-            }
-        }
-        return 0;
-    }
-    
-    // Handle numeric context - auto-detect what type of ID this is
-    if ( is_numeric( $context ) && $context > 0 ) {
-        $id = (int) $context;
-        $post_type = get_post_type( $id );
-        
-        // If it's already an artist profile, return it
-        if ( $post_type === 'artist_profile' ) {
-            return $id;
-        }
-        
-        // If it's a link page, resolve to artist
-        if ( $post_type === 'artist_link_page' ) {
-            $artist_id = get_post_meta( $id, '_associated_artist_profile_id', true );
-            $artist_id = $artist_id ? (int) $artist_id : 0;
-            return $artist_id;
-        }
-        
-        if ( $post_type === false ) { // Likely a user ID
-            $user_artist_ids = ec_get_artists_for_user( $id );
-            if ( ! empty( $user_artist_ids ) ) {
-                $first_artist_id = (int) $user_artist_ids[0];
-                return $first_artist_id;
-            }
-        }
-        
-        return 0;
-    }
-    
-    // Handle null context - current context resolution (integrate ec_get_current_artist_id logic)
-    if ( is_null( $context ) ) {
-        // From query var
-        $qv = get_query_var( 'ec_get_artist_id' );
-        if ( $qv ) {
-            $aid = (int) $qv;
-            if ( $aid > 0 && get_post_type( $aid ) === 'artist_profile' ) {
-                return $aid;
-            }
-        }
-        
-        // From global $post if it's a link page
-        global $post;
-        if ( $post && isset( $post->ID ) && 'artist_link_page' === get_post_type( $post->ID ) ) {
-            $artist_id = get_post_meta( $post->ID, '_associated_artist_profile_id', true );
-            $artist_id = $artist_id ? (int) $artist_id : 0;
-            if ( $artist_id ) {
-                return $artist_id;
-            }
-        }
-        
-        // From global $post if it's an artist profile
-        if ( $post && isset( $post->ID ) && 'artist_profile' === get_post_type( $post->ID ) ) {
-            return (int) $post->ID;
-        }
-        
-        return 0;
-    }
-    
-    return 0;
+	// Handle array context ($_GET, $_POST, query vars)
+	if ( is_array( $context ) ) {
+		// Check for all artist ID key variations
+		$artist_id_keys = array( 'artist_id', 'artist_profile_id', 'new_artist_id', 'target_artist_id', 'created_artist_id' );
+		foreach ( $artist_id_keys as $key ) {
+			if ( isset( $context[ $key ] ) && $context[ $key ] ) {
+				$artist_id = absint( $context[ $key ] );
+				if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
+					return $artist_id;
+				}
+			}
+		}
+		// Check for link_page_id in array to resolve to artist
+		if ( isset( $context['link_page_id'] ) && $context['link_page_id'] ) {
+			$link_page_id = absint( $context['link_page_id'] );
+			if ( $link_page_id && get_post_type( $link_page_id ) === 'artist_link_page' ) {
+				$artist_id = get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
+				$artist_id = $artist_id ? (int) $artist_id : 0;
+				return $artist_id;
+			}
+		}
+		return 0;
+	}
+
+	// Handle numeric context - auto-detect what type of ID this is
+	if ( is_numeric( $context ) && $context > 0 ) {
+		$id        = (int) $context;
+		$post_type = get_post_type( $id );
+
+		// If it's already an artist profile, return it
+		if ( $post_type === 'artist_profile' ) {
+			return $id;
+		}
+
+		// If it's a link page, resolve to artist
+		if ( $post_type === 'artist_link_page' ) {
+			$artist_id = get_post_meta( $id, '_associated_artist_profile_id', true );
+			$artist_id = $artist_id ? (int) $artist_id : 0;
+			return $artist_id;
+		}
+
+		if ( $post_type === false ) { // Likely a user ID
+			$user_artist_ids = ec_get_artists_for_user( $id );
+			if ( ! empty( $user_artist_ids ) ) {
+				$first_artist_id = (int) $user_artist_ids[0];
+				return $first_artist_id;
+			}
+		}
+
+		return 0;
+	}
+
+	// Handle null context - current context resolution (integrate ec_get_current_artist_id logic)
+	if ( is_null( $context ) ) {
+		// From query var
+		$qv = get_query_var( 'ec_get_artist_id' );
+		if ( $qv ) {
+			$aid = (int) $qv;
+			if ( $aid > 0 && get_post_type( $aid ) === 'artist_profile' ) {
+				return $aid;
+			}
+		}
+
+		// From global $post if it's a link page
+		global $post;
+		if ( $post && isset( $post->ID ) && 'artist_link_page' === get_post_type( $post->ID ) ) {
+			$artist_id = get_post_meta( $post->ID, '_associated_artist_profile_id', true );
+			$artist_id = $artist_id ? (int) $artist_id : 0;
+			if ( $artist_id ) {
+				return $artist_id;
+			}
+		}
+
+		// From global $post if it's an artist profile
+		if ( $post && isset( $post->ID ) && 'artist_profile' === get_post_type( $post->ID ) ) {
+			return (int) $post->ID;
+		}
+
+		return 0;
+	}
+
+	return 0;
 }
 
 /**
  * Universal link page ID resolver - handles all context types
- * 
+ *
  * @param mixed $context Context for ID resolution (int, array, or null)
  * @return int Link page ID (0 if not found)
  */
 function ec_get_link_page_id( $context = null ) {
-    // Handle array context ($_GET, $_POST, query vars)
-    if ( is_array( $context ) ) {
-        // Check for all link page ID key variations
-        $link_page_id_keys = ['link_page_id', 'new_link_page_id', 'created_link_page_id'];
-        foreach ( $link_page_id_keys as $key ) {
-            if ( isset( $context[$key] ) && $context[$key] ) {
-                $link_page_id = absint( $context[$key] );
-                if ( $link_page_id && get_post_type( $link_page_id ) === 'artist_link_page' ) {
-                    return $link_page_id;
-                }
-            }
-        }
-        // Check for artist_id in array to resolve to link page
-        if ( isset( $context['artist_id'] ) && $context['artist_id'] ) {
-            $artist_id = absint( $context['artist_id'] );
-            if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
-                $link_pages = get_posts( array(
-                    'post_type' => 'artist_link_page',
-                    'meta_key' => '_associated_artist_profile_id',
-                    'meta_value' => (string) $artist_id,
-                    'posts_per_page' => 1,
-                    'fields' => 'ids'
-                ) );
-                $link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
-                return $link_page_id;
-            }
-        }
-        return 0;
-    }
-    
-    // Handle numeric context - auto-detect what type of ID this is
-    if ( is_numeric( $context ) && $context > 0 ) {
-        $id = (int) $context;
-        $post_type = get_post_type( $id );
-        
-        // If it's already a link page, return it
-        if ( $post_type === 'artist_link_page' ) {
-            return $id;
-        }
-        
-        // If it's an artist profile, resolve to link page
-        if ( $post_type === 'artist_profile' ) {
-            $link_pages = get_posts( array(
-                'post_type' => 'artist_link_page',
-                'meta_key' => '_associated_artist_profile_id',
-                'meta_value' => (string) $id,
-                'posts_per_page' => 1,
-                'fields' => 'ids'
-            ) );
-            $link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
-            return $link_page_id;
-        }
-        
-        if ( $post_type === false ) { // Likely a user ID
-            $user_artist_ids = ec_get_artists_for_user( $id );
-            if ( ! empty( $user_artist_ids ) ) {
-                $first_artist_id = (int) $user_artist_ids[0];
-                $link_pages = get_posts( array(
-                    'post_type' => 'artist_link_page',
-                    'meta_key' => '_associated_artist_profile_id',
-                    'meta_value' => (string) $first_artist_id,
-                    'posts_per_page' => 1,
-                    'fields' => 'ids'
-                ) );
-                $link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
-                return $link_page_id;
-            }
-        }
-        
-        return 0;
-    }
-    
-    // Handle null context - current context resolution (integrate ec_get_current_link_page_id logic)
-    if ( is_null( $context ) ) {
-        // From query var
-        $qv = get_query_var( 'ec_get_link_page_id' );
-        if ( $qv ) {
-            $lpid = (int) $qv;
-            if ( $lpid > 0 && get_post_type( $lpid ) === 'artist_link_page' ) {
-                return $lpid;
-            }
-        }
-        
-        // From global $post
-        global $post;
-        if ( $post && isset( $post->ID ) ) {
-            $pt = get_post_type( $post->ID );
-            if ( 'artist_profile' === $pt ) {
-                $link_pages = get_posts( array(
-                    'post_type' => 'artist_link_page',
-                    'meta_key' => '_associated_artist_profile_id',
-                    'meta_value' => (string) $post->ID,
-                    'posts_per_page' => 1,
-                    'fields' => 'ids'
-                ) );
-                $link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
-                if ( $link_page_id ) {
-                    return $link_page_id;
-                }
-            }
-            if ( 'artist_link_page' === $pt ) {
-                return (int) $post->ID;
-            }
-        }
-        
-        return 0;
-    }
-    
-    return 0;
+	// Handle array context ($_GET, $_POST, query vars)
+	if ( is_array( $context ) ) {
+		// Check for all link page ID key variations
+		$link_page_id_keys = array( 'link_page_id', 'new_link_page_id', 'created_link_page_id' );
+		foreach ( $link_page_id_keys as $key ) {
+			if ( isset( $context[ $key ] ) && $context[ $key ] ) {
+				$link_page_id = absint( $context[ $key ] );
+				if ( $link_page_id && get_post_type( $link_page_id ) === 'artist_link_page' ) {
+					return $link_page_id;
+				}
+			}
+		}
+		// Check for artist_id in array to resolve to link page
+		if ( isset( $context['artist_id'] ) && $context['artist_id'] ) {
+			$artist_id = absint( $context['artist_id'] );
+			if ( $artist_id && get_post_type( $artist_id ) === 'artist_profile' ) {
+				$link_pages   = get_posts(
+					array(
+						'post_type'      => 'artist_link_page',
+						'meta_key'       => '_associated_artist_profile_id',
+						'meta_value'     => (string) $artist_id,
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+					)
+				);
+				$link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
+				return $link_page_id;
+			}
+		}
+		return 0;
+	}
+
+	// Handle numeric context - auto-detect what type of ID this is
+	if ( is_numeric( $context ) && $context > 0 ) {
+		$id        = (int) $context;
+		$post_type = get_post_type( $id );
+
+		// If it's already a link page, return it
+		if ( $post_type === 'artist_link_page' ) {
+			return $id;
+		}
+
+		// If it's an artist profile, resolve to link page
+		if ( $post_type === 'artist_profile' ) {
+			$link_pages   = get_posts(
+				array(
+					'post_type'      => 'artist_link_page',
+					'meta_key'       => '_associated_artist_profile_id',
+					'meta_value'     => (string) $id,
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			$link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
+			return $link_page_id;
+		}
+
+		if ( $post_type === false ) { // Likely a user ID
+			$user_artist_ids = ec_get_artists_for_user( $id );
+			if ( ! empty( $user_artist_ids ) ) {
+				$first_artist_id = (int) $user_artist_ids[0];
+				$link_pages      = get_posts(
+					array(
+						'post_type'      => 'artist_link_page',
+						'meta_key'       => '_associated_artist_profile_id',
+						'meta_value'     => (string) $first_artist_id,
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+					)
+				);
+				$link_page_id    = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
+				return $link_page_id;
+			}
+		}
+
+		return 0;
+	}
+
+	// Handle null context - current context resolution (integrate ec_get_current_link_page_id logic)
+	if ( is_null( $context ) ) {
+		// From query var
+		$qv = get_query_var( 'ec_get_link_page_id' );
+		if ( $qv ) {
+			$lpid = (int) $qv;
+			if ( $lpid > 0 && get_post_type( $lpid ) === 'artist_link_page' ) {
+				return $lpid;
+			}
+		}
+
+		// From global $post
+		global $post;
+		if ( $post && isset( $post->ID ) ) {
+			$pt = get_post_type( $post->ID );
+			if ( 'artist_profile' === $pt ) {
+				$link_pages   = get_posts(
+					array(
+						'post_type'      => 'artist_link_page',
+						'meta_key'       => '_associated_artist_profile_id',
+						'meta_value'     => (string) $post->ID,
+						'posts_per_page' => 1,
+						'fields'         => 'ids',
+					)
+				);
+				$link_page_id = ! empty( $link_pages ) ? (int) $link_pages[0] : 0;
+				if ( $link_page_id ) {
+					return $link_page_id;
+				}
+			}
+			if ( 'artist_link_page' === $pt ) {
+				return (int) $post->ID;
+			}
+		}
+
+		return 0;
+	}
+
+	return 0;
 }
 
 /**
  * Register query vars used by previews and cross-context retrieval
  */
-add_filter( 'query_vars', function( $vars ) {
-    $vars[] = 'ec_get_artist_id';
-    $vars[] = 'ec_get_link_page_id';
-    return $vars;
-} );
+add_filter(
+	'query_vars',
+	function ( $vars ) {
+		$vars[] = 'ec_get_artist_id';
+		$vars[] = 'ec_get_link_page_id';
+		return $vars;
+	}
+);
 
 /**
  * Register ID resolution functions as WordPress filters
  */
 add_filter( 'ec_get_artist_id', 'ec_get_artist_id', 10, 2 );
 add_filter( 'ec_get_link_page_id', 'ec_get_link_page_id', 10, 2 );
-
-

--- a/inc/core/filters/permissions.php
+++ b/inc/core/filters/permissions.php
@@ -8,77 +8,77 @@
 
 /**
  * Extract artist ID from request data
- * 
+ *
  * @param array $data Request data (POST, GET, or other)
  * @return int Artist ID or 0 if not found
  */
 function ec_get_permission_artist_id( $data ) {
-    $artist_id = isset( $data['artist_id'] ) ? (int) $data['artist_id'] : 0;
-    if ( ! $artist_id ) {
-        return 0;
-    }
+	$artist_id = isset( $data['artist_id'] ) ? (int) $data['artist_id'] : 0;
+	if ( ! $artist_id ) {
+		return 0;
+	}
 
-    return ec_can_manage_artist( get_current_user_id(), $artist_id ) ? $artist_id : 0;
+	return ec_can_manage_artist( get_current_user_id(), $artist_id ) ? $artist_id : 0;
 }
 
 /**
  * Extract link page ID from request data and validate permissions
- * 
+ *
  * @param array $data Request data (POST, GET, or other)
  * @return int|false Artist ID if user can manage link page, false otherwise
  */
 function ec_get_permission_link_page_id( $data ) {
-    $link_page_id = isset( $data['link_page_id'] ) ? (int) $data['link_page_id'] : 0;
-    if ( ! $link_page_id ) {
-        return false;
-    }
+	$link_page_id = isset( $data['link_page_id'] ) ? (int) $data['link_page_id'] : 0;
+	if ( ! $link_page_id ) {
+		return false;
+	}
 
-    $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-    if ( ! $artist_id ) {
-        return false;
-    }
+	$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+	if ( ! $artist_id ) {
+		return false;
+	}
 
-    return ec_can_manage_artist( get_current_user_id(), $artist_id ) ? $artist_id : false;
+	return ec_can_manage_artist( get_current_user_id(), $artist_id ) ? $artist_id : false;
 }
 
 /**
  * Check if current user is admin from request data
- * 
+ *
  * @param array $data Request data (POST, GET, or other)
  * @return bool True if user can manage options
  */
 function ec_get_permission_is_admin( $data ) {
-    return current_user_can( 'manage_options' );
+	return current_user_can( 'manage_options' );
 }
 
 /**
  * Check if user can create artists from request data
- * 
+ *
  * @param array $data Request data (POST, GET, or other)
  * @return bool True if user can create artist profiles
  */
 function ec_get_permission_can_create_artists( $data ) {
-    return ec_can_create_artist_profiles( get_current_user_id() );
+	return ec_can_create_artist_profiles( get_current_user_id() );
 }
 
 /**
  * WordPress capability filtering for artist permissions
  */
 function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
-    $user_id = $user->ID;
-    $cap     = $args[0];
-    $object_id = isset( $args[2] ) ? $args[2] : null;
+	$user_id   = $user->ID;
+	$cap       = $args[0];
+	$object_id = isset( $args[2] ) ? $args[2] : null;
 
-    if ( $object_id && get_post_type( $object_id ) === 'artist_profile' ) {
-        if ( ec_can_manage_artist( $user_id, $object_id ) ) {
-            $post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post' );
-            if ( in_array( $cap, $post_caps ) ) {
-                $allcaps[$cap] = true;
-            }
-        }
-    }
+	if ( $object_id && get_post_type( $object_id ) === 'artist_profile' ) {
+		if ( ec_can_manage_artist( $user_id, $object_id ) ) {
+			$post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post' );
+			if ( in_array( $cap, $post_caps ) ) {
+				$allcaps[ $cap ] = true;
+			}
+		}
+	}
 
-    return $allcaps;
+	return $allcaps;
 }
 
 add_filter( 'user_has_cap', 'ec_filter_user_capabilities', 10, 4 );

--- a/inc/core/filters/social-icons.php
+++ b/inc/core/filters/social-icons.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Extra Chill Artist Platform Social Links Manager
- * 
+ *
  * Centralized management for artist social links functionality.
  * Single source for social types, CRUD operations, validation, and rendering.
  */
@@ -10,613 +10,613 @@ defined( 'ABSPATH' ) || exit;
 
 class ExtraChillArtistPlatform_SocialLinks {
 
-    private static $instance = null;
-
-    const META_KEY = '_artist_profile_social_links';
-
-    private $supported_types = null;
-
-    public static function instance() {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    private function __construct() {
-        add_action( 'init', array( $this, 'init_hooks' ) );
-    }
-
-    public function init_hooks() {
-        // Hook for when social links are updated
-        add_action( 'updated_post_meta', array( $this, 'on_social_links_updated' ), 10, 4 );
-    }
-
-    /**
-     * Get supported social link types
-     * 
-     * @since 1.1.0
-     * @return array Array of supported social link types
-     */
-    public function get_supported_types() {
-        if ( null === $this->supported_types ) {
-            $this->supported_types = array(
-                'apple_music' => array(
-                    'label' => __( 'Apple Music', 'extrachill-artist-platform' ),
-                    'icon' => 'fab fa-apple',
-                    'base_url' => 'music.apple.com'
-                ),
-                'bandcamp' => array( 
-                    'label' => __( 'Bandcamp', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-bandcamp',
-                    'base_url' => 'bandcamp.com'
-                ),
-                'bluesky' => array( 
-                    'label' => __( 'Bluesky', 'extrachill-artist-platform' ), 
-                    'icon' => 'fa-brands fa-bluesky',
-                    'base_url' => 'bsky.app'
-                ),
-                'custom'  => array( 
-                    'label' => __( 'Custom Link', 'extrachill-artist-platform' ), 
-                    'icon' => 'fas fa-link', 
-                    'has_custom_label' => true 
-                ),
-                'facebook' => array( 
-                    'label' => __( 'Facebook', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-facebook-f',
-                    'base_url' => 'facebook.com'
-                ),
-                'github' => array( 
-                    'label' => __( 'GitHub', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-github',
-                    'base_url' => 'github.com'
-                ),
-                'instagram' => array( 
-                    'label' => __( 'Instagram', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-instagram',
-                    'base_url' => 'instagram.com'
-                ),
-                'patreon' => array( 
-                    'label' => __( 'Patreon', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-patreon',
-                    'base_url' => 'patreon.com'
-                ),
-                'pinterest' => array(
-                    'label' => __( 'Pinterest', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-pinterest',
-                    'base_url' => 'pinterest.com'
-                ),
-                'soundcloud' => array( 
-                    'label' => __( 'SoundCloud', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-soundcloud',
-                    'base_url' => 'soundcloud.com'
-                ),
-                'spotify' => array( 
-                    'label' => __( 'Spotify', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-spotify',
-                    'base_url' => 'spotify.com'
-                ),
-                'substack' => array( 
-                    'label' => __( 'Substack', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-substack',
-                    'base_url' => 'substack.com'
-                ),
-                'tiktok' => array( 
-                    'label' => __( 'TikTok', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-tiktok',
-                    'base_url' => 'tiktok.com'
-                ),
-                'twitch' => array( 
-                    'label' => __( 'Twitch', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-twitch',
-                    'base_url' => 'twitch.tv'
-                ),
-                'twitter_x' => array( 
-                    'label' => __( 'Twitter / X', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-x-twitter',
-                    'base_url' => 'x.com'
-                ),
-                'venmo' => array( 
-                    'label' => __( 'Venmo', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-venmo',
-                    'base_url' => 'venmo.com'
-                ),
-                'website' => array( 
-                    'label' => __( 'Website', 'extrachill-artist-platform' ), 
-                    'icon' => 'fas fa-globe' 
-                ),
-                'youtube' => array( 
-                    'label' => __( 'YouTube', 'extrachill-artist-platform' ), 
-                    'icon' => 'fab fa-youtube',
-                    'base_url' => 'youtube.com'
-                ),
-            );
-
-            /**
-             * Filter supported social link types
-             * 
-             * @since 1.1.0
-             * @param array $types Supported social link types
-             */
-            $this->supported_types = apply_filters( 'ec_social_types', $this->supported_types );
-        }
-
-        return $this->supported_types;
-    }
-
-    /**
-     * Get social links for an artist
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @return array Array of social link objects
-     */
-    public function get( $artist_id ) {
-        if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-            return array();
-        }
-
-        $social_links = get_post_meta( $artist_id, self::META_KEY, true );
-        if ( ! is_array( $social_links ) ) {
-            $social_links = maybe_unserialize( $social_links );
-        }
-        if ( ! is_array( $social_links ) ) {
-            return array();
-        }
-
-        // Validate and normalize each social link
-        $normalized_links = array();
-        foreach ( $social_links as $link ) {
-            $normalized_link = $this->validate_and_normalize_link( $link );
-            if ( $normalized_link ) {
-                $normalized_links[] = $normalized_link;
-            }
-        }
-
-        /**
-         * Filter artist social links after retrieval
-         * 
-         * @since 1.1.0
-         * @param array $normalized_links Array of normalized social links
-         * @param int $artist_id Artist profile post ID
-         */
-        return apply_filters( 'extrachill_artist_platform_get_social_links', $normalized_links, $artist_id );
-    }
-
-    /**
-     * Save social links for an artist
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @param array $social_links Array of social link objects
-     * @return bool|WP_Error True on success, WP_Error on failure
-     */
-    public function save( $artist_id, $social_links ) {
-        if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-            return new WP_Error( 'invalid_artist', __( 'Invalid artist profile ID.', 'extrachill-artist-platform' ) );
-        }
-
-        // Check user permissions
-        if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-            return new WP_Error( 'permission_denied', __( 'Permission denied: You do not have access to manage this artist.', 'extrachill-artist-platform' ) );
-        }
-
-        // Validate and sanitize all links
-        $sanitized_links = $this->sanitize_links( $social_links );
-        if ( is_wp_error( $sanitized_links ) ) {
-            return $sanitized_links;
-        }
-
-        /**
-         * Filter artist social links before saving
-         * 
-         * @since 1.1.0
-         * @param array $sanitized_links Array of sanitized social links
-         * @param int $artist_id Artist profile post ID
-         * @param array $social_links Original social links array
-         */
-        $sanitized_links = apply_filters( 'extrachill_artist_platform_save_social_links', $sanitized_links, $artist_id, $social_links );
-
-        $result = update_post_meta( $artist_id, self::META_KEY, $sanitized_links );
-
-        if ( false === $result ) {
-            return new WP_Error( 'save_failed', __( 'Failed to save social links.', 'extrachill-artist-platform' ) );
-        }
-
-        /**
-         * Action fired after social links are successfully saved
-         * 
-         * @since 1.1.0
-         * @param array $sanitized_links Array of saved social links
-         * @param int $artist_id Artist profile post ID
-         */
-        do_action( 'extrachill_artist_platform_social_links_saved', $sanitized_links, $artist_id );
-
-        return true;
-    }
-
-    /**
-     * Delete all social links for an artist
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @return bool True on success, false on failure
-     */
-    public function delete( $artist_id ) {
-        if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-            return false;
-        }
-
-        // Check user permissions
-        if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-            return false;
-        }
-
-        $result = delete_post_meta( $artist_id, self::META_KEY );
-
-        if ( $result ) {
-            /**
-             * Action fired after social links are successfully deleted
-             *
-             * @since 1.1.0
-             * @param int $artist_id Artist profile post ID
-             */
-            do_action( 'extrachill_artist_platform_social_links_deleted', $artist_id );
-        }
-
-        return $result;
-    }
-
-    /**
-     * Validate and normalize a single social link
-     * 
-     * @since 1.1.0
-     * @param array $link Social link data
-     * @return array|false Normalized link or false if invalid
-     */
-    private function validate_and_normalize_link( $link ) {
-        if ( ! is_array( $link ) || empty( $link['type'] ) || empty( $link['url'] ) ) {
-            return false;
-        }
-
-        $supported_types = $this->get_supported_types();
-        
-        // Validate type
-        if ( ! array_key_exists( $link['type'], $supported_types ) ) {
-            return false;
-        }
-
-        // Validate URL
-        $url = $this->validate_url( $link['url'] );
-        if ( ! $url ) {
-            return false;
-        }
-
-        $normalized = array(
-            'type' => sanitize_key( $link['type'] ),
-            'url'  => $url,
-        );
-
-        if ( ! empty( $link['id'] ) ) {
-            $normalized['id'] = sanitize_text_field( wp_unslash( $link['id'] ) );
-        }
-
-        // Handle custom labels
-        if ( ! empty( $supported_types[ $link['type'] ]['has_custom_label'] ) && ! empty( $link['custom_label'] ) ) {
-            $normalized['custom_label'] = sanitize_text_field( $link['custom_label'] );
-        }
-
-        return $normalized;
-    }
-
-    /**
-     * Sanitize an array of social links
-     * 
-     * @since 1.1.0
-     * @param array $social_links Array of social link objects
-     * @return array|WP_Error Sanitized links array or WP_Error on failure
-     */
-    public function sanitize_links( $social_links ) {
-        if ( ! is_array( $social_links ) ) {
-            return new WP_Error( 'invalid_data', __( 'Social links must be an array.', 'extrachill-artist-platform' ) );
-        }
-
-        $sanitized_links = array();
-        $errors = array();
-
-        foreach ( $social_links as $index => $link ) {
-            $sanitized_link = $this->validate_and_normalize_link( $link );
-            
-            if ( false === $sanitized_link ) {
-                $errors[] = sprintf( 
-                    /* translators: %d: Link index number */
-                    __( 'Invalid social link at position %d.', 'extrachill-artist-platform' ), 
-                    $index + 1 
-                );
-                continue;
-            }
-
-            $sanitized_links[] = $sanitized_link;
-        }
-
-        if ( ! empty( $errors ) ) {
-            return new WP_Error( 'validation_failed', implode( ' ', $errors ) );
-        }
-
-        return $sanitized_links;
-    }
-
-    /**
-     * Validate a URL
-     * 
-     * @since 1.1.0
-     * @param string $url URL to validate
-     * @return string|false Sanitized URL or false if invalid
-     */
-    private function validate_url( $url ) {
-        $url = trim( $url );
-        
-        if ( empty( $url ) ) {
-            return false;
-        }
-
-        // Add https:// if no protocol specified
-        if ( ! preg_match( '/^https?:\/\//', $url ) ) {
-            $url = 'https://' . $url;
-        }
-
-        $sanitized_url = esc_url_raw( $url );
-        
-        if ( ! $sanitized_url || ! filter_var( $sanitized_url, FILTER_VALIDATE_URL ) ) {
-            return false;
-        }
-
-        return $sanitized_url;
-    }
-
-    /**
-     * Sanitize Font Awesome icon classes while preserving spaces
-     * 
-     * @since 1.1.0
-     * @param string $icon_class Font Awesome icon class string
-     * @return string Sanitized icon class string
-     */
-    private function sanitize_icon_class( $icon_class ) {
-        if ( empty( $icon_class ) ) {
-            return 'fas fa-globe';
-        }
-
-        // Split the class string into individual classes
-        $classes = explode( ' ', trim( $icon_class ) );
-        $sanitized_classes = array();
-
-        foreach ( $classes as $class ) {
-            $class = trim( $class );
-            
-            // Skip empty classes
-            if ( empty( $class ) ) {
-                continue;
-            }
-
-            // Allow Font Awesome prefixes and icon classes
-            if ( preg_match( '/^(fab|fas|far|fal|fat|fad|fa-brands|fa-solid|fa-regular|fa-light|fa-thin|fa-duotone)$/i', $class ) ) {
-                $sanitized_classes[] = strtolower( $class );
-            }
-            // Allow Font Awesome icon names (fa-*)
-            elseif ( preg_match( '/^fa-[a-z0-9-]+$/i', $class ) ) {
-                $sanitized_classes[] = strtolower( $class );
-            }
-        }
-
-        // If no valid classes found, return fallback
-        if ( empty( $sanitized_classes ) ) {
-            return 'fas fa-globe';
-        }
-
-        // Ensure we have at least a prefix and icon
-        if ( count( $sanitized_classes ) === 1 ) {
-            // If only one class and it's an icon, add default prefix
-            if ( preg_match( '/^fa-/', $sanitized_classes[0] ) ) {
-                array_unshift( $sanitized_classes, 'fas' );
-            }
-            // If only prefix, add default icon
-            elseif ( in_array( $sanitized_classes[0], array( 'fab', 'fas', 'far', 'fal', 'fat', 'fad' ) ) ) {
-                $sanitized_classes[] = 'fa-globe';
-            }
-        }
-
-        return implode( ' ', $sanitized_classes );
-    }
-
-    /**
-     * Get icon class for a social link type
-     * 
-     * @since 1.1.0
-     * @param string $type Social link type
-     * @param array $link_data Optional. Complete link data for context
-     * @return string Icon class string
-     */
-    public function get_icon_class( $type, $link_data = array() ) {
-        $supported_types = $this->get_supported_types();
-        
-        // First priority: Check if icon is specified in link data
-        if ( ! empty( $link_data['icon'] ) ) {
-            return $this->sanitize_icon_class( $link_data['icon'] );
-        }
-
-        // Second priority: Get from supported types config
-        if ( array_key_exists( $type, $supported_types ) && ! empty( $supported_types[ $type ]['icon'] ) ) {
-            return $this->sanitize_icon_class( $supported_types[ $type ]['icon'] );
-        }
-
-        // Third priority: Generate FontAwesome class from type
-        if ( $type !== 'custom' && $type !== 'website' ) {
-            $icon_name = sanitize_html_class( str_replace( '_', '-', $type ) );
-            return $this->sanitize_icon_class( 'fab fa-' . $icon_name );
-        }
-
-        // Final fallback
-        return 'fas fa-globe';
-    }
-
-    /**
-     * Get label for a social link
-     * 
-     * @since 1.1.0
-     * @param array $link Social link data
-     * @return string Link label
-     */
-    public function get_link_label( $link ) {
-        if ( ! is_array( $link ) || empty( $link['type'] ) ) {
-            return __( 'Social Link', 'extrachill-artist-platform' );
-        }
-
-        // Use custom label if available
-        if ( ! empty( $link['custom_label'] ) ) {
-            return sanitize_text_field( $link['custom_label'] );
-        }
-
-        $supported_types = $this->get_supported_types();
-        
-        if ( array_key_exists( $link['type'], $supported_types ) ) {
-            return $supported_types[ $link['type'] ]['label'];
-        }
-
-        return ucfirst( str_replace( '_', ' ', $link['type'] ) );
-    }
-
-    /**
-     * Render social icons for an artist
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @param array $options Rendering options
-     * @return string HTML output
-     */
-    public function render_social_icons( $artist_id, $options = array() ) {
-        $social_links = $this->get( $artist_id );
-        
-        if ( empty( $social_links ) ) {
-            return '';
-        }
-
-        $defaults = array(
-            'container_class' => 'extrch-social-icons',
-            'icon_class' => 'extrch-social-icon',
-            'show_labels' => false,
-            'target' => '_blank',
-            'rel' => 'ugc noopener noreferrer',
-            'before' => '',
-            'after' => ''
-        );
-
-        $options = wp_parse_args( $options, $defaults );
-
-        /**
-         * Filter social icons rendering options
-         * 
-         * @since 1.1.0
-         * @param array $options Rendering options
-         * @param int $artist_id Artist profile post ID
-         * @param array $social_links Social links data
-         */
-        $options = apply_filters( 'extrachill_artist_platform_render_social_icons_options', $options, $artist_id, $social_links );
-
-        $output = $options['before'];
-        $output .= '<div class="' . esc_attr( $options['container_class'] ) . '">';
-
-        foreach ( $social_links as $link ) {
-            $icon_class = $this->get_icon_class( $link['type'], $link );
-            $label = $this->get_link_label( $link );
-            
-            $output .= sprintf(
-                '<a href="%s" class="%s" target="%s" rel="%s" title="%s" aria-label="%s">',
-                esc_url( $link['url'] ),
-                esc_attr( $options['icon_class'] ),
-                esc_attr( $options['target'] ),
-                esc_attr( $options['rel'] ),
-                esc_attr( $label ),
-                esc_attr( $label )
-            );
-            
-            $output .= '<i class="' . esc_attr( $icon_class ) . '" aria-hidden="true"></i>';
-            
-            if ( $options['show_labels'] ) {
-                $output .= '<span class="social-label">' . esc_html( $label ) . '</span>';
-            }
-            
-            $output .= '</a>';
-        }
-
-        $output .= '</div>';
-        $output .= $options['after'];
-
-        /**
-         * Filter social icons HTML output
-         * 
-         * @since 1.1.0
-         * @param string $output HTML output
-         * @param int $artist_id Artist profile post ID
-         * @param array $social_links Social links data
-         * @param array $options Rendering options
-         */
-        return apply_filters( 'extrachill_artist_platform_render_social_icons_html', $output, $artist_id, $social_links, $options );
-    }
-
-    /**
-     * Handle social links updated action
-     * 
-     * @since 1.1.0
-     * @param int $meta_id Meta ID
-     * @param int $object_id Post ID
-     * @param string $meta_key Meta key
-     * @param mixed $meta_value Meta value
-     */
-    public function on_social_links_updated( $meta_id, $object_id, $meta_key, $meta_value ) {
-        if ( $meta_key === self::META_KEY && get_post_type( $object_id ) === 'artist_profile' ) {
-            /**
-             * Action fired when artist social links are updated via update_post_meta
-             * 
-             * @since 1.1.0
-             * @param int $artist_id Artist profile post ID
-             * @param array $meta_value Updated social links
-             */
-            do_action( 'extrachill_artist_platform_social_links_updated', $object_id, $meta_value );
-        }
-    }
-
-    /**
-     * Get social links in JSON format for JavaScript
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @return string JSON-encoded social links
-     */
-    public function get_json( $artist_id ) {
-        $social_links = $this->get( $artist_id );
-        return wp_json_encode( $social_links );
-    }
-
-    /**
-     * Save social links from JSON data
-     * 
-     * @since 1.1.0
-     * @param int $artist_id Artist profile post ID
-     * @param string $json_data JSON-encoded social links
-     * @return bool|WP_Error True on success, WP_Error on failure
-     */
-    public function save_from_json( $artist_id, $json_data ) {
-        $social_links = json_decode( $json_data, true );
-        
-        if ( json_last_error() !== JSON_ERROR_NONE ) {
-            return new WP_Error( 'invalid_json', __( 'Invalid JSON data provided.', 'extrachill-artist-platform' ) );
-        }
-
-        return $this->save( $artist_id, $social_links );
-    }
+	private static $instance = null;
+
+	const META_KEY = '_artist_profile_social_links';
+
+	private $supported_types = null;
+
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		add_action( 'init', array( $this, 'init_hooks' ) );
+	}
+
+	public function init_hooks() {
+		// Hook for when social links are updated
+		add_action( 'updated_post_meta', array( $this, 'on_social_links_updated' ), 10, 4 );
+	}
+
+	/**
+	 * Get supported social link types
+	 *
+	 * @since 1.1.0
+	 * @return array Array of supported social link types
+	 */
+	public function get_supported_types() {
+		if ( null === $this->supported_types ) {
+			$this->supported_types = array(
+				'apple_music' => array(
+					'label'    => __( 'Apple Music', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-apple',
+					'base_url' => 'music.apple.com',
+				),
+				'bandcamp'    => array(
+					'label'    => __( 'Bandcamp', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-bandcamp',
+					'base_url' => 'bandcamp.com',
+				),
+				'bluesky'     => array(
+					'label'    => __( 'Bluesky', 'extrachill-artist-platform' ),
+					'icon'     => 'fa-brands fa-bluesky',
+					'base_url' => 'bsky.app',
+				),
+				'custom'      => array(
+					'label'            => __( 'Custom Link', 'extrachill-artist-platform' ),
+					'icon'             => 'fas fa-link',
+					'has_custom_label' => true,
+				),
+				'facebook'    => array(
+					'label'    => __( 'Facebook', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-facebook-f',
+					'base_url' => 'facebook.com',
+				),
+				'github'      => array(
+					'label'    => __( 'GitHub', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-github',
+					'base_url' => 'github.com',
+				),
+				'instagram'   => array(
+					'label'    => __( 'Instagram', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-instagram',
+					'base_url' => 'instagram.com',
+				),
+				'patreon'     => array(
+					'label'    => __( 'Patreon', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-patreon',
+					'base_url' => 'patreon.com',
+				),
+				'pinterest'   => array(
+					'label'    => __( 'Pinterest', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-pinterest',
+					'base_url' => 'pinterest.com',
+				),
+				'soundcloud'  => array(
+					'label'    => __( 'SoundCloud', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-soundcloud',
+					'base_url' => 'soundcloud.com',
+				),
+				'spotify'     => array(
+					'label'    => __( 'Spotify', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-spotify',
+					'base_url' => 'spotify.com',
+				),
+				'substack'    => array(
+					'label'    => __( 'Substack', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-substack',
+					'base_url' => 'substack.com',
+				),
+				'tiktok'      => array(
+					'label'    => __( 'TikTok', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-tiktok',
+					'base_url' => 'tiktok.com',
+				),
+				'twitch'      => array(
+					'label'    => __( 'Twitch', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-twitch',
+					'base_url' => 'twitch.tv',
+				),
+				'twitter_x'   => array(
+					'label'    => __( 'Twitter / X', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-x-twitter',
+					'base_url' => 'x.com',
+				),
+				'venmo'       => array(
+					'label'    => __( 'Venmo', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-venmo',
+					'base_url' => 'venmo.com',
+				),
+				'website'     => array(
+					'label' => __( 'Website', 'extrachill-artist-platform' ),
+					'icon'  => 'fas fa-globe',
+				),
+				'youtube'     => array(
+					'label'    => __( 'YouTube', 'extrachill-artist-platform' ),
+					'icon'     => 'fab fa-youtube',
+					'base_url' => 'youtube.com',
+				),
+			);
+
+			/**
+			 * Filter supported social link types
+			 *
+			 * @since 1.1.0
+			 * @param array $types Supported social link types
+			 */
+			$this->supported_types = apply_filters( 'ec_social_types', $this->supported_types );
+		}
+
+		return $this->supported_types;
+	}
+
+	/**
+	 * Get social links for an artist
+	 *
+	 * @since 1.1.0
+	 * @param int $artist_id Artist profile post ID
+	 * @return array Array of social link objects
+	 */
+	public function get( $artist_id ) {
+		if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+			return array();
+		}
+
+		$social_links = get_post_meta( $artist_id, self::META_KEY, true );
+		if ( ! is_array( $social_links ) ) {
+			$social_links = maybe_unserialize( $social_links );
+		}
+		if ( ! is_array( $social_links ) ) {
+			return array();
+		}
+
+		// Validate and normalize each social link
+		$normalized_links = array();
+		foreach ( $social_links as $link ) {
+			$normalized_link = $this->validate_and_normalize_link( $link );
+			if ( $normalized_link ) {
+				$normalized_links[] = $normalized_link;
+			}
+		}
+
+		/**
+		 * Filter artist social links after retrieval
+		 *
+		 * @since 1.1.0
+		 * @param array $normalized_links Array of normalized social links
+		 * @param int $artist_id Artist profile post ID
+		 */
+		return apply_filters( 'extrachill_artist_platform_get_social_links', $normalized_links, $artist_id );
+	}
+
+	/**
+	 * Save social links for an artist
+	 *
+	 * @since 1.1.0
+	 * @param int   $artist_id Artist profile post ID
+	 * @param array $social_links Array of social link objects
+	 * @return bool|WP_Error True on success, WP_Error on failure
+	 */
+	public function save( $artist_id, $social_links ) {
+		if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+			return new WP_Error( 'invalid_artist', __( 'Invalid artist profile ID.', 'extrachill-artist-platform' ) );
+		}
+
+		// Check user permissions
+		if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+			return new WP_Error( 'permission_denied', __( 'Permission denied: You do not have access to manage this artist.', 'extrachill-artist-platform' ) );
+		}
+
+		// Validate and sanitize all links
+		$sanitized_links = $this->sanitize_links( $social_links );
+		if ( is_wp_error( $sanitized_links ) ) {
+			return $sanitized_links;
+		}
+
+		/**
+		 * Filter artist social links before saving
+		 *
+		 * @since 1.1.0
+		 * @param array $sanitized_links Array of sanitized social links
+		 * @param int $artist_id Artist profile post ID
+		 * @param array $social_links Original social links array
+		 */
+		$sanitized_links = apply_filters( 'extrachill_artist_platform_save_social_links', $sanitized_links, $artist_id, $social_links );
+
+		$result = update_post_meta( $artist_id, self::META_KEY, $sanitized_links );
+
+		if ( false === $result ) {
+			return new WP_Error( 'save_failed', __( 'Failed to save social links.', 'extrachill-artist-platform' ) );
+		}
+
+		/**
+		 * Action fired after social links are successfully saved
+		 *
+		 * @since 1.1.0
+		 * @param array $sanitized_links Array of saved social links
+		 * @param int $artist_id Artist profile post ID
+		 */
+		do_action( 'extrachill_artist_platform_social_links_saved', $sanitized_links, $artist_id );
+
+		return true;
+	}
+
+	/**
+	 * Delete all social links for an artist
+	 *
+	 * @since 1.1.0
+	 * @param int $artist_id Artist profile post ID
+	 * @return bool True on success, false on failure
+	 */
+	public function delete( $artist_id ) {
+		if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
+			return false;
+		}
+
+		// Check user permissions
+		if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+			return false;
+		}
+
+		$result = delete_post_meta( $artist_id, self::META_KEY );
+
+		if ( $result ) {
+			/**
+			 * Action fired after social links are successfully deleted
+			 *
+			 * @since 1.1.0
+			 * @param int $artist_id Artist profile post ID
+			 */
+			do_action( 'extrachill_artist_platform_social_links_deleted', $artist_id );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Validate and normalize a single social link
+	 *
+	 * @since 1.1.0
+	 * @param array $link Social link data
+	 * @return array|false Normalized link or false if invalid
+	 */
+	private function validate_and_normalize_link( $link ) {
+		if ( ! is_array( $link ) || empty( $link['type'] ) || empty( $link['url'] ) ) {
+			return false;
+		}
+
+		$supported_types = $this->get_supported_types();
+
+		// Validate type
+		if ( ! array_key_exists( $link['type'], $supported_types ) ) {
+			return false;
+		}
+
+		// Validate URL
+		$url = $this->validate_url( $link['url'] );
+		if ( ! $url ) {
+			return false;
+		}
+
+		$normalized = array(
+			'type' => sanitize_key( $link['type'] ),
+			'url'  => $url,
+		);
+
+		if ( ! empty( $link['id'] ) ) {
+			$normalized['id'] = sanitize_text_field( wp_unslash( $link['id'] ) );
+		}
+
+		// Handle custom labels
+		if ( ! empty( $supported_types[ $link['type'] ]['has_custom_label'] ) && ! empty( $link['custom_label'] ) ) {
+			$normalized['custom_label'] = sanitize_text_field( $link['custom_label'] );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Sanitize an array of social links
+	 *
+	 * @since 1.1.0
+	 * @param array $social_links Array of social link objects
+	 * @return array|WP_Error Sanitized links array or WP_Error on failure
+	 */
+	public function sanitize_links( $social_links ) {
+		if ( ! is_array( $social_links ) ) {
+			return new WP_Error( 'invalid_data', __( 'Social links must be an array.', 'extrachill-artist-platform' ) );
+		}
+
+		$sanitized_links = array();
+		$errors          = array();
+
+		foreach ( $social_links as $index => $link ) {
+			$sanitized_link = $this->validate_and_normalize_link( $link );
+
+			if ( false === $sanitized_link ) {
+				$errors[] = sprintf(
+					/* translators: %d: Link index number */
+					__( 'Invalid social link at position %d.', 'extrachill-artist-platform' ),
+					$index + 1
+				);
+				continue;
+			}
+
+			$sanitized_links[] = $sanitized_link;
+		}
+
+		if ( ! empty( $errors ) ) {
+			return new WP_Error( 'validation_failed', implode( ' ', $errors ) );
+		}
+
+		return $sanitized_links;
+	}
+
+	/**
+	 * Validate a URL
+	 *
+	 * @since 1.1.0
+	 * @param string $url URL to validate
+	 * @return string|false Sanitized URL or false if invalid
+	 */
+	private function validate_url( $url ) {
+		$url = trim( $url );
+
+		if ( empty( $url ) ) {
+			return false;
+		}
+
+		// Add https:// if no protocol specified
+		if ( ! preg_match( '/^https?:\/\//', $url ) ) {
+			$url = 'https://' . $url;
+		}
+
+		$sanitized_url = esc_url_raw( $url );
+
+		if ( ! $sanitized_url || ! filter_var( $sanitized_url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+
+		return $sanitized_url;
+	}
+
+	/**
+	 * Sanitize Font Awesome icon classes while preserving spaces
+	 *
+	 * @since 1.1.0
+	 * @param string $icon_class Font Awesome icon class string
+	 * @return string Sanitized icon class string
+	 */
+	private function sanitize_icon_class( $icon_class ) {
+		if ( empty( $icon_class ) ) {
+			return 'fas fa-globe';
+		}
+
+		// Split the class string into individual classes
+		$classes           = explode( ' ', trim( $icon_class ) );
+		$sanitized_classes = array();
+
+		foreach ( $classes as $class ) {
+			$class = trim( $class );
+
+			// Skip empty classes
+			if ( empty( $class ) ) {
+				continue;
+			}
+
+			// Allow Font Awesome prefixes and icon classes
+			if ( preg_match( '/^(fab|fas|far|fal|fat|fad|fa-brands|fa-solid|fa-regular|fa-light|fa-thin|fa-duotone)$/i', $class ) ) {
+				$sanitized_classes[] = strtolower( $class );
+			}
+			// Allow Font Awesome icon names (fa-*)
+			elseif ( preg_match( '/^fa-[a-z0-9-]+$/i', $class ) ) {
+				$sanitized_classes[] = strtolower( $class );
+			}
+		}
+
+		// If no valid classes found, return fallback
+		if ( empty( $sanitized_classes ) ) {
+			return 'fas fa-globe';
+		}
+
+		// Ensure we have at least a prefix and icon
+		if ( count( $sanitized_classes ) === 1 ) {
+			// If only one class and it's an icon, add default prefix
+			if ( preg_match( '/^fa-/', $sanitized_classes[0] ) ) {
+				array_unshift( $sanitized_classes, 'fas' );
+			}
+			// If only prefix, add default icon
+			elseif ( in_array( $sanitized_classes[0], array( 'fab', 'fas', 'far', 'fal', 'fat', 'fad' ) ) ) {
+				$sanitized_classes[] = 'fa-globe';
+			}
+		}
+
+		return implode( ' ', $sanitized_classes );
+	}
+
+	/**
+	 * Get icon class for a social link type
+	 *
+	 * @since 1.1.0
+	 * @param string $type Social link type
+	 * @param array  $link_data Optional. Complete link data for context
+	 * @return string Icon class string
+	 */
+	public function get_icon_class( $type, $link_data = array() ) {
+		$supported_types = $this->get_supported_types();
+
+		// First priority: Check if icon is specified in link data
+		if ( ! empty( $link_data['icon'] ) ) {
+			return $this->sanitize_icon_class( $link_data['icon'] );
+		}
+
+		// Second priority: Get from supported types config
+		if ( array_key_exists( $type, $supported_types ) && ! empty( $supported_types[ $type ]['icon'] ) ) {
+			return $this->sanitize_icon_class( $supported_types[ $type ]['icon'] );
+		}
+
+		// Third priority: Generate FontAwesome class from type
+		if ( $type !== 'custom' && $type !== 'website' ) {
+			$icon_name = sanitize_html_class( str_replace( '_', '-', $type ) );
+			return $this->sanitize_icon_class( 'fab fa-' . $icon_name );
+		}
+
+		// Final fallback
+		return 'fas fa-globe';
+	}
+
+	/**
+	 * Get label for a social link
+	 *
+	 * @since 1.1.0
+	 * @param array $link Social link data
+	 * @return string Link label
+	 */
+	public function get_link_label( $link ) {
+		if ( ! is_array( $link ) || empty( $link['type'] ) ) {
+			return __( 'Social Link', 'extrachill-artist-platform' );
+		}
+
+		// Use custom label if available
+		if ( ! empty( $link['custom_label'] ) ) {
+			return sanitize_text_field( $link['custom_label'] );
+		}
+
+		$supported_types = $this->get_supported_types();
+
+		if ( array_key_exists( $link['type'], $supported_types ) ) {
+			return $supported_types[ $link['type'] ]['label'];
+		}
+
+		return ucfirst( str_replace( '_', ' ', $link['type'] ) );
+	}
+
+	/**
+	 * Render social icons for an artist
+	 *
+	 * @since 1.1.0
+	 * @param int   $artist_id Artist profile post ID
+	 * @param array $options Rendering options
+	 * @return string HTML output
+	 */
+	public function render_social_icons( $artist_id, $options = array() ) {
+		$social_links = $this->get( $artist_id );
+
+		if ( empty( $social_links ) ) {
+			return '';
+		}
+
+		$defaults = array(
+			'container_class' => 'extrch-social-icons',
+			'icon_class'      => 'extrch-social-icon',
+			'show_labels'     => false,
+			'target'          => '_blank',
+			'rel'             => 'ugc noopener noreferrer',
+			'before'          => '',
+			'after'           => '',
+		);
+
+		$options = wp_parse_args( $options, $defaults );
+
+		/**
+		 * Filter social icons rendering options
+		 *
+		 * @since 1.1.0
+		 * @param array $options Rendering options
+		 * @param int $artist_id Artist profile post ID
+		 * @param array $social_links Social links data
+		 */
+		$options = apply_filters( 'extrachill_artist_platform_render_social_icons_options', $options, $artist_id, $social_links );
+
+		$output  = $options['before'];
+		$output .= '<div class="' . esc_attr( $options['container_class'] ) . '">';
+
+		foreach ( $social_links as $link ) {
+			$icon_class = $this->get_icon_class( $link['type'], $link );
+			$label      = $this->get_link_label( $link );
+
+			$output .= sprintf(
+				'<a href="%s" class="%s" target="%s" rel="%s" title="%s" aria-label="%s">',
+				esc_url( $link['url'] ),
+				esc_attr( $options['icon_class'] ),
+				esc_attr( $options['target'] ),
+				esc_attr( $options['rel'] ),
+				esc_attr( $label ),
+				esc_attr( $label )
+			);
+
+			$output .= '<i class="' . esc_attr( $icon_class ) . '" aria-hidden="true"></i>';
+
+			if ( $options['show_labels'] ) {
+				$output .= '<span class="social-label">' . esc_html( $label ) . '</span>';
+			}
+
+			$output .= '</a>';
+		}
+
+		$output .= '</div>';
+		$output .= $options['after'];
+
+		/**
+		 * Filter social icons HTML output
+		 *
+		 * @since 1.1.0
+		 * @param string $output HTML output
+		 * @param int $artist_id Artist profile post ID
+		 * @param array $social_links Social links data
+		 * @param array $options Rendering options
+		 */
+		return apply_filters( 'extrachill_artist_platform_render_social_icons_html', $output, $artist_id, $social_links, $options );
+	}
+
+	/**
+	 * Handle social links updated action
+	 *
+	 * @since 1.1.0
+	 * @param int    $meta_id Meta ID
+	 * @param int    $object_id Post ID
+	 * @param string $meta_key Meta key
+	 * @param mixed  $meta_value Meta value
+	 */
+	public function on_social_links_updated( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( $meta_key === self::META_KEY && get_post_type( $object_id ) === 'artist_profile' ) {
+			/**
+			 * Action fired when artist social links are updated via update_post_meta
+			 *
+			 * @since 1.1.0
+			 * @param int $artist_id Artist profile post ID
+			 * @param array $meta_value Updated social links
+			 */
+			do_action( 'extrachill_artist_platform_social_links_updated', $object_id, $meta_value );
+		}
+	}
+
+	/**
+	 * Get social links in JSON format for JavaScript
+	 *
+	 * @since 1.1.0
+	 * @param int $artist_id Artist profile post ID
+	 * @return string JSON-encoded social links
+	 */
+	public function get_json( $artist_id ) {
+		$social_links = $this->get( $artist_id );
+		return wp_json_encode( $social_links );
+	}
+
+	/**
+	 * Save social links from JSON data
+	 *
+	 * @since 1.1.0
+	 * @param int    $artist_id Artist profile post ID
+	 * @param string $json_data JSON-encoded social links
+	 * @return bool|WP_Error True on success, WP_Error on failure
+	 */
+	public function save_from_json( $artist_id, $json_data ) {
+		$social_links = json_decode( $json_data, true );
+
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return new WP_Error( 'invalid_json', __( 'Invalid JSON data provided.', 'extrachill-artist-platform' ) );
+		}
+
+		return $this->save( $artist_id, $social_links );
+	}
 }
 
 // Initialize the social links manager
 function extrachill_artist_platform_social_links() {
-    return ExtraChillArtistPlatform_SocialLinks::instance();
+	return ExtraChillArtistPlatform_SocialLinks::instance();
 }

--- a/inc/core/filters/templates.php
+++ b/inc/core/filters/templates.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WordPress Filter-Based Template System
- * 
+ *
  * Provides component template rendering using WordPress native filters.
  * Allows other plugins to modify template output and follows WordPress best practices.
  */
@@ -13,153 +13,151 @@ add_filter( 'ec_render_template', 'ec_template_handler', 10, 3 );
 
 /**
  * Universal template renderer using WordPress filters
- * 
+ *
  * @param string $template_name Template name (e.g., 'single-link', 'link-section')
- * @param array $args Template arguments
+ * @param array  $args Template arguments
  * @return string Rendered HTML
  */
 function ec_render_template( $template_name, $args = array() ) {
-    return apply_filters( 'ec_render_template', '', $template_name, $args );
+	return apply_filters( 'ec_render_template', '', $template_name, $args );
 }
 
 /**
  * Main template filter handler
- * 
+ *
  * @param string $output Current output (empty by default)
  * @param string $template_name Template name
- * @param array $args Template arguments
+ * @param array  $args Template arguments
  * @return string Rendered HTML
  */
 function ec_template_handler( $output, $template_name, $args = array() ) {
-    // Don't render if already has output (allows other plugins to override)
-    if ( ! empty( $output ) ) {
-        return $output;
-    }
-    
-    // Template validation and file mapping
-    $template_map = array(
-        'single-link' => array(
-            'file' => 'inc/link-pages/live/templates/components/single-link.php',
-            'required' => array()
-        ),
-        'link-section' => array(
-            'file' => 'inc/link-pages/live/templates/components/link-section.php',
-            'required' => array( 'links' )
-        ),
-        'social-icon' => array(
-            'file' => 'inc/link-pages/live/templates/components/social-icon.php',
-            'required' => array( 'social_data' )
-        ),
-        'social-icons-container' => array(
-            'file' => 'inc/link-pages/live/templates/components/social-icons-container.php',
-            'required' => array( 'social_links' )
-        ),
-        'artist-switcher' => array(
-            'file' => 'inc/core/templates/artist-switcher.php',
-            'required' => array()
-        ),
-        // Subscription Templates
-        'subscribe-inline-form' => array(
-            'file' => 'inc/link-pages/live/templates/subscribe-inline-form.php',
-            'required' => array( 'artist_id' )
-        ),
-        'subscribe-modal' => array(
-            'file' => 'inc/link-pages/live/templates/subscribe-modal.php',
-            'required' => array( 'artist_id' )
-        ),
-        // Share Modal Template (used by both live link page and preview)
-        'share-modal' => array(
-            'file' => 'inc/link-pages/live/templates/extrch-share-modal.php',
-            'required' => array() // JS populates content dynamically
-        ),
-        'artist-card' => array(
-            'file' => 'inc/artist-profiles/frontend/templates/artist-card.php',
-            'required' => array( 'artist_id' )
-        )
-    );
-    
-    // Check if template exists
-    if ( ! isset( $template_map[ $template_name ] ) ) {
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-            return '<!-- ec_render_template: unknown template ' . esc_html( $template_name ) . ' -->';
-        }
-        return '';
-    }
-    
-    $template_config = $template_map[ $template_name ];
-    
-    // Validate required arguments
-    foreach ( $template_config['required'] as $required_arg ) {
-        if ( $required_arg === 'social_data' ) {
-            $social_data = $args['social_data'] ?? array();
-            if ( empty( $social_data['url'] ) || empty( $social_data['type'] ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing social_data.url or social_data.type -->';
-                }
-                return '';
-            }
-        } elseif ( $required_arg === 'social_links' ) {
-            if ( empty( $args[ $required_arg ] ) || ! is_array( $args[ $required_arg ] ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid social_links (array required) -->';
-                }
-                return '';
-            }
-        } elseif ( $required_arg === 'links' ) {
-            if ( ! isset( $args[ $required_arg ] ) || ! is_array( $args[ $required_arg ] ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid links (array required) -->';
-                }
-                return '';
-            }
-        } elseif ( $required_arg === 'artist_id' ) {
-            if ( empty( $args[ $required_arg ] ) || ! is_numeric( $args[ $required_arg ] ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid artist_id -->';
-                }
-                return '';
-            }
-        } elseif ( $required_arg === 'target_artist_id' ) {
-            // Presence-only check: can be 0 in create mode
-            if ( ! array_key_exists( 'target_artist_id', $args ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): target_artist_id not provided -->';
-                }
-                return '';
-            }
-    } elseif ( in_array( $required_arg, array( 'edit_mode', 'display_artist_name', 'display_artist_bio', 'display_profile_image_url', 'display_header_image_url', 'sidx', 'lidx', 'index' ), true ) ) {
-            // Presence-only check: these fields can be empty strings or 0 (valid for indices)
-            if ( ! array_key_exists( $required_arg, $args ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): required key ' . esc_html( $required_arg ) . ' missing -->';
-                }
-                return '';
-            }
-        } else {
-            if ( empty( $args[ $required_arg ] ) ) {
-                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                    return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing required arg ' . esc_html( $required_arg ) . ' -->';
-                }
-                return '';
-            }
-        }
-    }
-    
-    // Render template
-    $template_file = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $template_config['file'];
-    if ( ! file_exists( $template_file ) ) {
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-            return '<!-- ec_render_template(' . esc_html( $template_name ) . '): file not found ' . esc_html( $template_config['file'] ) . ' -->';
-        }
-        return '';
-    }
-    
-    ob_start();
-    // Expose args to the included template without renaming/aliases
-    if ( is_array( $args ) && ! empty( $args ) ) {
-        // Use EXTR_SKIP to avoid overwriting any pre-set local vars
-        extract( $args, EXTR_SKIP );
-    }
-    include $template_file;
-    return ob_get_clean();
+	// Don't render if already has output (allows other plugins to override)
+	if ( ! empty( $output ) ) {
+		return $output;
+	}
+
+	// Template validation and file mapping
+	$template_map = array(
+		'single-link'            => array(
+			'file'     => 'inc/link-pages/live/templates/components/single-link.php',
+			'required' => array(),
+		),
+		'link-section'           => array(
+			'file'     => 'inc/link-pages/live/templates/components/link-section.php',
+			'required' => array( 'links' ),
+		),
+		'social-icon'            => array(
+			'file'     => 'inc/link-pages/live/templates/components/social-icon.php',
+			'required' => array( 'social_data' ),
+		),
+		'social-icons-container' => array(
+			'file'     => 'inc/link-pages/live/templates/components/social-icons-container.php',
+			'required' => array( 'social_links' ),
+		),
+		'artist-switcher'        => array(
+			'file'     => 'inc/core/templates/artist-switcher.php',
+			'required' => array(),
+		),
+		// Subscription Templates
+		'subscribe-inline-form'  => array(
+			'file'     => 'inc/link-pages/live/templates/subscribe-inline-form.php',
+			'required' => array( 'artist_id' ),
+		),
+		'subscribe-modal'        => array(
+			'file'     => 'inc/link-pages/live/templates/subscribe-modal.php',
+			'required' => array( 'artist_id' ),
+		),
+		// Share Modal Template (used by both live link page and preview)
+		'share-modal'            => array(
+			'file'     => 'inc/link-pages/live/templates/extrch-share-modal.php',
+			'required' => array(), // JS populates content dynamically
+		),
+		'artist-card'            => array(
+			'file'     => 'inc/artist-profiles/frontend/templates/artist-card.php',
+			'required' => array( 'artist_id' ),
+		),
+	);
+
+	// Check if template exists
+	if ( ! isset( $template_map[ $template_name ] ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			return '<!-- ec_render_template: unknown template ' . esc_html( $template_name ) . ' -->';
+		}
+		return '';
+	}
+
+	$template_config = $template_map[ $template_name ];
+
+	// Validate required arguments
+	foreach ( $template_config['required'] as $required_arg ) {
+		if ( $required_arg === 'social_data' ) {
+			$social_data = $args['social_data'] ?? array();
+			if ( empty( $social_data['url'] ) || empty( $social_data['type'] ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing social_data.url or social_data.type -->';
+				}
+				return '';
+			}
+		} elseif ( $required_arg === 'social_links' ) {
+			if ( empty( $args[ $required_arg ] ) || ! is_array( $args[ $required_arg ] ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid social_links (array required) -->';
+				}
+				return '';
+			}
+		} elseif ( $required_arg === 'links' ) {
+			if ( ! isset( $args[ $required_arg ] ) || ! is_array( $args[ $required_arg ] ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid links (array required) -->';
+				}
+				return '';
+			}
+		} elseif ( $required_arg === 'artist_id' ) {
+			if ( empty( $args[ $required_arg ] ) || ! is_numeric( $args[ $required_arg ] ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing or invalid artist_id -->';
+				}
+				return '';
+			}
+		} elseif ( $required_arg === 'target_artist_id' ) {
+			// Presence-only check: can be 0 in create mode
+			if ( ! array_key_exists( 'target_artist_id', $args ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): target_artist_id not provided -->';
+				}
+				return '';
+			}
+		} elseif ( in_array( $required_arg, array( 'edit_mode', 'display_artist_name', 'display_artist_bio', 'display_profile_image_url', 'display_header_image_url', 'sidx', 'lidx', 'index' ), true ) ) {
+			// Presence-only check: these fields can be empty strings or 0 (valid for indices)
+			if ( ! array_key_exists( $required_arg, $args ) ) {
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					return '<!-- ec_render_template(' . esc_html( $template_name ) . '): required key ' . esc_html( $required_arg ) . ' missing -->';
+				}
+				return '';
+			}
+		} elseif ( empty( $args[ $required_arg ] ) ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				return '<!-- ec_render_template(' . esc_html( $template_name ) . '): missing required arg ' . esc_html( $required_arg ) . ' -->';
+			}
+				return '';
+		}
+	}
+
+	// Render template
+	$template_file = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $template_config['file'];
+	if ( ! file_exists( $template_file ) ) {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			return '<!-- ec_render_template(' . esc_html( $template_name ) . '): file not found ' . esc_html( $template_config['file'] ) . ' -->';
+		}
+		return '';
+	}
+
+	ob_start();
+	// Expose args to the included template without renaming/aliases
+	if ( is_array( $args ) && ! empty( $args ) ) {
+		// Use EXTR_SKIP to avoid overwriting any pre-set local vars
+		extract( $args, EXTR_SKIP );
+	}
+	include $template_file;
+	return ob_get_clean();
 }

--- a/inc/core/filters/upload.php
+++ b/inc/core/filters/upload.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * File Upload Functions for ExtraChill Artist Platform
- * 
+ *
  * Centralized file upload handling for artist profiles and link pages.
  * Uses WordPress native media_handle_upload() and related functions.
- * 
+ *
  * Note: This module will be moved to the theme when theme architecture
  * is restructured to handle user-facing file uploads.
  *
@@ -16,152 +16,152 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Handle file uploads for link pages
  *
- * @param int $link_page_id The link page ID
+ * @param int   $link_page_id The link page ID
  * @param array $files_data $_FILES array
  * @param array $save_data Save data containing removal flags
  * @return string|null Error code if upload fails, null on success
  */
 function ec_handle_link_page_file_uploads( $link_page_id, $files_data, $save_data = array() ) {
 
-    require_once( ABSPATH . 'wp-admin/includes/file.php' );
-    require_once( ABSPATH . 'wp-admin/includes/image.php' );
-    require_once( ABSPATH . 'wp-admin/includes/media.php' );
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+	require_once ABSPATH . 'wp-admin/includes/media.php';
 
-    $max_file_size = 5 * 1024 * 1024; // 5MB
+	$max_file_size = 5 * 1024 * 1024; // 5MB
 
-    // Profile image removal
-    if ( isset( $save_data['remove_profile_image'] ) && $save_data['remove_profile_image'] === true ) {
-        $associated_artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-        if ( $associated_artist_id ) {
-            // Get current profile image ID before removing
-            $current_profile_image_id = get_post_thumbnail_id( $associated_artist_id );
-            if ( $current_profile_image_id ) {
-                // Remove from both storage locations
-                delete_post_thumbnail( $associated_artist_id );
-                delete_post_meta( $link_page_id, '_link_page_profile_image_id' );
+	// Profile image removal
+	if ( isset( $save_data['remove_profile_image'] ) && $save_data['remove_profile_image'] === true ) {
+		$associated_artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+		if ( $associated_artist_id ) {
+			// Get current profile image ID before removing
+			$current_profile_image_id = get_post_thumbnail_id( $associated_artist_id );
+			if ( $current_profile_image_id ) {
+				// Remove from both storage locations
+				delete_post_thumbnail( $associated_artist_id );
+				delete_post_meta( $link_page_id, '_link_page_profile_image_id' );
 
-                // Delete the actual attachment file
-                wp_delete_attachment( $current_profile_image_id, true );
-            }
-        }
-    }
+				// Delete the actual attachment file
+				wp_delete_attachment( $current_profile_image_id, true );
+			}
+		}
+	}
 
-    // Background image upload
-    if ( ! empty( $files_data['link_page_background_image_upload']['tmp_name'] ) ) {
-        if ( $files_data['link_page_background_image_upload']['size'] <= $max_file_size ) {
-            $associated_artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-            // Get old image from filter BEFORE updating (single source of truth)
-            $data = ec_get_link_page_data( $associated_artist_id, $link_page_id );
-            $old_bg_image_id = $data['settings']['background_image_id'] ?? '';
-            $new_bg_image_id = media_handle_upload( 'link_page_background_image_upload', $link_page_id );
-            
-            if ( is_numeric( $new_bg_image_id ) ) {
-                update_post_meta( $link_page_id, '_link_page_background_image_id', $new_bg_image_id );
-                if ( $old_bg_image_id && $old_bg_image_id != $new_bg_image_id ) {
-                    /**
-                     * Fires when an old background image should be deleted.
-                     * 
-                     * This action hook allows cleanup of old background images when
-                     * a new one is uploaded, helping maintain storage efficiency.
-                     * 
-                     * @since 1.0.0
-                     * 
-                     * @param int $old_bg_image_id The attachment ID of the old background image to delete.
-                     */
-                    do_action( 'ec_delete_old_bg_image', $old_bg_image_id );
-                }
-            }
-        }
-    }
+	// Background image upload
+	if ( ! empty( $files_data['link_page_background_image_upload']['tmp_name'] ) ) {
+		if ( $files_data['link_page_background_image_upload']['size'] <= $max_file_size ) {
+			$associated_artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+			// Get old image from filter BEFORE updating (single source of truth)
+			$data            = ec_get_link_page_data( $associated_artist_id, $link_page_id );
+			$old_bg_image_id = $data['settings']['background_image_id'] ?? '';
+			$new_bg_image_id = media_handle_upload( 'link_page_background_image_upload', $link_page_id );
 
-    // Profile image upload
-    if ( ! empty( $files_data['link_page_profile_image_upload']['tmp_name'] ) ) {
-        if ( $files_data['link_page_profile_image_upload']['size'] <= $max_file_size && $files_data['link_page_profile_image_upload']['error'] == UPLOAD_ERR_OK ) {
-            $associated_artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-            if ( $associated_artist_id ) {
-                // Get old image from filter BEFORE updating (single source of truth) 
-                $data = ec_get_link_page_data( $associated_artist_id, $link_page_id );
-                $old_profile_image_id = $data['settings']['profile_image_id'] ?? '';
-                $attach_id = media_handle_upload( 'link_page_profile_image_upload', $associated_artist_id );
-                if ( is_wp_error( $attach_id ) ) {
-                    // Upload failed - log error and return error code
-                    error_log( 'Profile image upload failed: ' . $attach_id->get_error_message() );
-                    return 'upload_failed';
-                }
-                if ( is_numeric( $attach_id ) ) {
-                    set_post_thumbnail( $associated_artist_id, $attach_id );
-                    update_post_meta( $link_page_id, '_link_page_profile_image_id', $attach_id );
-                    if ( $old_profile_image_id && $old_profile_image_id != $attach_id ) {
-                        /**
-                         * Fires when an old profile image should be deleted.
-                         * 
-                         * This action hook allows cleanup of old profile images when
-                         * a new one is uploaded, helping maintain storage efficiency.
-                         * 
-                         * @since 1.0.0
-                         * 
-                         * @param int $old_profile_image_id The attachment ID of the old profile image to delete.
-                         */
-                        do_action( 'ec_delete_old_profile_image', $old_profile_image_id );
-                    }
-                }
-            }
-        } else {
-            // File size exceeded or upload error
-            if ( $files_data['link_page_profile_image_upload']['size'] > $max_file_size ) {
-                return 'profile_image_size';
-            }
-        }
-    }
+			if ( is_numeric( $new_bg_image_id ) ) {
+				update_post_meta( $link_page_id, '_link_page_background_image_id', $new_bg_image_id );
+				if ( $old_bg_image_id && $old_bg_image_id != $new_bg_image_id ) {
+					/**
+					 * Fires when an old background image should be deleted.
+					 *
+					 * This action hook allows cleanup of old background images when
+					 * a new one is uploaded, helping maintain storage efficiency.
+					 *
+					 * @since 1.0.0
+					 *
+					 * @param int $old_bg_image_id The attachment ID of the old background image to delete.
+					 */
+					do_action( 'ec_delete_old_bg_image', $old_bg_image_id );
+				}
+			}
+		}
+	}
+
+	// Profile image upload
+	if ( ! empty( $files_data['link_page_profile_image_upload']['tmp_name'] ) ) {
+		if ( $files_data['link_page_profile_image_upload']['size'] <= $max_file_size && $files_data['link_page_profile_image_upload']['error'] == UPLOAD_ERR_OK ) {
+			$associated_artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+			if ( $associated_artist_id ) {
+				// Get old image from filter BEFORE updating (single source of truth)
+				$data                 = ec_get_link_page_data( $associated_artist_id, $link_page_id );
+				$old_profile_image_id = $data['settings']['profile_image_id'] ?? '';
+				$attach_id            = media_handle_upload( 'link_page_profile_image_upload', $associated_artist_id );
+				if ( is_wp_error( $attach_id ) ) {
+					// Upload failed - log error and return error code
+					error_log( 'Profile image upload failed: ' . $attach_id->get_error_message() );
+					return 'upload_failed';
+				}
+				if ( is_numeric( $attach_id ) ) {
+					set_post_thumbnail( $associated_artist_id, $attach_id );
+					update_post_meta( $link_page_id, '_link_page_profile_image_id', $attach_id );
+					if ( $old_profile_image_id && $old_profile_image_id != $attach_id ) {
+						/**
+						 * Fires when an old profile image should be deleted.
+						 *
+						 * This action hook allows cleanup of old profile images when
+						 * a new one is uploaded, helping maintain storage efficiency.
+						 *
+						 * @since 1.0.0
+						 *
+						 * @param int $old_profile_image_id The attachment ID of the old profile image to delete.
+						 */
+						do_action( 'ec_delete_old_profile_image', $old_profile_image_id );
+					}
+				}
+			}
+		} else {
+			// File size exceeded or upload error
+			if ( $files_data['link_page_profile_image_upload']['size'] > $max_file_size ) {
+				return 'profile_image_size';
+			}
+		}
+	}
 }
 
 /**
  * Handle file uploads for artist profiles
  *
- * @param int $artist_id The artist profile ID
+ * @param int   $artist_id The artist profile ID
  * @param array $files_data $_FILES array
  */
 function ec_handle_artist_profile_file_uploads( $artist_id, $files_data ) {
 
-    require_once( ABSPATH . 'wp-admin/includes/file.php' );
-    require_once( ABSPATH . 'wp-admin/includes/image.php' );
-    require_once( ABSPATH . 'wp-admin/includes/media.php' );
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+	require_once ABSPATH . 'wp-admin/includes/media.php';
 
-    $max_file_size = 5 * 1024 * 1024; // 5MB
+	$max_file_size = 5 * 1024 * 1024; // 5MB
 
-    // Featured image upload
-    if ( ! empty( $files_data['featured_image']['tmp_name'] ) ) {
-        if ( $files_data['featured_image']['size'] <= $max_file_size && $files_data['featured_image']['error'] == UPLOAD_ERR_OK ) {
-            $old_thumbnail_id = get_post_thumbnail_id( $artist_id );
-            $new_image_id = media_handle_upload( 'featured_image', $artist_id );
-            
-            if ( is_numeric( $new_image_id ) ) {
-                set_post_thumbnail( $artist_id, $new_image_id );
-                if ( $old_thumbnail_id && $old_thumbnail_id != $new_image_id ) {
-                    wp_delete_attachment( $old_thumbnail_id, true );
-                }
-            }
-        }
-    } elseif ( isset( $files_data['prefill_avatar_id'] ) && is_numeric( $files_data['prefill_avatar_id'] ) ) {
-        // Handle prefill avatar for new artist profiles
-        $prefill_avatar_id = absint( $files_data['prefill_avatar_id'] );
-        if ( wp_attachment_is_image( $prefill_avatar_id ) ) {
-            set_post_thumbnail( $artist_id, $prefill_avatar_id );
-        }
-    }
+	// Featured image upload
+	if ( ! empty( $files_data['featured_image']['tmp_name'] ) ) {
+		if ( $files_data['featured_image']['size'] <= $max_file_size && $files_data['featured_image']['error'] == UPLOAD_ERR_OK ) {
+			$old_thumbnail_id = get_post_thumbnail_id( $artist_id );
+			$new_image_id     = media_handle_upload( 'featured_image', $artist_id );
 
-    // Artist header image upload
-    if ( ! empty( $files_data['artist_header_image']['tmp_name'] ) ) {
-        if ( $files_data['artist_header_image']['size'] <= $max_file_size && $files_data['artist_header_image']['error'] == UPLOAD_ERR_OK ) {
-            $old_header_image_id = get_post_meta( $artist_id, '_artist_profile_header_image_id', true );
-            $new_header_image_id = media_handle_upload( 'artist_header_image', $artist_id );
-            
-            if ( is_numeric( $new_header_image_id ) ) {
-                update_post_meta( $artist_id, '_artist_profile_header_image_id', $new_header_image_id );
-                if ( $old_header_image_id && $old_header_image_id != $new_header_image_id ) {
-                    wp_delete_attachment( $old_header_image_id, true );
-                }
-            }
-        }
-    }
+			if ( is_numeric( $new_image_id ) ) {
+				set_post_thumbnail( $artist_id, $new_image_id );
+				if ( $old_thumbnail_id && $old_thumbnail_id != $new_image_id ) {
+					wp_delete_attachment( $old_thumbnail_id, true );
+				}
+			}
+		}
+	} elseif ( isset( $files_data['prefill_avatar_id'] ) && is_numeric( $files_data['prefill_avatar_id'] ) ) {
+		// Handle prefill avatar for new artist profiles
+		$prefill_avatar_id = absint( $files_data['prefill_avatar_id'] );
+		if ( wp_attachment_is_image( $prefill_avatar_id ) ) {
+			set_post_thumbnail( $artist_id, $prefill_avatar_id );
+		}
+	}
+
+	// Artist header image upload
+	if ( ! empty( $files_data['artist_header_image']['tmp_name'] ) ) {
+		if ( $files_data['artist_header_image']['size'] <= $max_file_size && $files_data['artist_header_image']['error'] == UPLOAD_ERR_OK ) {
+			$old_header_image_id = get_post_meta( $artist_id, '_artist_profile_header_image_id', true );
+			$new_header_image_id = media_handle_upload( 'artist_header_image', $artist_id );
+
+			if ( is_numeric( $new_header_image_id ) ) {
+				update_post_meta( $artist_id, '_artist_profile_header_image_id', $new_header_image_id );
+				if ( $old_header_image_id && $old_header_image_id != $new_header_image_id ) {
+					wp_delete_attachment( $old_header_image_id, true );
+				}
+			}
+		}
+	}
 }

--- a/inc/core/nav.php
+++ b/inc/core/nav.php
@@ -24,8 +24,8 @@ function ec_artist_platform_secondary_header_items( $items ) {
 		return $items;
 	}
 
-	$user_artists  = ec_get_artists_for_user( $user_id );
-	$artist_count  = count( $user_artists );
+	$user_artists = ec_get_artists_for_user( $user_id );
+	$artist_count = count( $user_artists );
 
 	// Artist Profile Link (priority 10)
 	if ( $artist_count > 0 ) {
@@ -74,7 +74,6 @@ function ec_artist_platform_secondary_header_items( $items ) {
 				'priority' => 40,
 			);
 		}
-
 	}
 
 	// Shop Link (priority 30).

--- a/inc/core/platform-artist-provisioning.php
+++ b/inc/core/platform-artist-provisioning.php
@@ -99,7 +99,6 @@ function ec_provision_platform_artist() {
 			update_option( 'extrachill_shop_needs_lifetime_membership_product_sync', 1 );
 			restore_current_blog();
 		}
-
 	} finally {
 		restore_current_blog();
 	}

--- a/inc/core/templates/artist-switcher.php
+++ b/inc/core/templates/artist-switcher.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Artist Switcher Template Component
- * 
+ *
  * Shared template for artist switcher dropdown used across management pages.
  * Eliminates code duplication between link page and artist profile management.
- * 
+ *
  * @param array $args Template arguments
  *   - switcher_id: HTML element ID (default: 'artist-switcher-select')
  *   - base_url: URL to redirect to when switching artists
@@ -18,37 +18,40 @@
 defined( 'ABSPATH' ) || exit;
 
 // Parse template arguments with defaults
-$switcher_id = $args['switcher_id'] ?? 'artist-switcher-select';
-$base_url = $args['base_url'] ?? get_permalink();
+$switcher_id       = $args['switcher_id'] ?? 'artist-switcher-select';
+$base_url          = $args['base_url'] ?? get_permalink();
 $current_artist_id = $args['current_artist_id'] ?? 0;
-$user_id = $args['user_id'] ?? get_current_user_id();
-$css_class = $args['css_class'] ?? '';
-$label_text = $args['label_text'] ?? __( '-- Select an Artist --', 'extrachill-artist-platform' );
+$user_id           = $args['user_id'] ?? get_current_user_id();
+$css_class         = $args['css_class'] ?? '';
+$label_text        = $args['label_text'] ?? __( '-- Select an Artist --', 'extrachill-artist-platform' );
 
 $user_artist_ids = $args['artist_ids'] ?? ec_get_artists_for_user( $user_id, true );
 
 // Only render if user has multiple artists
 if ( count( $user_artist_ids ) <= 1 ) {
-    return; // No switcher needed for single artist
+	return; // No switcher needed for single artist
 }
 
 // Build CSS classes
 $container_classes = 'artist-switcher-container';
 if ( ! empty( $css_class ) ) {
-    $container_classes .= ' ' . esc_attr( $css_class );
+	$container_classes .= ' ' . esc_attr( $css_class );
 }
 ?>
 
 <div class="<?php echo esc_attr( $container_classes ); ?>">
-    <select name="<?php echo esc_attr( $switcher_id ); ?>" id="<?php echo esc_attr( $switcher_id ); ?>" class="artist-switcher-select" data-base-url="<?php echo esc_attr( $base_url ); ?>">
-        <option value=""><?php echo esc_html( $label_text ); ?></option>
-        <?php foreach ( $user_artist_ids as $artist_id ) : 
-            $artist_title = get_the_title( $artist_id );
-            if ( empty( $artist_title ) ) continue; // Skip invalid artists
-        ?>
-            <option value="<?php echo esc_attr( $artist_id ); ?>" <?php selected( $current_artist_id, $artist_id ); ?>>
-                <?php echo esc_html( $artist_title ); ?>
-            </option>
-        <?php endforeach; ?>
-    </select>
+	<select name="<?php echo esc_attr( $switcher_id ); ?>" id="<?php echo esc_attr( $switcher_id ); ?>" class="artist-switcher-select" data-base-url="<?php echo esc_attr( $base_url ); ?>">
+		<option value=""><?php echo esc_html( $label_text ); ?></option>
+		<?php
+		foreach ( $user_artist_ids as $artist_id ) :
+			$artist_title = get_the_title( $artist_id );
+			if ( empty( $artist_title ) ) {
+				continue; // Skip invalid artists
+			}
+			?>
+			<option value="<?php echo esc_attr( $artist_id ); ?>" <?php selected( $current_artist_id, $artist_id ); ?>>
+				<?php echo esc_html( $artist_title ); ?>
+			</option>
+		<?php endforeach; ?>
+	</select>
 </div>

--- a/inc/database/subscriber-db.php
+++ b/inc/database/subscriber-db.php
@@ -9,13 +9,13 @@ defined( 'ABSPATH' ) || exit;
  * Creates artist_subscribers table with indexes and constraints.
  */
 function extrachill_artist_create_subscribers_table() {
-    global $wpdb;
-    require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+	global $wpdb;
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-    $table_name = $wpdb->prefix . 'artist_subscribers';
-    $charset_collate = $wpdb->get_charset_collate();
+	$table_name      = $wpdb->prefix . 'artist_subscribers';
+	$charset_collate = $wpdb->get_charset_collate();
 
-    $sql = "CREATE TABLE $table_name (
+	$sql = "CREATE TABLE $table_name (
         subscriber_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
         user_id BIGINT(20) UNSIGNED NULL,
         artist_profile_id BIGINT(20) UNSIGNED NOT NULL,
@@ -32,7 +32,5 @@ function extrachill_artist_create_subscribers_table() {
         KEY user_artist_source (user_id, artist_profile_id, source)
     ) $charset_collate;";
 
-    dbDelta( $sql );
-
+	dbDelta( $sql );
 }
-

--- a/inc/home/homepage-artist-card-actions.php
+++ b/inc/home/homepage-artist-card-actions.php
@@ -12,7 +12,7 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -24,36 +24,36 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param int $artist_id The artist profile post ID
  */
 function ec_add_artist_card_management_buttons( $artist_id ) {
-    // Only show for logged-in users
-    if ( ! is_user_logged_in() ) {
-        return;
-    }
+	// Only show for logged-in users
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
 
-    // Check if user can manage this artist
-    if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
-        return;
-    }
+	// Check if user can manage this artist
+	if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+		return;
+	}
 
-    // Get management URLs
-    $manage_artist_page = get_page_by_path( 'manage-artist' );
-    $manage_link_page = get_page_by_path( 'manage-link-page' );
+	// Get management URLs
+	$manage_artist_page = get_page_by_path( 'manage-artist' );
+	$manage_link_page   = get_page_by_path( 'manage-link-page' );
 
-    $manage_artist_url = $manage_artist_page ? get_permalink( $manage_artist_page ) : '';
-    $manage_link_url = $manage_link_page ? get_permalink( $manage_link_page ) : '';
+	$manage_artist_url = $manage_artist_page ? get_permalink( $manage_artist_page ) : '';
+	$manage_link_url   = $manage_link_page ? get_permalink( $manage_link_page ) : '';
 
-    // Output management buttons
-    ?>
-    <?php if ( $manage_artist_url ) : ?>
-        <a href="<?php echo esc_url( $manage_artist_url ); ?>" class="button-2 button-medium" data-action-button>
-            <?php esc_html_e( 'Manage Artist', 'extrachill-artist-platform' ); ?>
-        </a>
-    <?php endif; ?>
+	// Output management buttons
+	?>
+	<?php if ( $manage_artist_url ) : ?>
+		<a href="<?php echo esc_url( $manage_artist_url ); ?>" class="button-2 button-medium" data-action-button>
+			<?php esc_html_e( 'Manage Artist', 'extrachill-artist-platform' ); ?>
+		</a>
+	<?php endif; ?>
 
-    <?php if ( $manage_link_url ) : ?>
-        <a href="<?php echo esc_url( $manage_link_url ); ?>" class="button-2 button-medium" data-action-button>
-            <?php esc_html_e( 'Manage Link Page', 'extrachill-artist-platform' ); ?>
-        </a>
-    <?php endif; ?>
-    <?php
+	<?php if ( $manage_link_url ) : ?>
+		<a href="<?php echo esc_url( $manage_link_url ); ?>" class="button-2 button-medium" data-action-button>
+			<?php esc_html_e( 'Manage Link Page', 'extrachill-artist-platform' ); ?>
+		</a>
+	<?php endif; ?>
+	<?php
 }
 add_action( 'ec_artist_card_actions', 'ec_add_artist_card_management_buttons', 10, 1 );

--- a/inc/home/homepage-hooks.php
+++ b/inc/home/homepage-hooks.php
@@ -9,7 +9,7 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Hooked via extrachill_homepage_content action.
  */
 function ec_artist_platform_render_homepage() {
-    include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/homepage.php';
+	include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/homepage.php';
 }
 add_action( 'extrachill_homepage_content', 'ec_artist_platform_render_homepage' );
 
@@ -33,7 +33,7 @@ add_action( 'extrachill_homepage_content', 'ec_artist_platform_render_homepage' 
  * @param array   $user_artist_ids  Array of artist profile IDs for current user
  */
 function ec_render_artist_home_hero( $current_user, $is_logged_in, $can_create_artists, $user_artist_ids ) {
-    include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/hero.php';
+	include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/hero.php';
 }
 add_action( 'extrachill_artist_home_hero', 'ec_render_artist_home_hero', 10, 4 );
 
@@ -43,13 +43,13 @@ add_action( 'extrachill_artist_home_hero', 'ec_render_artist_home_hero', 10, 4 )
  * Displays centered "Support Forum" and "Contact" buttons above the artist grid.
  */
 function ec_render_support_buttons() {
-    ?>
-    <?php $main_site_url = ec_get_site_url( 'main' ); ?>
-    <div class="welcome-actions">
-        <a href="<?php echo esc_url( ec_get_site_url( 'community' ) . '/r/tech-support' ); ?>" class="button-1 button-large"><?php esc_html_e( 'Support Forum', 'extrachill-artist-platform' ); ?></a>
-        <a href="<?php echo esc_url( $main_site_url ); ?>/contact-us" class="button-1 button-large"><?php esc_html_e( 'Contact', 'extrachill-artist-platform' ); ?></a>
-    </div>
-    <?php
+	?>
+	<?php $main_site_url = ec_get_site_url( 'main' ); ?>
+	<div class="welcome-actions">
+		<a href="<?php echo esc_url( ec_get_site_url( 'community' ) . '/r/tech-support' ); ?>" class="button-1 button-large"><?php esc_html_e( 'Support Forum', 'extrachill-artist-platform' ); ?></a>
+		<a href="<?php echo esc_url( $main_site_url ); ?>/contact-us" class="button-1 button-large"><?php esc_html_e( 'Contact', 'extrachill-artist-platform' ); ?></a>
+	</div>
+	<?php
 }
 add_action( 'extrachill_above_artist_grid', 'ec_render_support_buttons', 15 );
 
@@ -61,6 +61,6 @@ add_action( 'extrachill_above_artist_grid', 'ec_render_support_buttons', 15 );
  * @param array $user_artist_ids Array of artist profile IDs for current user
  */
 function ec_render_your_artists( $user_artist_ids ) {
-    include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/your-artists.php';
+	include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/home/templates/your-artists.php';
 }
 add_action( 'extrachill_above_artist_grid', 'ec_render_your_artists', 10, 1 );

--- a/inc/home/templates/hero.php
+++ b/inc/home/templates/hero.php
@@ -12,7 +12,7 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 // Extract parameters from action hook
@@ -23,59 +23,59 @@ $user_artist_ids    = isset( $user_artist_ids ) ? $user_artist_ids : array();
 ?>
 
 <?php if ( ! $is_logged_in ) : ?>
-    <!-- Not Logged In - Hero -->
-    <div class="artist-home-hero">
-        <h2><?php esc_html_e( 'Welcome to the Artist Platform', 'extrachill-artist-platform' ); ?></h2>
-        <p><?php esc_html_e( 'Create your artist profile, build a custom link page at extrachill.link, track analytics, and grow your audience.', 'extrachill-artist-platform' ); ?></p>
+	<!-- Not Logged In - Hero -->
+	<div class="artist-home-hero">
+		<h2><?php esc_html_e( 'Welcome to the Artist Platform', 'extrachill-artist-platform' ); ?></h2>
+		<p><?php esc_html_e( 'Create your artist profile, build a custom link page at extrachill.link, track analytics, and grow your audience.', 'extrachill-artist-platform' ); ?></p>
 
-        <div class="welcome-actions">
-            <a href="<?php echo esc_url( home_url( '/login/' ) ); ?>" class="button-1 button-medium">
-                <?php esc_html_e( 'Log In', 'extrachill-artist-platform' ); ?>
-            </a>
-            <a href="<?php echo esc_url( home_url( '/login/#tab-register' ) ); ?>" class="button-2 button-medium">
-                <?php esc_html_e( 'Sign Up', 'extrachill-artist-platform' ); ?>
-            </a>
-            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
-                <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
-            </a>
-        </div>
-    </div>
+		<div class="welcome-actions">
+			<a href="<?php echo esc_url( home_url( '/login/' ) ); ?>" class="button-1 button-medium">
+				<?php esc_html_e( 'Log In', 'extrachill-artist-platform' ); ?>
+			</a>
+			<a href="<?php echo esc_url( home_url( '/login/#tab-register' ) ); ?>" class="button-2 button-medium">
+				<?php esc_html_e( 'Sign Up', 'extrachill-artist-platform' ); ?>
+			</a>
+			<a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
+				<?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
+			</a>
+		</div>
+	</div>
 
 <?php elseif ( empty( $user_artist_ids ) && $can_create_artists ) : ?>
-    <!-- Logged In, No Artists, CAN Create -->
-    <div class="artist-home-hero">
-        <h2><?php printf( esc_html__( 'Welcome, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
-        <p><?php esc_html_e( 'Create your artist profile to get a custom link page at extrachill.link, analytics dashboard, and subscriber tools.', 'extrachill-artist-platform' ); ?></p>
-        <div class="welcome-actions">
-            <a href="<?php echo esc_url( home_url( '/create-artist/' ) ); ?>" class="button-1 button-medium">
-                <?php esc_html_e( 'Create Artist Profile', 'extrachill-artist-platform' ); ?>
-            </a>
-            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
-                <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
-            </a>
-        </div>
-    </div>
+	<!-- Logged In, No Artists, CAN Create -->
+	<div class="artist-home-hero">
+		<h2><?php printf( esc_html__( 'Welcome, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
+		<p><?php esc_html_e( 'Create your artist profile to get a custom link page at extrachill.link, analytics dashboard, and subscriber tools.', 'extrachill-artist-platform' ); ?></p>
+		<div class="welcome-actions">
+			<a href="<?php echo esc_url( home_url( '/create-artist/' ) ); ?>" class="button-1 button-medium">
+				<?php esc_html_e( 'Create Artist Profile', 'extrachill-artist-platform' ); ?>
+			</a>
+			<a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
+				<?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
+			</a>
+		</div>
+	</div>
 
 <?php elseif ( empty( $user_artist_ids ) ) : ?>
-    <!-- Logged In, No Artists, CANNOT Create -->
-    <div class="artist-home-hero">
-        <h2><?php printf( esc_html__( 'Welcome, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
-        <p><?php esc_html_e( 'Request artist access to create profiles and custom link pages on extrachill.link.', 'extrachill-artist-platform' ); ?></p>
-        <div class="welcome-actions">
-            <a href="<?php echo esc_url( ec_get_site_url( 'community' ) . '/settings/#tab-artist-platform' ); ?>" class="button-1 button-medium">
-                <?php esc_html_e( 'Request Artist Access', 'extrachill-artist-platform' ); ?>
-            </a>
-            <a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
-                <?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
-            </a>
-        </div>
-    </div>
+	<!-- Logged In, No Artists, CANNOT Create -->
+	<div class="artist-home-hero">
+		<h2><?php printf( esc_html__( 'Welcome, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
+		<p><?php esc_html_e( 'Request artist access to create profiles and custom link pages on extrachill.link.', 'extrachill-artist-platform' ); ?></p>
+		<div class="welcome-actions">
+			<a href="<?php echo esc_url( ec_get_site_url( 'community' ) . '/settings/#tab-artist-platform' ); ?>" class="button-1 button-medium">
+				<?php esc_html_e( 'Request Artist Access', 'extrachill-artist-platform' ); ?>
+			</a>
+			<a href="<?php echo esc_url( ec_get_site_url( 'docs' ) . '/artist-platform/' ); ?>" class="button-3 button-medium">
+				<?php esc_html_e( 'Learn More', 'extrachill-artist-platform' ); ?>
+			</a>
+		</div>
+	</div>
 
 <?php else : ?>
-    <!-- Logged In, Has Artists - Dashboard Welcome -->
-    <div class="artist-home-hero">
-        <h2><?php printf( esc_html__( 'Welcome back, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
-        <p><?php printf( esc_html( _n( 'Manage your artist profile and platform features below.', 'Manage your %d artist profiles and platform features below.', count( $user_artist_ids ), 'extrachill-artist-platform' ) ), count( $user_artist_ids ) ); ?></p>
-    </div>
+	<!-- Logged In, Has Artists - Dashboard Welcome -->
+	<div class="artist-home-hero">
+		<h2><?php printf( esc_html__( 'Welcome back, %s!', 'extrachill-artist-platform' ), esc_html( $current_user->display_name ) ); ?></h2>
+		<p><?php printf( esc_html( _n( 'Manage your artist profile and platform features below.', 'Manage your %d artist profiles and platform features below.', count( $user_artist_ids ), 'extrachill-artist-platform' ) ), count( $user_artist_ids ) ); ?></p>
+	</div>
 
 <?php endif; ?>

--- a/inc/home/templates/homepage.php
+++ b/inc/home/templates/homepage.php
@@ -15,10 +15,10 @@ extrachill_breadcrumbs();
 	<div class="ec-edge-gutter">
 		<div class="entry-content" itemprop="text">
 			<?php
-			$current_user     = wp_get_current_user();
-			$is_logged_in     = is_user_logged_in();
+			$current_user       = wp_get_current_user();
+			$is_logged_in       = is_user_logged_in();
 			$can_create_artists = ec_can_create_artist_profiles( get_current_user_id() );
-			$user_artist_ids  = ec_get_artists_for_user( $current_user->ID );
+			$user_artist_ids    = ec_get_artists_for_user( $current_user->ID );
 			?>
 
 			<?php if ( ! $is_logged_in ) : ?>

--- a/inc/home/templates/your-artists.php
+++ b/inc/home/templates/your-artists.php
@@ -10,65 +10,65 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 // Get user artist IDs from parameters
 $user_artist_ids = isset( $user_artist_ids ) ? $user_artist_ids : array();
 
 if ( empty( $user_artist_ids ) ) {
-    return;
+	return;
 }
 ?>
 
 <!-- Artist Profiles -->
 <div class="artist-profiles-section">
-    <h3><?php esc_html_e( 'Your Artist Profiles', 'extrachill-artist-platform' ); ?></h3>
-    <div class="artist-cards-minimal">
-        <?php
-        foreach ( $user_artist_ids as $artist_id ) :
-            $artist_post = get_post( $artist_id );
-            if ( ! $artist_post ) {
-                continue;
-            }
+	<h3><?php esc_html_e( 'Your Artist Profiles', 'extrachill-artist-platform' ); ?></h3>
+	<div class="artist-cards-minimal">
+		<?php
+		foreach ( $user_artist_ids as $artist_id ) :
+			$artist_post = get_post( $artist_id );
+			if ( ! $artist_post ) {
+				continue;
+			}
 
-            $artist_url = get_permalink( $artist_id );
-            $profile_image_id = get_post_thumbnail_id( $artist_id );
-            $profile_image_url = $profile_image_id ? wp_get_attachment_image_url( $profile_image_id, 'thumbnail' ) : '';
-            $manage_artist_page = get_page_by_path( 'manage-artist' );
-            $manage_link_page = get_page_by_path( 'manage-link-page' );
-            $manage_artist_url = $manage_artist_page ? get_permalink( $manage_artist_page ) : '';
-            $manage_link_url = $manage_link_page ? get_permalink( $manage_link_page ) : '';
-            ?>
-            <div class="artist-card-minimal">
-                <div class="artist-card-minimal-info">
-                    <?php if ( $profile_image_url ) : ?>
-                        <img src="<?php echo esc_url( $profile_image_url ); ?>" 
-                             alt="<?php echo esc_attr( $artist_post->post_title ); ?>" 
-                             class="artist-card-minimal-avatar">
-                    <?php endif; ?>
-                    <a href="<?php echo esc_url( $artist_url ); ?>" class="artist-card-minimal-name">
-                        <?php echo esc_html( $artist_post->post_title ); ?>
-                    </a>
-                </div>
-                <div class="artist-card-minimal-actions">
-                    <a href="<?php echo esc_url( $artist_url ); ?>" class="button-1 button-small">
-                        <?php esc_html_e( 'View Profile', 'extrachill-artist-platform' ); ?>
-                    </a>
-                    <?php if ( $manage_artist_url ) : ?>
-                        <a href="<?php echo esc_url( $manage_artist_url ); ?>" class="button-2 button-small">
-                            <?php esc_html_e( 'Manage Artist', 'extrachill-artist-platform' ); ?>
-                        </a>
-                    <?php endif; ?>
-                    <?php if ( $manage_link_url ) : ?>
-                        <a href="<?php echo esc_url( $manage_link_url ); ?>" class="button-3 button-small">
-                            <?php esc_html_e( 'Manage Link Page', 'extrachill-artist-platform' ); ?>
-                        </a>
-                    <?php endif; ?>
-                </div>
-            </div>
-        <?php
-        endforeach;
-        ?>
-    </div>
+			$artist_url         = get_permalink( $artist_id );
+			$profile_image_id   = get_post_thumbnail_id( $artist_id );
+			$profile_image_url  = $profile_image_id ? wp_get_attachment_image_url( $profile_image_id, 'thumbnail' ) : '';
+			$manage_artist_page = get_page_by_path( 'manage-artist' );
+			$manage_link_page   = get_page_by_path( 'manage-link-page' );
+			$manage_artist_url  = $manage_artist_page ? get_permalink( $manage_artist_page ) : '';
+			$manage_link_url    = $manage_link_page ? get_permalink( $manage_link_page ) : '';
+			?>
+			<div class="artist-card-minimal">
+				<div class="artist-card-minimal-info">
+					<?php if ( $profile_image_url ) : ?>
+						<img src="<?php echo esc_url( $profile_image_url ); ?>"
+							alt="<?php echo esc_attr( $artist_post->post_title ); ?>"
+							class="artist-card-minimal-avatar">
+					<?php endif; ?>
+					<a href="<?php echo esc_url( $artist_url ); ?>" class="artist-card-minimal-name">
+						<?php echo esc_html( $artist_post->post_title ); ?>
+					</a>
+				</div>
+				<div class="artist-card-minimal-actions">
+					<a href="<?php echo esc_url( $artist_url ); ?>" class="button-1 button-small">
+						<?php esc_html_e( 'View Profile', 'extrachill-artist-platform' ); ?>
+					</a>
+					<?php if ( $manage_artist_url ) : ?>
+						<a href="<?php echo esc_url( $manage_artist_url ); ?>" class="button-2 button-small">
+							<?php esc_html_e( 'Manage Artist', 'extrachill-artist-platform' ); ?>
+						</a>
+					<?php endif; ?>
+					<?php if ( $manage_link_url ) : ?>
+						<a href="<?php echo esc_url( $manage_link_url ); ?>" class="button-3 button-small">
+							<?php esc_html_e( 'Manage Link Page', 'extrachill-artist-platform' ); ?>
+						</a>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php
+		endforeach;
+		?>
+	</div>
 </div>

--- a/inc/join/assets/css/join-flow.css
+++ b/inc/join/assets/css/join-flow.css
@@ -5,49 +5,49 @@
  */
 
 .join-flow-modal-overlay {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.8);
-    z-index: 1000;
+	display: none;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, 0.8);
+	z-index: 1000;
 }
 
 .join-flow-modal-content {
-    display: none;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: var(--card-background);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-md);
-    padding: var(--spacing-xl);
-    box-shadow: var(--card-shadow);
-    z-index: 1001;
-    text-align: center;
-    max-width: var(--form-width);
-    width: 90%;
-    box-sizing: border-box;
+	display: none;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background: var(--card-background);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	padding: var(--spacing-xl);
+	box-shadow: var(--card-shadow);
+	z-index: 1001;
+	text-align: center;
+	max-width: var(--form-width);
+	width: 90%;
+	box-sizing: border-box;
 }
 
 .join-flow-modal-content h2 {
-    font-family: var(--font-family-heading);
-    font-size: var(--font-size-xl);
-    margin: 0 0 var(--spacing-md) 0;
-    color: var(--text-color);
+	font-family: var(--font-family-heading);
+	font-size: var(--font-size-xl);
+	margin: 0 0 var(--spacing-md) 0;
+	color: var(--text-color);
 }
 
 .join-flow-modal-content p {
-    font-size: var(--font-size-body);
-    color: var(--muted-text);
-    margin: 0 0 var(--spacing-lg) 0;
+	font-size: var(--font-size-body);
+	color: var(--muted-text);
+	margin: 0 0 var(--spacing-lg) 0;
 }
 
 .join-flow-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing-sm);
 }

--- a/inc/link-pages/create-link-page.php
+++ b/inc/link-pages/create-link-page.php
@@ -18,26 +18,26 @@ defined( 'ABSPATH' ) || exit;
  * @param WP_Post $post    The artist_profile post object.
  */
 function extrachill_artist_create_link_page_for_artist_profile( $post_id, $post ) {
-    // Only run on actual post publish, not on auto-save or revisions
-    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-        return;
-    }
-    if ( wp_is_post_revision( $post_id ) ) {
-        return;
-    }
-    if ( 'artist_profile' !== $post->post_type ) {
-        return;
-    }
-    
-    // Skip if we're in sync mode to prevent duplicate creation
-    if ( class_exists( 'ArtistDataSyncManager' ) && ArtistDataSyncManager::is_syncing() ) {
-        return;
-    }
-    
-    // Use centralized creation filter system
-    $result = ec_create_link_page( $post_id );
-    
-    // Creation filter handles everything - no defensive programming needed
+	// Only run on actual post publish, not on auto-save or revisions
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+	if ( wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+	if ( 'artist_profile' !== $post->post_type ) {
+		return;
+	}
+
+	// Skip if we're in sync mode to prevent duplicate creation
+	if ( class_exists( 'ArtistDataSyncManager' ) && ArtistDataSyncManager::is_syncing() ) {
+		return;
+	}
+
+	// Use centralized creation filter system
+	$result = ec_create_link_page( $post_id );
+
+	// Creation filter handles everything - no defensive programming needed
 }
 // Auto-creation of link pages is now handled by the centralized join flow system
 // Only join flow registrations will automatically create link pages
@@ -53,28 +53,26 @@ function extrachill_artist_create_link_page_for_artist_profile( $post_id, $post 
  * @param int $post_id The ID of the post being deleted.
  */
 function extrachill_artist_clear_artist_profile_link_page_id_on_delete( $post_id ) {
-    if ( get_post_type( $post_id ) === 'artist_link_page' ) {
-        // Get the associated artist_profile_id from the link page's meta
-        $associated_artist_profile_id = apply_filters('ec_get_artist_id', $post_id);
+	if ( get_post_type( $post_id ) === 'artist_link_page' ) {
+		// Get the associated artist_profile_id from the link page's meta
+		$associated_artist_profile_id = apply_filters( 'ec_get_artist_id', $post_id );
 
-        if ( $associated_artist_profile_id ) {
-            // Get the current link page ID stored on the artist profile
-            $current_link_page_id_on_artist = apply_filters('ec_get_link_page_id', $associated_artist_profile_id);
+		if ( $associated_artist_profile_id ) {
+			// Get the current link page ID stored on the artist profile
+			$current_link_page_id_on_artist = apply_filters( 'ec_get_link_page_id', $associated_artist_profile_id );
 
-            // Only delete the meta if it matches the ID of the link page being deleted
-            if ( (int) $current_link_page_id_on_artist === (int) $post_id ) {
-                delete_post_meta( $associated_artist_profile_id, '_extrch_link_page_id' );
-            }
-        }
+			// Only delete the meta if it matches the ID of the link page being deleted
+			if ( (int) $current_link_page_id_on_artist === (int) $post_id ) {
+				delete_post_meta( $associated_artist_profile_id, '_extrch_link_page_id' );
+			}
+		}
 
-        // Attempt to clear the post cache for the deleted link page.
-        // This is important as get_posts can sometimes return cached results.
-        wp_cache_delete( $post_id, 'posts' );
-        wp_cache_delete( $post_id, 'post_meta' );
-        // If using persistent object cache, you might need more specific cache clearing depending on the implementation.
-    }
+		// Attempt to clear the post cache for the deleted link page.
+		// This is important as get_posts can sometimes return cached results.
+		wp_cache_delete( $post_id, 'posts' );
+		wp_cache_delete( $post_id, 'post_meta' );
+		// If using persistent object cache, you might need more specific cache clearing depending on the implementation.
+	}
 }
 add_action( 'before_delete_post', 'extrachill_artist_clear_artist_profile_link_page_id_on_delete', 10, 1 );
 // Note: 'deleted_post' could also be used, but 'before_delete_post' ensures meta is available.
-
-?>

--- a/inc/link-pages/live/assets/js/link-page-edit-button.js
+++ b/inc/link-pages/live/assets/js/link-page-edit-button.js
@@ -24,241 +24,251 @@
  * - Permissions route: extrachill-api/inc/routes/artists/permissions.php
  */
 (function () {
-    'use strict';
+	'use strict';
 
-    var TOKEN_STORAGE_KEY = 'ecLinkEditToken';
-    // Marker so an anonymous visitor only round-trips through the mint handoff
-    // once per browser tab session instead of redirecting on every page view.
-    var HANDOFF_ATTEMPTED_KEY = 'ecLinkEditHandoffAttempted';
+	var TOKEN_STORAGE_KEY = 'ecLinkEditToken';
+	// Marker so an anonymous visitor only round-trips through the mint handoff
+	// once per browser tab session instead of redirecting on every page view.
+	var HANDOFF_ATTEMPTED_KEY = 'ecLinkEditHandoffAttempted';
 
-    /**
-     * Read a non-expired cached token from localStorage.
-     *
-     * @return {string|null} The token string, or null if absent/expired.
-     */
-    function getStoredToken() {
-        try {
-            var raw = window.localStorage.getItem(TOKEN_STORAGE_KEY);
-            if (!raw) {
-                return null;
-            }
-            var parsed = JSON.parse(raw);
-            if (!parsed || !parsed.token || !parsed.expiresAt) {
-                return null;
-            }
-            // Treat as expired a little early to avoid using a token that dies
-            // mid-request. wp-native access tokens live ~15 minutes.
-            if (Date.now() >= (parsed.expiresAt - 5000)) {
-                window.localStorage.removeItem(TOKEN_STORAGE_KEY);
-                return null;
-            }
-            return parsed.token;
-        } catch (e) {
-            return null;
-        }
-    }
+	/**
+	 * Read a non-expired cached token from localStorage.
+	 *
+	 * @return {string|null} The token string, or null if absent/expired.
+	 */
+	function getStoredToken() {
+		try {
+			var raw = window.localStorage.getItem( TOKEN_STORAGE_KEY );
+			if ( ! raw) {
+				return null;
+			}
+			var parsed = JSON.parse( raw );
+			if ( ! parsed || ! parsed.token || ! parsed.expiresAt) {
+				return null;
+			}
+			// Treat as expired a little early to avoid using a token that dies
+			// mid-request. wp-native access tokens live ~15 minutes.
+			if (Date.now() >= (parsed.expiresAt - 5000)) {
+				window.localStorage.removeItem( TOKEN_STORAGE_KEY );
+				return null;
+			}
+			return parsed.token;
+		} catch (e) {
+			return null;
+		}
+	}
 
-    /**
-     * Persist a token with a client-side expiry (~15 min, matching wp-native).
-     *
-     * @param {string} token The plaintext access token.
-     * @return {void}
-     */
-    function storeToken(token) {
-        try {
-            window.localStorage.setItem(
-                TOKEN_STORAGE_KEY,
-                JSON.stringify({
-                    token: token,
-                    // 15 minutes; the server is the source of truth and a 401
-                    // will clear it early if it dies sooner.
-                    expiresAt: Date.now() + (15 * 60 * 1000)
-                })
-            );
-        } catch (e) {
-            // localStorage unavailable (private mode quotas etc.) — the button
-            // just won't render. Non-fatal.
-        }
-    }
+	/**
+	 * Persist a token with a client-side expiry (~15 min, matching wp-native).
+	 *
+	 * @param {string} token The plaintext access token.
+	 * @return {void}
+	 */
+	function storeToken(token) {
+		try {
+			window.localStorage.setItem(
+				TOKEN_STORAGE_KEY,
+				JSON.stringify(
+					{
+						token: token,
+						// 15 minutes; the server is the source of truth and a 401
+						// will clear it early if it dies sooner.
+						expiresAt: Date.now() + (15 * 60 * 1000)
+					}
+				)
+			);
+		} catch (e) {
+			// localStorage unavailable (private mode quotas etc.) — the button
+			// just won't render. Non-fatal.
+		}
+	}
 
-    /**
-     * Clear the cached token.
-     *
-     * @return {void}
-     */
-    function clearStoredToken() {
-        try {
-            window.localStorage.removeItem(TOKEN_STORAGE_KEY);
-        } catch (e) {}
-    }
+	/**
+	 * Clear the cached token.
+	 *
+	 * @return {void}
+	 */
+	function clearStoredToken() {
+		try {
+			window.localStorage.removeItem( TOKEN_STORAGE_KEY );
+		} catch (e) {
+		}
+	}
 
-    /**
-     * Parse the token (or the tokenless marker) out of the URL fragment left by
-     * the mint handoff redirect, then scrub the fragment from the address bar.
-     *
-     * @return {{token: (string|null), attempted: boolean}}
-     */
-    function consumeFragmentToken() {
-        var result = { token: null, attempted: false };
-        var hash = window.location.hash || '';
-        if (!hash || hash.length < 2) {
-            return result;
-        }
+	/**
+	 * Parse the token (or the tokenless marker) out of the URL fragment left by
+	 * the mint handoff redirect, then scrub the fragment from the address bar.
+	 *
+	 * @return {{token: (string|null), attempted: boolean}}
+	 */
+	function consumeFragmentToken() {
+		var result = { token: null, attempted: false };
+		var hash   = window.location.hash || '';
+		if ( ! hash || hash.length < 2) {
+			return result;
+		}
 
-        var fragment = hash.charAt(0) === '#' ? hash.substring(1) : hash;
-        var params = new URLSearchParams(fragment);
+		var fragment = hash.charAt( 0 ) === '#' ? hash.substring( 1 ) : hash;
+		var params   = new URLSearchParams( fragment );
 
-        if (params.has('ec_link_token')) {
-            result.token = params.get('ec_link_token');
-            result.attempted = true;
-        } else if (params.has('ec_link_token_none')) {
-            // Handoff ran and the visitor was not logged in.
-            result.attempted = true;
-        } else {
-            return result;
-        }
+		if (params.has( 'ec_link_token' )) {
+			result.token     = params.get( 'ec_link_token' );
+			result.attempted = true;
+		} else if (params.has( 'ec_link_token_none' )) {
+			// Handoff ran and the visitor was not logged in.
+			result.attempted = true;
+		} else {
+			return result;
+		}
 
-        // Scrub our keys from the fragment, preserving any unrelated fragment.
-        params.delete('ec_link_token');
-        params.delete('ec_link_token_none');
-        var remaining = params.toString();
-        var cleanUrl = window.location.pathname + window.location.search + (remaining ? '#' + remaining : '');
-        try {
-            window.history.replaceState(null, '', cleanUrl);
-        } catch (e) {
-            // history API unavailable — leave the URL as-is.
-        }
+		// Scrub our keys from the fragment, preserving any unrelated fragment.
+		params.delete( 'ec_link_token' );
+		params.delete( 'ec_link_token_none' );
+		var remaining = params.toString();
+		var cleanUrl  = window.location.pathname + window.location.search + (remaining ? '#' + remaining : '');
+		try {
+			window.history.replaceState( null, '', cleanUrl );
+		} catch (e) {
+			// history API unavailable — leave the URL as-is.
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    /**
-     * Redirect to the mint handoff endpoint on the artist site, which mints a
-     * short-lived token (if the visitor is logged in there) and 302s back with
-     * the token in the fragment. Guarded by a per-session marker so anonymous
-     * visitors only round-trip once.
-     *
-     * @param {string} handoffUrl Base handoff URL from the body data attribute.
-     * @return {void}
-     */
-    function attemptHandoff(handoffUrl) {
-        if (!handoffUrl) {
-            return;
-        }
-        try {
-            if (window.sessionStorage.getItem(HANDOFF_ATTEMPTED_KEY)) {
-                return;
-            }
-            window.sessionStorage.setItem(HANDOFF_ATTEMPTED_KEY, '1');
-        } catch (e) {
-            // sessionStorage unavailable — fall through; without the guard we'd
-            // risk a redirect loop, so bail rather than redirect.
-            return;
-        }
+	/**
+	 * Redirect to the mint handoff endpoint on the artist site, which mints a
+	 * short-lived token (if the visitor is logged in there) and 302s back with
+	 * the token in the fragment. Guarded by a per-session marker so anonymous
+	 * visitors only round-trip once.
+	 *
+	 * @param {string} handoffUrl Base handoff URL from the body data attribute.
+	 * @return {void}
+	 */
+	function attemptHandoff(handoffUrl) {
+		if ( ! handoffUrl) {
+			return;
+		}
+		try {
+			if (window.sessionStorage.getItem( HANDOFF_ATTEMPTED_KEY )) {
+				return;
+			}
+			window.sessionStorage.setItem( HANDOFF_ATTEMPTED_KEY, '1' );
+		} catch (e) {
+			// sessionStorage unavailable — fall through; without the guard we'd
+			// risk a redirect loop, so bail rather than redirect.
+			return;
+		}
 
-        var returnUrl = window.location.href.split('#')[0];
-        var separator = handoffUrl.indexOf('?') === -1 ? '?' : '&';
-        var destination = handoffUrl + separator + 'return=' + encodeURIComponent(returnUrl);
-        window.location.assign(destination);
-    }
+		var returnUrl   = window.location.href.split( '#' )[0];
+		var separator   = handoffUrl.indexOf( '?' ) === -1 ? '?' : '&';
+		var destination = handoffUrl + separator + 'return=' + encodeURIComponent( returnUrl );
+		window.location.assign( destination );
+	}
 
-    /**
-     * Call the permissions endpoint with a bearer token and render the button if
-     * authorized. On 401 (token expired/invalid) clears the cached token.
-     *
-     * @param {string} apiUrl The permissions endpoint URL.
-     * @param {string} token  The bearer access token.
-     * @return {void}
-     */
-    function checkPermission(apiUrl, token) {
-        fetch(apiUrl, {
-            method: 'GET',
-            headers: {
-                'Authorization': 'Bearer ' + token
-            }
-        })
-            .then(function (response) {
-                if (response.status === 401) {
-                    clearStoredToken();
-                    return null;
-                }
-                if (!response.ok) {
-                    return null;
-                }
-                return response.json();
-            })
-            .then(function (data) {
-                if (!data || data.can_edit !== true || !data.manage_url) {
-                    return;
-                }
-                renderEditButton(data.manage_url);
-            })
-            .catch(function () {});
-    }
+	/**
+	 * Call the permissions endpoint with a bearer token and render the button if
+	 * authorized. On 401 (token expired/invalid) clears the cached token.
+	 *
+	 * @param {string} apiUrl The permissions endpoint URL.
+	 * @param {string} token  The bearer access token.
+	 * @return {void}
+	 */
+	function checkPermission(apiUrl, token) {
+		fetch(
+			apiUrl,
+			{
+				method: 'GET',
+				headers: {
+					'Authorization': 'Bearer ' + token
+				}
+			}
+		)
+			.then(
+				function (response) {
+					if (response.status === 401) {
+						clearStoredToken();
+						return null;
+					}
+					if ( ! response.ok) {
+						return null;
+					}
+					return response.json();
+				}
+			)
+			.then(
+				function (data) {
+					if ( ! data || data.can_edit !== true || ! data.manage_url) {
+						return;
+					}
+					renderEditButton( data.manage_url );
+				}
+			)
+			.catch( function () {} );
+	}
 
-    /**
-     * Render the fixed-position edit button.
-     *
-     * @param {string} manageUrl URL to the link page management interface.
-     * @return {void}
-     */
-    function renderEditButton(manageUrl) {
-        if (document.querySelector('.extrch-link-page-edit-btn')) {
-            return;
-        }
+	/**
+	 * Render the fixed-position edit button.
+	 *
+	 * @param {string} manageUrl URL to the link page management interface.
+	 * @return {void}
+	 */
+	function renderEditButton(manageUrl) {
+		if (document.querySelector( '.extrch-link-page-edit-btn' )) {
+			return;
+		}
 
-        var editButton = document.createElement('a');
-        editButton.href = manageUrl;
-        editButton.className = 'extrch-link-page-edit-btn';
-        editButton.setAttribute('aria-label', 'Edit link page');
-        editButton.innerHTML = '<i class="fas fa-pencil-alt"></i>';
+		var editButton       = document.createElement( 'a' );
+		editButton.href      = manageUrl;
+		editButton.className = 'extrch-link-page-edit-btn';
+		editButton.setAttribute( 'aria-label', 'Edit link page' );
+		editButton.innerHTML = '<i class="fas fa-pencil-alt"></i>';
 
-        document.body.appendChild(editButton);
-    }
+		document.body.appendChild( editButton );
+	}
 
-    /**
-     * Orchestrate the edit-button auth flow.
-     *
-     * @return {void}
-     */
-    function init() {
-        var body = document.body;
-        if (!body || !body.dataset) {
-            return;
-        }
+	/**
+	 * Orchestrate the edit-button auth flow.
+	 *
+	 * @return {void}
+	 */
+	function init() {
+		var body = document.body;
+		if ( ! body || ! body.dataset) {
+			return;
+		}
 
-        var apiUrl = body.dataset.extrchPermissionsApiUrl || '';
-        var handoffUrl = body.dataset.extrchTokenHandoffUrl || '';
-        if (!apiUrl) {
-            return;
-        }
+		var apiUrl     = body.dataset.extrchPermissionsApiUrl || '';
+		var handoffUrl = body.dataset.extrchTokenHandoffUrl || '';
+		if ( ! apiUrl) {
+			return;
+		}
 
-        // 1. If we just came back from the mint handoff, capture the token.
-        var fragment = consumeFragmentToken();
-        if (fragment.token) {
-            storeToken(fragment.token);
-        }
+		// 1. If we just came back from the mint handoff, capture the token.
+		var fragment = consumeFragmentToken();
+		if (fragment.token) {
+			storeToken( fragment.token );
+		}
 
-        // 2. Use a cached/just-captured token if we have one.
-        var token = getStoredToken();
-        if (token) {
-            checkPermission(apiUrl, token);
-            return;
-        }
+		// 2. Use a cached/just-captured token if we have one.
+		var token = getStoredToken();
+		if (token) {
+			checkPermission( apiUrl, token );
+			return;
+		}
 
-        // 3. No token. If the handoff already ran this session (including the
-        //    tokenless "not logged in" return), stop — anonymous visitor.
-        if (fragment.attempted) {
-            return;
-        }
+		// 3. No token. If the handoff already ran this session (including the
+		// tokenless "not logged in" return), stop — anonymous visitor.
+		if (fragment.attempted) {
+			return;
+		}
 
-        // 4. Bootstrap a token via the one-time handoff redirect.
-        attemptHandoff(handoffUrl);
-    }
+		// 4. Bootstrap a token via the one-time handoff redirect.
+		attemptHandoff( handoffUrl );
+	}
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
+	if (document.readyState === 'loading') {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
 })();

--- a/inc/link-pages/live/link-page-head.php
+++ b/inc/link-pages/live/link-page-head.php
@@ -15,112 +15,111 @@
  */
 function extrachill_artist_link_page_custom_head( $artist_id, $link_page_id ) {
 
-    echo '<meta charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
-    echo '<meta name="viewport" content="width=device-width,initial-scale=1">';
+	echo '<meta charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
+	echo '<meta name="viewport" content="width=device-width,initial-scale=1">';
 
-    $artist_title = $artist_id ? get_the_title( $artist_id ) : 'Link Page';
-    echo '<title>' . esc_html( $artist_title ) . ' | extrachill.link</title>';
+	$artist_title = $artist_id ? get_the_title( $artist_id ) : 'Link Page';
+	echo '<title>' . esc_html( $artist_title ) . ' | extrachill.link</title>';
 
-    // --- SEO Meta Tags via extrachill-seo ---
-    if ( function_exists( 'ExtraChill\SEO\Core\ec_seo_render_head' ) && function_exists( 'extrachill_artist_link_page_seo_context' ) ) {
-        $seo_context = extrachill_artist_link_page_seo_context( $artist_id, $link_page_id );
-        \ExtraChill\SEO\Core\ec_seo_render_head( $seo_context );
-    } else {
-        // Fallback: basic meta description when extrachill-seo is not available.
-        $artist_excerpt = $artist_id ? get_the_excerpt( $artist_id ) : 'All important links in one place.';
-        echo '<meta name="description" content="' . esc_attr( wp_strip_all_tags( $artist_excerpt ) ) . '">';
-    }
+	// --- SEO Meta Tags via extrachill-seo ---
+	if ( function_exists( 'ExtraChill\SEO\Core\ec_seo_render_head' ) && function_exists( 'extrachill_artist_link_page_seo_context' ) ) {
+		$seo_context = extrachill_artist_link_page_seo_context( $artist_id, $link_page_id );
+		\ExtraChill\SEO\Core\ec_seo_render_head( $seo_context );
+	} else {
+		// Fallback: basic meta description when extrachill-seo is not available.
+		$artist_excerpt = $artist_id ? get_the_excerpt( $artist_id ) : 'All important links in one place.';
+		echo '<meta name="description" content="' . esc_attr( wp_strip_all_tags( $artist_excerpt ) ) . '">';
+	}
 
-    // Favicon.
-    $site_icon_url = get_site_icon_url( 32 );
-    if ( $site_icon_url ) {
-        echo '<link rel="icon" href="' . esc_url( $site_icon_url ) . '" sizes="32x32" />';
-        echo '<link rel="icon" href="' . esc_url( $site_icon_url ) . '" sizes="192x192" />';
-        echo '<link rel="apple-touch-icon" href="' . esc_url( $site_icon_url ) . '">';
-    }
+	// Favicon.
+	$site_icon_url = get_site_icon_url( 32 );
+	if ( $site_icon_url ) {
+		echo '<link rel="icon" href="' . esc_url( $site_icon_url ) . '" sizes="32x32" />';
+		echo '<link rel="icon" href="' . esc_url( $site_icon_url ) . '" sizes="192x192" />';
+		echo '<link rel="apple-touch-icon" href="' . esc_url( $site_icon_url ) . '">';
+	}
 
-    // Link page assets are enqueued via extrachill_artist_link_page_minimal_head.
-    // These templates bypass wp_head(), so styles are printed below
-    // via wp_print_styles() after the enqueue hook fires.
+	// Link page assets are enqueued via extrachill_artist_link_page_minimal_head.
+	// These templates bypass wp_head(), so styles are printed below
+	// via wp_print_styles() after the enqueue hook fires.
 
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    $final_vars = $data['css_vars'];
+	$data       = ec_get_link_page_data( $artist_id, $link_page_id );
+	$final_vars = $data['css_vars'];
 
-    echo ec_generate_css_variables_style_block( $final_vars, 'extrch-link-page-custom-vars' );
+	echo ec_generate_css_variables_style_block( $final_vars, 'extrch-link-page-custom-vars' );
 
-    $font_manager = ExtraChillArtistPlatform_Fonts::instance();
-    $font_values = array();
+	$font_manager = ExtraChillArtistPlatform_Fonts::instance();
+	$font_values  = array();
 
-    if ( isset( $data['raw_font_values']['title_font'] ) && ! empty( $data['raw_font_values']['title_font'] ) ) {
-        $font_values[] = $data['raw_font_values']['title_font'];
-    }
+	if ( isset( $data['raw_font_values']['title_font'] ) && ! empty( $data['raw_font_values']['title_font'] ) ) {
+		$font_values[] = $data['raw_font_values']['title_font'];
+	}
 
-    if ( isset( $data['raw_font_values']['body_font'] ) && ! empty( $data['raw_font_values']['body_font'] ) ) {
-        $font_values[] = $data['raw_font_values']['body_font'];
-    }
+	if ( isset( $data['raw_font_values']['body_font'] ) && ! empty( $data['raw_font_values']['body_font'] ) ) {
+		$font_values[] = $data['raw_font_values']['body_font'];
+	}
 
-    $font_url = $font_manager->get_google_fonts_url( $font_values );
-    if ( ! empty( $font_url ) ) {
-        echo '<link rel="stylesheet" href="' . esc_url($font_url) . '" media="print" onload="this.media=\'all\'">';
-        echo '<noscript><link rel="stylesheet" href="' . esc_url($font_url) . '"></noscript>';
-    }
+	$font_url = $font_manager->get_google_fonts_url( $font_values );
+	if ( ! empty( $font_url ) ) {
+		echo '<link rel="stylesheet" href="' . esc_url( $font_url ) . '" media="print" onload="this.media=\'all\'">';
+		echo '<noscript><link rel="stylesheet" href="' . esc_url( $font_url ) . '"></noscript>';
+	}
 
-    $local_fonts_css = $font_manager->get_local_fonts_css( $font_values );
-    if ( ! empty( $local_fonts_css ) ) {
-        echo '<style>' . $local_fonts_css . '</style>';
-    }
+	$local_fonts_css = $font_manager->get_local_fonts_css( $font_values );
+	if ( ! empty( $local_fonts_css ) ) {
+		echo '<style>' . $local_fonts_css . '</style>';
+	}
 
-    do_action( 'extrachill_artist_link_page_minimal_head', $link_page_id, $artist_id );
-    wp_print_styles();
+	do_action( 'extrachill_artist_link_page_minimal_head', $link_page_id, $artist_id );
+	wp_print_styles();
 
-    $meta_pixel_id = $data['settings']['meta_pixel_id'] ?? '';
-    if (!empty($meta_pixel_id) && ctype_digit($meta_pixel_id)) {
-        echo "<!-- Meta Pixel Code -->\n";
-        echo "<script>\n";
-        echo "!function(f,b,e,v,n,t,s)\n";
-        echo "{if(f.fbq)return;n=f.fbq=function(){n.callMethod?\n";
-        echo "n.callMethod.apply(n,arguments):n.queue.push(arguments)};\n";
-        echo "if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';\n";
-        echo "n.queue=[];t=b.createElement(e);t.async=!0;\n";
-        echo "t.src=v;s=b.getElementsByTagName(e)[0];\n";
-        echo "s.parentNode.insertBefore(t,s)}(window, document,'script',\n";
-        echo "'https://connect.facebook.net/en_US/fbevents.js');\n";
-        echo "fbq('init', '" . esc_js($meta_pixel_id) . "');\n";
-        echo "fbq('track', 'PageView');\n";
-        echo "</script>\n";
-        echo "<noscript><img height=\"1\" width=\"1\" style=\"display:none\"\n";
-        echo "src=\"https://www.facebook.com/tr?id=" . esc_attr($meta_pixel_id) . "&ev=PageView&noscript=1\"\n";
-        echo "/></noscript>\n";
-        echo "<!-- End Meta Pixel Code -->\n";
-    }
+	$meta_pixel_id = $data['settings']['meta_pixel_id'] ?? '';
+	if ( ! empty( $meta_pixel_id ) && ctype_digit( $meta_pixel_id ) ) {
+		echo "<!-- Meta Pixel Code -->\n";
+		echo "<script>\n";
+		echo "!function(f,b,e,v,n,t,s)\n";
+		echo "{if(f.fbq)return;n=f.fbq=function(){n.callMethod?\n";
+		echo "n.callMethod.apply(n,arguments):n.queue.push(arguments)};\n";
+		echo "if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';\n";
+		echo "n.queue=[];t=b.createElement(e);t.async=!0;\n";
+		echo "t.src=v;s=b.getElementsByTagName(e)[0];\n";
+		echo "s.parentNode.insertBefore(t,s)}(window, document,'script',\n";
+		echo "'https://connect.facebook.net/en_US/fbevents.js');\n";
+		echo "fbq('init', '" . esc_js( $meta_pixel_id ) . "');\n";
+		echo "fbq('track', 'PageView');\n";
+		echo "</script>\n";
+		echo "<noscript><img height=\"1\" width=\"1\" style=\"display:none\"\n";
+		echo 'src="https://www.facebook.com/tr?id=' . esc_attr( $meta_pixel_id ) . "&ev=PageView&noscript=1\"\n";
+		echo "/></noscript>\n";
+		echo "<!-- End Meta Pixel Code -->\n";
+	}
 
-    $google_tag_id = $data['settings']['google_tag_id'] ?? '';
-    if (!empty($google_tag_id) && preg_match('/^(G|AW)-[a-zA-Z0-9]+$/', $google_tag_id)) {
-        echo "<!-- Google Tag Manager -->\n";
-        echo "<script async src=\"https://www.googletagmanager.com/gtag/js?id=" . esc_attr($google_tag_id) . "\"></script>\n";
-        echo "<script>\n";
-        echo "  window.dataLayer = window.dataLayer || [];\n";
-        echo "  function gtag(){dataLayer.push(arguments);}\n";
-        echo "  gtag('js', new Date());\n";
-        echo "\n";
-        echo "  gtag('config', '" . esc_js($google_tag_id) . "');\n";
-        echo "</script>\n";
-        echo "<!-- End Google Tag Manager -->\n";
-    }
+	$google_tag_id = $data['settings']['google_tag_id'] ?? '';
+	if ( ! empty( $google_tag_id ) && preg_match( '/^(G|AW)-[a-zA-Z0-9]+$/', $google_tag_id ) ) {
+		echo "<!-- Google Tag Manager -->\n";
+		echo '<script async src="https://www.googletagmanager.com/gtag/js?id=' . esc_attr( $google_tag_id ) . "\"></script>\n";
+		echo "<script>\n";
+		echo "  window.dataLayer = window.dataLayer || [];\n";
+		echo "  function gtag(){dataLayer.push(arguments);}\n";
+		echo "  gtag('js', new Date());\n";
+		echo "\n";
+		echo "  gtag('config', '" . esc_js( $google_tag_id ) . "');\n";
+		echo "</script>\n";
+		echo "<!-- End Google Tag Manager -->\n";
+	}
 
-    echo '<!-- Google Tag Manager -->';
-    echo '<script>';
-    echo '(function(w,d,s,l,i){';
-    echo 'w[l]=w[l]||[];';
-    echo 'w[l].push({\'gtm.start\': new Date().getTime(), event:\'gtm.js\'});';
-    echo 'var f=d.getElementsByTagName(s)[0],';
-    echo 'j=d.createElement(s),';
-    echo 'dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';';
-    echo 'j.async=true;';
-    echo 'j.src=\'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;';
-    echo 'f.parentNode.insertBefore(j,f);';
-    echo '})(window,document,\'script\',\'dataLayer\',\'GTM-NXKDLFD\');';
-    echo '</script>';
-    echo '<!-- End Google Tag Manager -->';
-
-} 
+	echo '<!-- Google Tag Manager -->';
+	echo '<script>';
+	echo '(function(w,d,s,l,i){';
+	echo 'w[l]=w[l]||[];';
+	echo 'w[l].push({\'gtm.start\': new Date().getTime(), event:\'gtm.js\'});';
+	echo 'var f=d.getElementsByTagName(s)[0],';
+	echo 'j=d.createElement(s),';
+	echo 'dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';';
+	echo 'j.async=true;';
+	echo 'j.src=\'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;';
+	echo 'f.parentNode.insertBefore(j,f);';
+	echo '})(window,document,\'script\',\'dataLayer\',\'GTM-NXKDLFD\');';
+	echo '</script>';
+	echo '<!-- End Google Tag Manager -->';
+}

--- a/inc/link-pages/live/minimal-head-assets.php
+++ b/inc/link-pages/live/minimal-head-assets.php
@@ -19,44 +19,44 @@ add_action( 'extrachill_artist_link_page_minimal_head', 'extrachill_artist_enque
  * @return void
  */
 function extrachill_artist_enqueue_link_page_minimal_assets( $link_page_id, $artist_id ) {
-    $plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
-    $plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
+	$plugin_dir = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR;
+	$plugin_url = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL;
 
-    $styles = array(
-        'extrch-link-page'           => 'assets/css/extrch-links.css',
-        'extrch-share-modal'         => 'assets/css/extrch-share-modal.css',
-        'extrch-custom-social-icons' => 'assets/css/custom-social-icons.css',
-        'extrch-font-awesome'        => 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css',
-    );
+	$styles = array(
+		'extrch-link-page'           => 'assets/css/extrch-links.css',
+		'extrch-share-modal'         => 'assets/css/extrch-share-modal.css',
+		'extrch-custom-social-icons' => 'assets/css/custom-social-icons.css',
+		'extrch-font-awesome'        => 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css',
+	);
 
-    foreach ( $styles as $handle => $path ) {
-        if ( 0 === strpos( $path, 'http' ) ) {
-            wp_enqueue_style( $handle, $path, array(), null );
-            continue;
-        }
+	foreach ( $styles as $handle => $path ) {
+		if ( 0 === strpos( $path, 'http' ) ) {
+			wp_enqueue_style( $handle, $path, array(), null );
+			continue;
+		}
 
-        $abs_path = $plugin_dir . $path;
-        if ( ! file_exists( $abs_path ) ) {
-            continue;
-        }
+		$abs_path = $plugin_dir . $path;
+		if ( ! file_exists( $abs_path ) ) {
+			continue;
+		}
 
-        wp_enqueue_style( $handle, $plugin_url . $path, array(), filemtime( $abs_path ) );
-    }
+		wp_enqueue_style( $handle, $plugin_url . $path, array(), filemtime( $abs_path ) );
+	}
 
-    $scripts = array(
-        'extrch-share-modal'         => 'inc/link-pages/live/assets/js/extrch-share-modal.js',
-        'extrch-subscribe'           => 'inc/link-pages/live/assets/js/link-page-subscribe.js',
-        'extrch-edit-button'         => 'inc/link-pages/live/assets/js/link-page-edit-button.js',
-        'extrch-public-tracking'     => 'inc/link-pages/live/assets/js/link-page-public-tracking.js',
-        'extrch-link-page-youtube'   => 'inc/link-pages/live/assets/js/link-page-youtube-embed.js',
-    );
+	$scripts = array(
+		'extrch-share-modal'       => 'inc/link-pages/live/assets/js/extrch-share-modal.js',
+		'extrch-subscribe'         => 'inc/link-pages/live/assets/js/link-page-subscribe.js',
+		'extrch-edit-button'       => 'inc/link-pages/live/assets/js/link-page-edit-button.js',
+		'extrch-public-tracking'   => 'inc/link-pages/live/assets/js/link-page-public-tracking.js',
+		'extrch-link-page-youtube' => 'inc/link-pages/live/assets/js/link-page-youtube-embed.js',
+	);
 
-    foreach ( $scripts as $handle => $path ) {
-        $abs_path = $plugin_dir . $path;
-        if ( ! file_exists( $abs_path ) ) {
-            continue;
-        }
+	foreach ( $scripts as $handle => $path ) {
+		$abs_path = $plugin_dir . $path;
+		if ( ! file_exists( $abs_path ) ) {
+			continue;
+		}
 
-        wp_enqueue_script( $handle, $plugin_url . $path, array(), filemtime( $abs_path ), true );
-    }
+		wp_enqueue_script( $handle, $plugin_url . $path, array(), filemtime( $abs_path ), true );
+	}
 }

--- a/inc/link-pages/live/templates/components/link-section.php
+++ b/inc/link-pages/live/templates/components/link-section.php
@@ -7,15 +7,18 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 // Expected args: section_title (string), links (array), link_page_id (int, optional)
-$args = wp_parse_args( $args ?? array(), array(
-    'section_title' => '',
-    'links'        => array(),
-    'link_page_id' => 0,
-) );
+$args = wp_parse_args(
+	$args ?? array(),
+	array(
+		'section_title' => '',
+		'links'         => array(),
+		'link_page_id'  => 0,
+	)
+);
 
 $section_title = $args['section_title'];
 $links         = is_array( $args['links'] ) ? $args['links'] : array();
@@ -24,10 +27,10 @@ $link_page_id  = (int) $args['link_page_id'];
 // Filter links with required fields
 $links_to_render = array();
 foreach ( $links as $link_item ) {
-    if ( empty( $link_item['link_url'] ) || empty( $link_item['link_text'] ) ) {
-        continue;
-    }
-    $links_to_render[] = $link_item;
+	if ( empty( $link_item['link_url'] ) || empty( $link_item['link_text'] ) ) {
+		continue;
+	}
+	$links_to_render[] = $link_item;
 }
 ?>
 
@@ -36,25 +39,27 @@ foreach ( $links as $link_item ) {
 <?php endif; ?>
 
 <div class="extrch-link-page-links">
-    <?php foreach ( $links_to_render as $link_item ) :
-        $link_classes    = 'extrch-link-page-link';
-        $is_youtube_link = false;
+	<?php
+	foreach ( $links_to_render as $link_item ) :
+		$link_classes    = 'extrch-link-page-link';
+		$is_youtube_link = false;
 
-        if ( $link_page_id && function_exists( 'extrachill_artist_is_youtube_embed_enabled' ) && extrachill_artist_is_youtube_embed_enabled( $link_page_id ) ) {
-            $url = $link_item['link_url'];
-            if ( strpos( $url, 'youtube.com' ) !== false || strpos( $url, 'youtu.be' ) !== false ) {
-                $link_classes    .= ' extrch-youtube-embed-link';
-                $is_youtube_link = true;
-            }
-        }
+		if ( $link_page_id && function_exists( 'extrachill_artist_is_youtube_embed_enabled' ) && extrachill_artist_is_youtube_embed_enabled( $link_page_id ) ) {
+			$url = $link_item['link_url'];
+			if ( strpos( $url, 'youtube.com' ) !== false || strpos( $url, 'youtu.be' ) !== false ) {
+				$link_classes   .= ' extrch-youtube-embed-link';
+				$is_youtube_link = true;
+			}
+		}
 
-        $link_args = array(
-            'link_url'     => $link_item['link_url'],
-            'link_text'    => $link_item['link_text'],
-            'link_classes' => $link_classes,
-            'youtube_embed'=> $is_youtube_link,
-        );
+		$link_args = array(
+			'link_url'      => $link_item['link_url'],
+			'link_text'     => $link_item['link_text'],
+			'link_classes'  => $link_classes,
+			'youtube_embed' => $is_youtube_link,
+		);
 
-        echo ec_render_template( 'single-link', $link_args );
-    endforeach; ?>
+		echo ec_render_template( 'single-link', $link_args );
+	endforeach;
+	?>
 </div>

--- a/inc/link-pages/live/templates/components/single-link.php
+++ b/inc/link-pages/live/templates/components/single-link.php
@@ -7,39 +7,42 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-$args = wp_parse_args( $args ?? array(), array(
-    'link_url'     => '',
-    'link_text'    => '',
-    'link_classes' => 'extrch-link-page-link',
-    'youtube_embed'=> false,
-) );
+$args = wp_parse_args(
+	$args ?? array(),
+	array(
+		'link_url'      => '',
+		'link_text'     => '',
+		'link_classes'  => 'extrch-link-page-link',
+		'youtube_embed' => false,
+	)
+);
 
 $link_url      = $args['link_url'];
 $link_text     = $args['link_text'];
 $link_classes  = $args['link_classes'];
 $youtube_embed = (bool) $args['youtube_embed'];
 
-$display_url   = ! empty( $link_url ) ? $link_url : '#';
-$display_text  = ! empty( $link_text ) ? $link_text : '';
-$share_url     = ! empty( $link_url ) ? $link_url : '#';
-$share_title   = ! empty( $link_text ) ? $link_text : 'Untitled Link';
+$display_url  = ! empty( $link_url ) ? $link_url : '#';
+$display_text = ! empty( $link_text ) ? $link_text : '';
+$share_url    = ! empty( $link_url ) ? $link_url : '#';
+$share_title  = ! empty( $link_text ) ? $link_text : 'Untitled Link';
 
 if ( $youtube_embed ) {
-    $link_classes .= ' extrch-youtube-embed-link';
+	$link_classes .= ' extrch-youtube-embed-link';
 }
 ?>
 <a href="<?php echo esc_url( $display_url ); ?>" class="<?php echo esc_attr( $link_classes ); ?>" rel="ugc noopener">
-    <span class="extrch-link-page-link-text"><?php echo esc_html( $display_text ); ?></span>
-    <span class="extrch-link-page-link-icon">
-        <button class="extrch-share-trigger extrch-share-item-trigger"
-                aria-label="Share this link"
-                data-share-type="link"
-                data-share-url="<?php echo esc_url( $share_url ); ?>"
-                data-share-title="<?php echo esc_attr( $share_title ); ?>">
-            <i class="fas fa-ellipsis-v"></i>
-        </button>
-    </span>
+	<span class="extrch-link-page-link-text"><?php echo esc_html( $display_text ); ?></span>
+	<span class="extrch-link-page-link-icon">
+		<button class="extrch-share-trigger extrch-share-item-trigger"
+				aria-label="Share this link"
+				data-share-type="link"
+				data-share-url="<?php echo esc_url( $share_url ); ?>"
+				data-share-title="<?php echo esc_attr( $share_title ); ?>">
+			<i class="fas fa-ellipsis-v"></i>
+		</button>
+	</span>
 </a>

--- a/inc/link-pages/live/templates/components/social-icon.php
+++ b/inc/link-pages/live/templates/components/social-icon.php
@@ -7,41 +7,44 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-$args = wp_parse_args( $args ?? array(), array(
-    'social_data'    => array(),
-    'social_manager' => null,
-) );
+$args = wp_parse_args(
+	$args ?? array(),
+	array(
+		'social_data'    => array(),
+		'social_manager' => null,
+	)
+);
 
 $social_data    = $args['social_data'];
 $social_manager = $args['social_manager'];
 
 if ( empty( $social_data['url'] ) || empty( $social_data['type'] ) ) {
-    return;
+	return;
 }
 
 if ( ! $social_manager && function_exists( 'extrachill_artist_platform_social_links' ) ) {
-    $social_manager = extrachill_artist_platform_social_links();
+	$social_manager = extrachill_artist_platform_social_links();
 }
 
 if ( ! $social_manager ) {
-    return;
+	return;
 }
 
 $icon_class = $social_manager->get_icon_class( $social_data['type'], $social_data );
 $label      = $social_manager->get_link_label( $social_data );
 
 if ( empty( $icon_class ) ) {
-    return;
+	return;
 }
 ?>
 <a href="<?php echo esc_url( $social_data['url'] ); ?>"
-   class="extrch-social-icon"
-   target="_blank"
-   rel="ugc noopener noreferrer"
-   title="<?php echo esc_attr( $label ); ?>"
-   aria-label="<?php echo esc_attr( $label ); ?>">
-    <i class="<?php echo esc_attr( $icon_class ); ?>"></i>
+	class="extrch-social-icon"
+	target="_blank"
+	rel="ugc noopener noreferrer"
+	title="<?php echo esc_attr( $label ); ?>"
+	aria-label="<?php echo esc_attr( $label ); ?>">
+	<i class="<?php echo esc_attr( $icon_class ); ?>"></i>
 </a>

--- a/inc/link-pages/live/templates/components/social-icons-container.php
+++ b/inc/link-pages/live/templates/components/social-icons-container.php
@@ -7,50 +7,58 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
-$args = wp_parse_args( $args ?? array(), array(
-    'social_links'   => array(),
-    'position'       => 'above',
-    'social_manager' => null,
-) );
+$args = wp_parse_args(
+	$args ?? array(),
+	array(
+		'social_links'   => array(),
+		'position'       => 'above',
+		'social_manager' => null,
+	)
+);
 
 $social_links   = $args['social_links'];
 $position       = $args['position'];
 $social_manager = $args['social_manager'];
 
 if ( empty( $social_links ) || ! is_array( $social_links ) ) {
-    return;
+	return;
 }
 
 if ( ! $social_manager && function_exists( 'extrachill_artist_platform_social_links' ) ) {
-    $social_manager = extrachill_artist_platform_social_links();
+	$social_manager = extrachill_artist_platform_social_links();
 }
 
 if ( ! $social_manager ) {
-    return;
+	return;
 }
 
 $container_classes = 'extrch-link-page-socials';
 if ( 'below' === $position ) {
-    $container_classes .= ' extrch-socials-below';
+	$container_classes .= ' extrch-socials-below';
 }
 
-$valid_social_links = array_filter( $social_links, function( $link ) {
-    return ! empty( $link['url'] ) && ! empty( $link['type'] );
-} );
+$valid_social_links = array_filter(
+	$social_links,
+	function ( $link ) {
+		return ! empty( $link['url'] ) && ! empty( $link['type'] );
+	}
+);
 
 if ( empty( $valid_social_links ) ) {
-    return;
+	return;
 }
 ?>
 <div class="<?php echo esc_attr( $container_classes ); ?>">
-    <?php foreach ( $valid_social_links as $social_link ) :
-        $icon_args = array(
-            'social_data'    => $social_link,
-            'social_manager' => $social_manager,
-        );
-        echo ec_render_template( 'social-icon', $icon_args );
-    endforeach; ?>
+	<?php
+	foreach ( $valid_social_links as $social_link ) :
+		$icon_args = array(
+			'social_data'    => $social_link,
+			'social_manager' => $social_manager,
+		);
+		echo ec_render_template( 'social-icon', $icon_args );
+	endforeach;
+	?>
 </div>

--- a/inc/link-pages/live/templates/extrch-link-page-template.php
+++ b/inc/link-pages/live/templates/extrch-link-page-template.php
@@ -13,51 +13,51 @@
 
 // If $data is not already set by the caller (e.g., REST API handler or direct include with params), then fetch it.
 if ( ! isset( $data ) || ! is_array( $data ) ) {
-    // Resolve IDs using centralized helpers with sensible fallbacks
-    if ( ! isset( $link_page_id ) || ! is_numeric( $link_page_id ) ) {
-        $link_page_id = apply_filters('ec_get_link_page_id', 0);
-    }
-    if ( ! isset( $artist_id ) || ! is_numeric( $artist_id ) ) {
-        $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-    }
+	// Resolve IDs using centralized helpers with sensible fallbacks
+	if ( ! isset( $link_page_id ) || ! is_numeric( $link_page_id ) ) {
+		$link_page_id = apply_filters( 'ec_get_link_page_id', 0 );
+	}
+	if ( ! isset( $artist_id ) || ! is_numeric( $artist_id ) ) {
+		$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+	}
 
-    // Ensure ec_get_link_page_data filter function is available.
-    $data_filter_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
-    if ( file_exists( $data_filter_path ) ) {
-        require_once $data_filter_path;
-    }
+	// Ensure ec_get_link_page_data filter function is available.
+	$data_filter_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
+	if ( file_exists( $data_filter_path ) ) {
+		require_once $data_filter_path;
+	}
 
-    if ( $link_page_id && $artist_id ) {
-        $data = ec_get_link_page_data( (int) $artist_id, (int) $link_page_id );
-    } else {
-        $data = array( 
-            'display_title' => 'Error: Link Page Data Unavailable',
-            'bio' => '',
-            'profile_img_url' => '',
-            'social_links' => array(),
-            'link_sections' => array(),
-            'powered_by' => true,
-            'css_vars' => array(),
-            'background_style' => 'background-color: #f0f0f0;',
-        );
-    }
+	if ( $link_page_id && $artist_id ) {
+		$data = ec_get_link_page_data( (int) $artist_id, (int) $link_page_id );
+	} else {
+		$data = array(
+			'display_title'    => 'Error: Link Page Data Unavailable',
+			'bio'              => '',
+			'profile_img_url'  => '',
+			'social_links'     => array(),
+			'link_sections'    => array(),
+			'powered_by'       => true,
+			'css_vars'         => array(),
+			'background_style' => 'background-color: #f0f0f0;',
+		);
+	}
 }
 
 // If $extrch_link_page_template_data is set (passed explicitly), use it as $data
-if (isset($extrch_link_page_template_data) && is_array($extrch_link_page_template_data)) {
-    $data = $extrch_link_page_template_data;
+if ( isset( $extrch_link_page_template_data ) && is_array( $extrch_link_page_template_data ) ) {
+	$data = $extrch_link_page_template_data;
 }
 
 // Ensure essential keys exist in $data to prevent undefined index errors,
 // especially if ec_get_link_page_data() might not return them all in some edge case.
-$data['powered_by'] = isset($data['powered_by']) ? $data['powered_by'] : true;
-$data['display_title'] = isset($data['display_title']) ? $data['display_title'] : '';
-$data['bio'] = isset($data['bio']) ? $data['bio'] : '';
-$data['profile_img_url'] = isset($data['profile_img_url']) ? $data['profile_img_url'] : '';
-$data['social_links'] = isset($data['social_links']) && is_array($data['social_links']) ? $data['social_links'] : [];
+$data['powered_by']      = isset( $data['powered_by'] ) ? $data['powered_by'] : true;
+$data['display_title']   = isset( $data['display_title'] ) ? $data['display_title'] : '';
+$data['bio']             = isset( $data['bio'] ) ? $data['bio'] : '';
+$data['profile_img_url'] = isset( $data['profile_img_url'] ) ? $data['profile_img_url'] : '';
+$data['social_links']    = isset( $data['social_links'] ) && is_array( $data['social_links'] ) ? $data['social_links'] : array();
 
 // ec_get_link_page_data() now returns 'link_sections' directly.
-$link_sections = isset($data['link_sections']) && is_array($data['link_sections']) ? $data['link_sections'] : [];
+$link_sections = isset( $data['link_sections'] ) && is_array( $data['link_sections'] ) ? $data['link_sections'] : array();
 
 // Determine the inline style for the container.
 // For the preview iframe, it receives 'initial_container_style_for_php_preview' via query_var.
@@ -66,8 +66,8 @@ $link_sections = isset($data['link_sections']) && is_array($data['link_sections'
 // We only apply the direct $data['background_style'] here if it's the preview iframe.
 
 $initial_container_style_attr = '';
-$container_classes = 'extrch-link-page-container'; // Base class
-$is_preview_iframe_context = false;
+$container_classes            = 'extrch-link-page-container'; // Base class
+$is_preview_iframe_context    = false;
 
 // For the public page (single-artist_link_page.php)
 // The .extrch-link-page-container's background should be handled by css/extrch-links.css.
@@ -83,34 +83,34 @@ $is_preview_iframe_context = false;
 
 // Determine profile image shape class
 $profile_img_shape_class = 'shape-square'; // Default to square
-if (isset($data['profile_img_shape'])) {
-    if ($data['profile_img_shape'] === 'circle') {
-        $profile_img_shape_class = 'shape-circle';
-    } elseif ($data['profile_img_shape'] === 'rectangle') {
-        $profile_img_shape_class = 'shape-rectangle';
-    } elseif ($data['profile_img_shape'] === 'square') {
-        $profile_img_shape_class = 'shape-square';
-    } else {
-        $profile_img_shape_class = 'shape-square'; // fallback for unknown values
-    }
+if ( isset( $data['profile_img_shape'] ) ) {
+	if ( $data['profile_img_shape'] === 'circle' ) {
+		$profile_img_shape_class = 'shape-circle';
+	} elseif ( $data['profile_img_shape'] === 'rectangle' ) {
+		$profile_img_shape_class = 'shape-rectangle';
+	} elseif ( $data['profile_img_shape'] === 'square' ) {
+		$profile_img_shape_class = 'shape-square';
+	} else {
+		$profile_img_shape_class = 'shape-square'; // fallback for unknown values
+	}
 }
 
-$overlay_enabled = isset($data['css_vars']['overlay']) ? $data['css_vars']['overlay'] === '1' : true;
-$wrapper_class = 'extrch-link-page-content-wrapper' . ($overlay_enabled ? '' : ' no-overlay');
+$overlay_enabled = isset( $data['css_vars']['overlay'] ) ? $data['css_vars']['overlay'] === '1' : true;
+$wrapper_class   = 'extrch-link-page-content-wrapper' . ( $overlay_enabled ? '' : ' no-overlay' );
 
 // Ensure all variables used in data attributes are defined in the scope
-$single_artist_link_page_id = isset($data['_actual_link_page_id_for_template']) ? $data['_actual_link_page_id_for_template'] : (isset($link_page_id) ? $link_page_id : 0);
-if (empty($single_artist_link_page_id) && isset($extrch_link_page_template_data['original_link_page_id'])) {
-    $single_artist_link_page_id = $extrch_link_page_template_data['original_link_page_id'];
+$single_artist_link_page_id = isset( $data['_actual_link_page_id_for_template'] ) ? $data['_actual_link_page_id_for_template'] : ( isset( $link_page_id ) ? $link_page_id : 0 );
+if ( empty( $single_artist_link_page_id ) && isset( $extrch_link_page_template_data['original_link_page_id'] ) ) {
+	$single_artist_link_page_id = $extrch_link_page_template_data['original_link_page_id'];
 }
 
-$artist_slug = isset($data['artist_profile']->post_name) ? $data['artist_profile']->post_name : '';
-$share_page_url = !empty($artist_slug) ? 'https://extrachill.link/' . $artist_slug : home_url('/');
+$artist_slug    = isset( $data['artist_profile']->post_name ) ? $data['artist_profile']->post_name : '';
+$share_page_url = ! empty( $artist_slug ) ? 'https://extrachill.link/' . $artist_slug : home_url( '/' );
 
-$bg_type = isset($data['css_vars']['--link-page-background-type']) ? $data['css_vars']['--link-page-background-type'] : 'color';
+$bg_type = isset( $data['css_vars']['--link-page-background-type'] ) ? $data['css_vars']['--link-page-background-type'] : 'color';
 
-if (isset($data) && is_array($data)) {
-    $data['original_link_page_id'] = $link_page_id; 
+if ( isset( $data ) && is_array( $data ) ) {
+	$data['original_link_page_id'] = $link_page_id;
 }
 
 // Fetch subscribe display mode setting
@@ -123,98 +123,110 @@ $body_bg_style = '';
 
 
 ?>
-<div class="<?php echo esc_attr($container_classes); ?>"
-     data-bg-type="<?php echo esc_attr($bg_type); ?>"
-     <?php echo $initial_container_style_attr; ?>>
-    <div class="<?php echo esc_attr($wrapper_class); ?>" style="flex-grow:1;">
-        <div class="extrch-link-page-header-content">
-            <?php 
-            // Absolutely positioned bell (subscribe) and ellipses (share) triggers in top left/right
-            if ($subscribe_display_mode === 'icon_modal') : ?>
-                <button class="extrch-share-trigger extrch-subscribe-icon-trigger extrch-bell-page-trigger" aria-label="Subscribe to this artist">
-                    <i class="fas fa-bell"></i>
-                </button>
-            <?php endif; ?>
-            <button class="extrch-share-trigger extrch-share-page-trigger" aria-label="Share this page" data-share-type="page" data-share-url="<?php echo esc_url($share_page_url); ?>" data-share-title="<?php echo esc_attr($data['display_title']); ?>">
-                <i class="fas fa-ellipsis-h"></i>
-            </button>
-            <!-- Main flex content below -->
-            <?php 
-            $img_container_classes = "extrch-link-page-profile-img " . $profile_img_shape_class;
-            $no_image_class = empty($data['profile_img_url']) ? ' no-image' : '';
-            if ($is_preview_iframe_context) : ?>
-                <div class="<?php echo esc_attr($img_container_classes . $no_image_class); ?>">
-                    <img src="<?php echo esc_url($data['profile_img_url']); ?>" alt="<?php echo esc_attr($data['display_title']); ?>">
-                </div>
-            <?php elseif (!empty($data['profile_img_url'])): ?>
-                <div class="<?php echo esc_attr($img_container_classes); ?>"><img src="<?php echo esc_url($data['profile_img_url']); ?>" alt="<?php echo esc_attr($data['display_title']); ?>"></div>
-            <?php endif; ?>
-            <h1 class="extrch-link-page-title"><?php echo esc_html( $data['display_title'] ); ?></h1>
-            <?php if (!empty($data['bio'])): ?><div class="extrch-link-page-bio"><?php echo esc_html($data['bio']); ?></div><?php endif; ?>
-        </div>
+<div class="<?php echo esc_attr( $container_classes ); ?>"
+	data-bg-type="<?php echo esc_attr( $bg_type ); ?>"
+	<?php echo $initial_container_style_attr; ?>>
+	<div class="<?php echo esc_attr( $wrapper_class ); ?>" style="flex-grow:1;">
+		<div class="extrch-link-page-header-content">
+			<?php
+			// Absolutely positioned bell (subscribe) and ellipses (share) triggers in top left/right
+			if ( $subscribe_display_mode === 'icon_modal' ) :
+				?>
+				<button class="extrch-share-trigger extrch-subscribe-icon-trigger extrch-bell-page-trigger" aria-label="Subscribe to this artist">
+					<i class="fas fa-bell"></i>
+				</button>
+			<?php endif; ?>
+			<button class="extrch-share-trigger extrch-share-page-trigger" aria-label="Share this page" data-share-type="page" data-share-url="<?php echo esc_url( $share_page_url ); ?>" data-share-title="<?php echo esc_attr( $data['display_title'] ); ?>">
+				<i class="fas fa-ellipsis-h"></i>
+			</button>
+			<!-- Main flex content below -->
+			<?php
+			$img_container_classes = 'extrch-link-page-profile-img ' . $profile_img_shape_class;
+			$no_image_class        = empty( $data['profile_img_url'] ) ? ' no-image' : '';
+			if ( $is_preview_iframe_context ) :
+				?>
+				<div class="<?php echo esc_attr( $img_container_classes . $no_image_class ); ?>">
+					<img src="<?php echo esc_url( $data['profile_img_url'] ); ?>" alt="<?php echo esc_attr( $data['display_title'] ); ?>">
+				</div>
+			<?php elseif ( ! empty( $data['profile_img_url'] ) ) : ?>
+				<div class="<?php echo esc_attr( $img_container_classes ); ?>"><img src="<?php echo esc_url( $data['profile_img_url'] ); ?>" alt="<?php echo esc_attr( $data['display_title'] ); ?>"></div>
+			<?php endif; ?>
+			<h1 class="extrch-link-page-title"><?php echo esc_html( $data['display_title'] ); ?></h1>
+			<?php
+			if ( ! empty( $data['bio'] ) ) :
+				?>
+				<div class="extrch-link-page-bio"><?php echo esc_html( $data['bio'] ); ?></div><?php endif; ?>
+		</div>
 
-        <?php 
-        // Conditionally render social icons ABOVE regular links using filter system
-        if ($social_icons_position === 'above' && !empty($data['social_links'])) {
-            echo ec_render_social_icons_container($data['social_links'], 'above');
-        } // end if $social_icons_position === 'above'
+		<?php
+		// Conditionally render social icons ABOVE regular links using filter system
+		if ( $social_icons_position === 'above' && ! empty( $data['social_links'] ) ) {
+			echo ec_render_social_icons_container( $data['social_links'], 'above' );
+		} // end if $social_icons_position === 'above'
 
-        // Prepare for rendering actual link sections
-        // ...
-        ?>
-        <?php if (!empty($link_sections)): ?>
-            <?php 
-            foreach ($link_sections as $section):
-                $section_args = array(
-                    'section_title' => $section['section_title'] ?? '',
-                    'links' => $section['links'] ?? array(),
-                    'link_page_id' => $link_page_id
-                );
-                echo ec_render_link_section( $section, $section_args );
-            endforeach; 
-            ?>
-        <?php endif; ?>
-        <?php
-        // Output the inline subscribe form below all links if in inline_form mode
-        if ($subscribe_display_mode === 'inline_form') {
-            echo ec_render_template('subscribe-inline-form', array(
-                'artist_id' => $artist_id,
-                'data' => $data
-            ));
-        }
-        // Output the modal partial (but not the bell icon) if in icon_modal mode
-        if ($subscribe_display_mode === 'icon_modal') {
-            echo ec_render_template('subscribe-modal', array(
-                'artist_id' => $artist_id,
-                'data' => $data
-            ));
-        }
+		// Prepare for rendering actual link sections
+		// ...
+		?>
+		<?php if ( ! empty( $link_sections ) ) : ?>
+			<?php
+			foreach ( $link_sections as $section ) :
+				$section_args = array(
+					'section_title' => $section['section_title'] ?? '',
+					'links'         => $section['links'] ?? array(),
+					'link_page_id'  => $link_page_id,
+				);
+				echo ec_render_link_section( $section, $section_args );
+			endforeach;
+			?>
+		<?php endif; ?>
+		<?php
+		// Output the inline subscribe form below all links if in inline_form mode
+		if ( $subscribe_display_mode === 'inline_form' ) {
+			echo ec_render_template(
+				'subscribe-inline-form',
+				array(
+					'artist_id' => $artist_id,
+					'data'      => $data,
+				)
+			);
+		}
+		// Output the modal partial (but not the bell icon) if in icon_modal mode
+		if ( $subscribe_display_mode === 'icon_modal' ) {
+			echo ec_render_template(
+				'subscribe-modal',
+				array(
+					'artist_id' => $artist_id,
+					'data'      => $data,
+				)
+			);
+		}
 
-        // Conditionally render social icons below links (and below subscribe form if present) using filter system
-        if ($social_icons_position === 'below' && !empty($data['social_links'])) {
-            echo ec_render_social_icons_container($data['social_links'], 'below');
-        }
-        ?>
+		// Conditionally render social icons below links (and below subscribe form if present) using filter system
+		if ( $social_icons_position === 'below' && ! empty( $data['social_links'] ) ) {
+			echo ec_render_social_icons_container( $data['social_links'], 'below' );
+		}
+		?>
 
-        <?php if ($data['powered_by']):
-            // Route the generic footer credit to the main site's network discovery page,
-            // with UTM params for attribution.
-            $powered_by_url = ec_get_site_url('main') . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power';
-        ?>
-        <div class="extrch-link-page-powered" style="margin-top:auto; padding-top:1em; padding-bottom:1em;">
-            <a href="<?php echo esc_url($powered_by_url); ?>" rel="noopener">Powered by Extra Chill</a>
-        </div>
-        <?php endif; ?>
-    </div>
+		<?php
+		if ( $data['powered_by'] ) :
+			// Route the generic footer credit to the main site's network discovery page,
+			// with UTM params for attribution.
+			$powered_by_url = ec_get_site_url( 'main' ) . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power';
+			?>
+		<div class="extrch-link-page-powered" style="margin-top:auto; padding-top:1em; padding-bottom:1em;">
+			<a href="<?php echo esc_url( $powered_by_url ); ?>" rel="noopener">Powered by Extra Chill</a>
+		</div>
+		<?php endif; ?>
+	</div>
 
-    <?php
-    // Include reusable share modal template (JS populates and controls it)
-    echo ec_render_template('share-modal');
-    ?>
+	<?php
+	// Include reusable share modal template (JS populates and controls it)
+	echo ec_render_template( 'share-modal' );
+	?>
 
-    <?php
-    // Edit button rendered client-side via JavaScript
-    // REST API check to artist.extrachill.com where WordPress cookies are validated
-    // JavaScript injects button if user has permission
-    ?>
+	<?php
+	// Edit button rendered client-side via JavaScript
+	// REST API check to artist.extrachill.com where WordPress cookies are validated
+	// JavaScript injects button if user has permission
+	?>
 </div>

--- a/inc/link-pages/live/templates/extrch-share-modal.php
+++ b/inc/link-pages/live/templates/extrch-share-modal.php
@@ -7,51 +7,53 @@
  * on trigger buttons.
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 <div id="extrch-share-modal" class="extrch-share-modal extrch-modal extrch-modal-hidden" role="dialog" aria-modal="true" aria-labelledby="extrch-share-modal-title">
-    <div class="extrch-share-modal-overlay extrch-modal-overlay"></div>
-    <div class="extrch-share-modal-content extrch-modal-content" data-bg-type="color">
-        <button class="extrch-share-modal-close extrch-modal-close" aria-label="<?php esc_attr_e('Close share modal', 'extrachill-artist-platform'); ?>">&times;</button>
+	<div class="extrch-share-modal-overlay extrch-modal-overlay"></div>
+	<div class="extrch-share-modal-content extrch-modal-content" data-bg-type="color">
+		<button class="extrch-share-modal-close extrch-modal-close" aria-label="<?php esc_attr_e( 'Close share modal', 'extrachill-artist-platform' ); ?>">&times;</button>
 
-        <div class="extrch-share-modal-header">
-            <img class="extrch-share-modal-profile-img extrch-share-profile-img-hidden" src="" alt="" />
-            <div class="extrch-share-modal-titles">
-                <h3 id="extrch-share-modal-title" class="extrch-share-modal-main-title"></h3>
-                <p class="extrch-share-modal-subtitle"></p>
-            </div>
-        </div>
+		<div class="extrch-share-modal-header">
+			<img class="extrch-share-modal-profile-img extrch-share-profile-img-hidden" src="" alt="" />
+			<div class="extrch-share-modal-titles">
+				<h3 id="extrch-share-modal-title" class="extrch-share-modal-main-title"></h3>
+				<p class="extrch-share-modal-subtitle"></p>
+			</div>
+		</div>
 
-        <div class="extrch-share-modal-options-grid extrch-share-modal-options">
-            <!-- Native share (shown only when supported) -->
-            <button type="button" class="extrch-share-option-button button-2 button-medium extrch-share-option-native extrch-modal-hidden">
-                <span class="extrch-share-option-icon"><i class="fas fa-share-square"></i></span>
-                <span class="extrch-share-option-label"><?php esc_html_e('Share', 'extrachill-artist-platform'); ?></span>
-            </button>
+		<div class="extrch-share-modal-options-grid extrch-share-modal-options">
+			<!-- Native share (shown only when supported) -->
+			<button type="button" class="extrch-share-option-button button-2 button-medium extrch-share-option-native extrch-modal-hidden">
+				<span class="extrch-share-option-icon"><i class="fas fa-share-square"></i></span>
+				<span class="extrch-share-option-label"><?php esc_html_e( 'Share', 'extrachill-artist-platform' ); ?></span>
+			</button>
 
-            <!-- Fallback social links (hidden when native share is available) -->
-            <a class="extrch-share-option-button button-2 button-medium extrch-share-option-facebook extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
-                <span class="extrch-share-option-icon"><i class="fab fa-facebook"></i></span>
-                <span class="extrch-share-option-label">Facebook</span>
-            </a>
-            <a class="extrch-share-option-button button-2 button-medium extrch-share-option-twitter extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
-                <span class="extrch-share-option-icon"><i class="fab fa-x-twitter"></i></span>
-                <span class="extrch-share-option-label">X</span>
-            </a>
-            <a class="extrch-share-option-button button-2 button-medium extrch-share-option-linkedin extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
-                <span class="extrch-share-option-icon"><i class="fab fa-linkedin"></i></span>
-                <span class="extrch-share-option-label">LinkedIn</span>
-            </a>
-            <a class="extrch-share-option-button button-2 button-medium extrch-share-option-email extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
-                <span class="extrch-share-option-icon"><i class="fas fa-envelope"></i></span>
-                <span class="extrch-share-option-label"><?php esc_html_e('Email', 'extrachill-artist-platform'); ?></span>
-            </a>
+			<!-- Fallback social links (hidden when native share is available) -->
+			<a class="extrch-share-option-button button-2 button-medium extrch-share-option-facebook extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
+				<span class="extrch-share-option-icon"><i class="fab fa-facebook"></i></span>
+				<span class="extrch-share-option-label">Facebook</span>
+			</a>
+			<a class="extrch-share-option-button button-2 button-medium extrch-share-option-twitter extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
+				<span class="extrch-share-option-icon"><i class="fab fa-x-twitter"></i></span>
+				<span class="extrch-share-option-label">X</span>
+			</a>
+			<a class="extrch-share-option-button button-2 button-medium extrch-share-option-linkedin extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
+				<span class="extrch-share-option-icon"><i class="fab fa-linkedin"></i></span>
+				<span class="extrch-share-option-label">LinkedIn</span>
+			</a>
+			<a class="extrch-share-option-button button-2 button-medium extrch-share-option-email extrch-share-option-visible" href="#" target="_blank" rel="ugc noopener">
+				<span class="extrch-share-option-icon"><i class="fas fa-envelope"></i></span>
+				<span class="extrch-share-option-label"><?php esc_html_e( 'Email', 'extrachill-artist-platform' ); ?></span>
+			</a>
 
-            <!-- Copy link (always available) -->
-            <button type="button" class="extrch-share-option-button button-2 button-medium extrch-share-option-copy-link">
-                <span class="extrch-share-option-icon"><i class="fas fa-copy"></i></span>
-                <span class="extrch-share-option-label"><?php esc_html_e('Copy Link', 'extrachill-artist-platform'); ?></span>
-            </button>
-        </div>
-    </div>
+			<!-- Copy link (always available) -->
+			<button type="button" class="extrch-share-option-button button-2 button-medium extrch-share-option-copy-link">
+				<span class="extrch-share-option-icon"><i class="fas fa-copy"></i></span>
+				<span class="extrch-share-option-label"><?php esc_html_e( 'Copy Link', 'extrachill-artist-platform' ); ?></span>
+			</button>
+		</div>
+	</div>
 </div>

--- a/inc/link-pages/live/templates/single-artist_link_page.php
+++ b/inc/link-pages/live/templates/single-artist_link_page.php
@@ -15,51 +15,51 @@ global $wp_query; // Make sure $wp_query is available
 // Use the current post as the link page
 $link_page = $wp_query->get_queried_object(); // Get the post object from the main query
 
-if ( !$link_page || !isset($link_page->ID) || $link_page->post_type !== 'artist_link_page' ) {
-    
-    // If the queried object isn't what we expect, then it's a genuine issue.
-    http_response_code(404);
-    echo '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>Not Found</title></head><body><h1>Link Page Not Found (Invalid Query)</h1></body></html>';
-    exit;
+if ( ! $link_page || ! isset( $link_page->ID ) || $link_page->post_type !== 'artist_link_page' ) {
+
+	// If the queried object isn't what we expect, then it's a genuine issue.
+	http_response_code( 404 );
+	echo '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>Not Found</title></head><body><h1>Link Page Not Found (Invalid Query)</h1></body></html>';
+	exit;
 }
 
 $link_page_id = $link_page->ID;
 
-$artist_id = apply_filters('ec_get_artist_id', $link_page_id);
+$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
 
-$artist_profile = $artist_id ? get_post($artist_id) : null;
+$artist_profile = $artist_id ? get_post( $artist_id ) : null;
 
-if ( !$artist_profile ) {
-    http_response_code(404);
-    echo '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>Not Found</title></head><body><h1>Link Page Not Found</h1></body></html>';
-    exit;
+if ( ! $artist_profile ) {
+	http_response_code( 404 );
+	echo '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width,initial-scale=1"><title>Not Found</title></head><body><h1>Link Page Not Found</h1></body></html>';
+	exit;
 }
 
 // Ensure ec_get_link_page_data filter function is available.
 if ( ! function_exists( 'ec_get_link_page_data' ) ) {
-    $data_filter_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
-    if ( file_exists( $data_filter_path ) ) {
-        require_once $data_filter_path;
-    }
+	$data_filter_path = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/data.php';
+	if ( file_exists( $data_filter_path ) ) {
+		require_once $data_filter_path;
+	}
 }
 
-$data = ec_get_link_page_data( $artist_id, $link_page_id );
+$data                          = ec_get_link_page_data( $artist_id, $link_page_id );
 $data['original_link_page_id'] = $link_page_id;
 
-$body_bg_style = '';
-$background_type = isset($data['background_type']) ? $data['background_type'] : ec_get_link_page_default( 'settings', 'background_type', 'color' );
-$background_image_url = isset($data['background_image_url']) ? $data['background_image_url'] : '';
-$background_color = isset($data['background_color']) ? $data['background_color'] : ec_get_link_page_default( 'settings', 'background_color', '#1a1a1a' );
-$background_gradient_start = isset($data['background_gradient_start']) ? $data['background_gradient_start'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-start', '#0b5394' );
-$background_gradient_end = isset($data['background_gradient_end']) ? $data['background_gradient_end'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-end', '#53940b' );
-$background_gradient_direction = isset($data['background_gradient_direction']) ? $data['background_gradient_direction'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-direction', 'to right' );
+$body_bg_style                 = '';
+$background_type               = isset( $data['background_type'] ) ? $data['background_type'] : ec_get_link_page_default( 'settings', 'background_type', 'color' );
+$background_image_url          = isset( $data['background_image_url'] ) ? $data['background_image_url'] : '';
+$background_color              = isset( $data['background_color'] ) ? $data['background_color'] : ec_get_link_page_default( 'settings', 'background_color', '#1a1a1a' );
+$background_gradient_start     = isset( $data['background_gradient_start'] ) ? $data['background_gradient_start'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-start', '#0b5394' );
+$background_gradient_end       = isset( $data['background_gradient_end'] ) ? $data['background_gradient_end'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-end', '#53940b' );
+$background_gradient_direction = isset( $data['background_gradient_direction'] ) ? $data['background_gradient_direction'] : ec_get_link_page_default( 'styles', '--link-page-background-gradient-direction', 'to right' );
 
-if ($background_type === 'image' && !empty($background_image_url)) {
-    $body_bg_style = 'background-image:url(' . esc_url($background_image_url) . ');background-size:cover;background-position:center;background-repeat:no-repeat;background-attachment:fixed;';
-} elseif ($background_type === 'gradient') {
-    $body_bg_style = 'background:linear-gradient(' . esc_attr($background_gradient_direction) . ', ' . esc_attr($background_gradient_start) . ', ' . esc_attr($background_gradient_end) . ');background-attachment:fixed;';
+if ( $background_type === 'image' && ! empty( $background_image_url ) ) {
+	$body_bg_style = 'background-image:url(' . esc_url( $background_image_url ) . ');background-size:cover;background-position:center;background-repeat:no-repeat;background-attachment:fixed;';
+} elseif ( $background_type === 'gradient' ) {
+	$body_bg_style = 'background:linear-gradient(' . esc_attr( $background_gradient_direction ) . ', ' . esc_attr( $background_gradient_start ) . ', ' . esc_attr( $background_gradient_end ) . ');background-attachment:fixed;';
 } else { // 'color' or default
-    $body_bg_style = 'background-color:' . esc_attr($background_color) . ';';
+	$body_bg_style = 'background-color:' . esc_attr( $background_color ) . ';';
 }
 // Ensure body takes full height
 $body_bg_style .= 'min-height:100vh;';
@@ -67,38 +67,43 @@ $body_bg_style .= 'min-height:100vh;';
 ?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-    <?php
-    // Call the custom head function to output minimal, necessary head elements
-    if (function_exists('extrachill_artist_link_page_custom_head')) {
-        extrachill_artist_link_page_custom_head( $artist_id, $link_page_id );
-    } else {
-        // Fallback basic meta if the function isn't loaded, though it should be.
-        echo '<meta charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
-        echo '<meta name="viewport" content="width=device-width,initial-scale=1">';
-        $artist_title_fallback = $artist_id ? get_the_title( $artist_id ) : 'Link Page';
-        echo '<title>' . esc_html( $artist_title_fallback ) . ' | extrachill.link</title>';
-    }
-    ?>
+	<?php
+	// Call the custom head function to output minimal, necessary head elements
+	if ( function_exists( 'extrachill_artist_link_page_custom_head' ) ) {
+		extrachill_artist_link_page_custom_head( $artist_id, $link_page_id );
+	} else {
+		// Fallback basic meta if the function isn't loaded, though it should be.
+		echo '<meta charset="' . esc_attr( get_bloginfo( 'charset' ) ) . '">';
+		echo '<meta name="viewport" content="width=device-width,initial-scale=1">';
+		$artist_title_fallback = $artist_id ? get_the_title( $artist_id ) : 'Link Page';
+		echo '<title>' . esc_html( $artist_title_fallback ) . ' | extrachill.link</title>';
+	}
+	?>
 </head>
 <?php
-$artist_site_url = ec_get_site_url( 'artist' );
-$api_base = $artist_site_url . '/wp-json/extrachill/v1';
+$artist_site_url     = ec_get_site_url( 'artist' );
+$api_base            = $artist_site_url . '/wp-json/extrachill/v1';
 $permissions_api_url = $api_base . '/artists/' . $artist_id . '/permissions';
-$subscribe_api_url = $api_base . '/artists/' . $artist_id . '/subscribe';
-$tracking_click_url = $api_base . '/analytics/click';
-$tracking_view_url = $api_base . '/analytics/view';
+$subscribe_api_url   = $api_base . '/artists/' . $artist_id . '/subscribe';
+$tracking_click_url  = $api_base . '/analytics/click';
+$tracking_view_url   = $api_base . '/analytics/view';
 // Bearer-token mint handoff on the artist site, where the .extrachill.com auth
 // cookie is first-party. The edit-button JS redirects here once to obtain a
 // short-lived token, which comes back in the URL fragment (see
 // extrachill-api/inc/auth/extrachill-link-token-handoff.php).
 $token_handoff_url = $artist_site_url . '/wp-admin/admin-post.php?action=ec_link_token_handoff';
 ?>
-<body class="extrch-link-page"<?php if ($body_bg_style) echo ' style="' . esc_attr( $body_bg_style ) . '"'; ?> data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-token-handoff-url="<?php echo esc_url( $token_handoff_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>" data-extrch-tracking-view-url="<?php echo esc_url( $tracking_view_url ); ?>">
+<body class="extrch-link-page"
+<?php
+if ( $body_bg_style ) {
+	echo ' style="' . esc_attr( $body_bg_style ) . '"';}
+?>
+data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-token-handoff-url="<?php echo esc_url( $token_handoff_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>" data-extrch-tracking-view-url="<?php echo esc_url( $tracking_view_url ); ?>">
 <?php
 // Google Tag Manager (noscript)
 ?>
 <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXKDLFD"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+			height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <?php
 /**
  * Edit button security model: client-side only rendering with zero server-side HTML.
@@ -115,14 +120,14 @@ $token_handoff_url = $artist_site_url . '/wp-admin/admin-post.php?action=ec_link
  * - Token mint handoff: extrachill-api/inc/auth/extrachill-link-token-handoff.php
  */
 
-    // Pass $data explicitly to the template so overlay and all settings are available
-    $extrch_link_page_template_data = $data;
-    // Add the link_page_id to the $extrch_link_page_template_data array as well for good measure
-    // though the template now tries to get it from $data['original_link_page_id'] first.
-    $extrch_link_page_template_data['original_link_page_id'] = $link_page_id;
+	// Pass $data explicitly to the template so overlay and all settings are available
+	$extrch_link_page_template_data = $data;
+	// Add the link_page_id to the $extrch_link_page_template_data array as well for good measure
+	// though the template now tries to get it from $data['original_link_page_id'] first.
+	$extrch_link_page_template_data['original_link_page_id'] = $link_page_id;
 
-    require EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/extrch-link-page-template.php';
-    ?>
-    <?php wp_print_footer_scripts(); // Output scripts enqueued for footer ?>
+	require EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/templates/extrch-link-page-template.php';
+?>
+	<?php wp_print_footer_scripts(); // Output scripts enqueued for footer ?>
 </body>
 </html> 

--- a/inc/link-pages/live/templates/subscribe-inline-form.php
+++ b/inc/link-pages/live/templates/subscribe-inline-form.php
@@ -8,31 +8,37 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$current_artist_id = apply_filters('ec_get_artist_id', isset($artist_id) ? compact('artist_id') : []);
+$current_artist_id = apply_filters( 'ec_get_artist_id', isset( $artist_id ) ? compact( 'artist_id' ) : array() );
 
-if (empty($current_artist_id)) {
-    return;
+if ( empty( $current_artist_id ) ) {
+	return;
 }
 
-$artist_name = isset($artist_name) ? $artist_name : (isset($data['display_title']) ? $data['display_title'] : '');
+$artist_name = isset( $artist_name ) ? $artist_name : ( isset( $data['display_title'] ) ? $data['display_title'] : '' );
 ?>
 
 <div class="extrch-link-page-subscribe-inline-form-container">
-    <h3 class="extrch-subscribe-header">
-        Subscribe<?php if (!empty($artist_name)) echo ' to ' . esc_html($artist_name); ?>
-    </h3>
-    <p><?php 
-    $subscribe_description = isset($data['_link_page_subscribe_description']) && $data['_link_page_subscribe_description'] !== '' ? $data['_link_page_subscribe_description'] : sprintf(__('Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform'), $artist_name);
-    echo esc_html($subscribe_description);
-    ?></p>
+	<h3 class="extrch-subscribe-header">
+		Subscribe
+		<?php
+		if ( ! empty( $artist_name ) ) {
+			echo ' to ' . esc_html( $artist_name );}
+		?>
+	</h3>
+	<p>
+	<?php
+	$subscribe_description = isset( $data['_link_page_subscribe_description'] ) && $data['_link_page_subscribe_description'] !== '' ? $data['_link_page_subscribe_description'] : sprintf( __( 'Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform' ), $artist_name );
+	echo esc_html( $subscribe_description );
+	?>
+	</p>
 
-    <form id="extrch-subscribe-form-inline" class="extrch-subscribe-form">
-        <div class="form-group">
-            <input type="email" name="subscriber_email" id="subscriber_email_inline" placeholder="<?php esc_attr_e('Your email address', 'extrachill-artist-platform'); ?>" required aria-label="<?php esc_attr_e('Email Address', 'extrachill-artist-platform'); ?>">
-        </div>
+	<form id="extrch-subscribe-form-inline" class="extrch-subscribe-form">
+		<div class="form-group">
+			<input type="email" name="subscriber_email" id="subscriber_email_inline" placeholder="<?php esc_attr_e( 'Your email address', 'extrachill-artist-platform' ); ?>" required aria-label="<?php esc_attr_e( 'Email Address', 'extrachill-artist-platform' ); ?>">
+		</div>
 
-        <button type="submit" class="button-1 button-medium"><?php esc_html_e('Subscribe', 'extrachill-artist-platform'); ?></button>
+		<button type="submit" class="button-1 button-medium"><?php esc_html_e( 'Subscribe', 'extrachill-artist-platform' ); ?></button>
 
-        <div class="extrch-form-message" aria-live="polite"></div>
-    </form>
+		<div class="extrch-form-message" aria-live="polite"></div>
+	</form>
 </div>

--- a/inc/link-pages/live/templates/subscribe-modal.php
+++ b/inc/link-pages/live/templates/subscribe-modal.php
@@ -8,38 +8,44 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$current_artist_id = apply_filters('ec_get_artist_id', isset($artist_id) ? compact('artist_id') : []);
+$current_artist_id = apply_filters( 'ec_get_artist_id', isset( $artist_id ) ? compact( 'artist_id' ) : array() );
 
-if (empty($current_artist_id)) {
-    return;
+if ( empty( $current_artist_id ) ) {
+	return;
 }
 
-$artist_name = isset($artist_name) ? $artist_name : (isset($data['display_title']) ? $data['display_title'] : '');
+$artist_name = isset( $artist_name ) ? $artist_name : ( isset( $data['display_title'] ) ? $data['display_title'] : '' );
 ?>
 
 <div id="extrch-subscribe-modal" class="extrch-subscribe-modal extrch-modal extrch-modal-hidden" role="dialog" aria-modal="true" aria-labelledby="extrch-subscribe-modal-title">
-    <div class="extrch-subscribe-modal-overlay extrch-modal-overlay"></div>
-    <div class="extrch-subscribe-modal-content extrch-modal-content">
-        <button class="extrch-subscribe-modal-close extrch-modal-close" aria-label="<?php esc_attr_e('Close subscription modal', 'extrachill-artist-platform'); ?>">&times;</button>
+	<div class="extrch-subscribe-modal-overlay extrch-modal-overlay"></div>
+	<div class="extrch-subscribe-modal-content extrch-modal-content">
+		<button class="extrch-subscribe-modal-close extrch-modal-close" aria-label="<?php esc_attr_e( 'Close subscription modal', 'extrachill-artist-platform' ); ?>">&times;</button>
 
-        <div class="extrch-subscribe-modal-header">
-            <h3 id="extrch-subscribe-modal-title" class="extrch-subscribe-header">
-                Subscribe<?php if (!empty($artist_name)) echo ' to ' . esc_html($artist_name); ?>
-            </h3>
-            <p><?php 
-            $subscribe_description = isset($data['_link_page_subscribe_description']) && $data['_link_page_subscribe_description'] !== '' ? $data['_link_page_subscribe_description'] : sprintf(__('Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform'), $artist_name);
-            echo esc_html($subscribe_description);
-            ?></p>
-        </div>
+		<div class="extrch-subscribe-modal-header">
+			<h3 id="extrch-subscribe-modal-title" class="extrch-subscribe-header">
+				Subscribe
+				<?php
+				if ( ! empty( $artist_name ) ) {
+					echo ' to ' . esc_html( $artist_name );}
+				?>
+			</h3>
+			<p>
+			<?php
+			$subscribe_description = isset( $data['_link_page_subscribe_description'] ) && $data['_link_page_subscribe_description'] !== '' ? $data['_link_page_subscribe_description'] : sprintf( __( 'Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform' ), $artist_name );
+			echo esc_html( $subscribe_description );
+			?>
+			</p>
+		</div>
 
-        <form id="extrch-subscribe-form-modal" class="extrch-subscribe-form">
-            <div class="form-group">
-                <input type="email" name="subscriber_email" id="subscriber_email_modal" placeholder="<?php esc_attr_e('Your email address', 'extrachill-artist-platform'); ?>" required aria-label="<?php esc_attr_e('Email Address', 'extrachill-artist-platform'); ?>">
-            </div>
+		<form id="extrch-subscribe-form-modal" class="extrch-subscribe-form">
+			<div class="form-group">
+				<input type="email" name="subscriber_email" id="subscriber_email_modal" placeholder="<?php esc_attr_e( 'Your email address', 'extrachill-artist-platform' ); ?>" required aria-label="<?php esc_attr_e( 'Email Address', 'extrachill-artist-platform' ); ?>">
+			</div>
 
-            <button type="submit" class="button-1 button-medium"><?php esc_html_e('Subscribe', 'extrachill-artist-platform'); ?></button>
+			<button type="submit" class="button-1 button-medium"><?php esc_html_e( 'Subscribe', 'extrachill-artist-platform' ); ?></button>
 
-            <div class="extrch-form-message" aria-live="polite"></div>
-        </form>
-    </div>
+			<div class="extrch-form-message" aria-live="polite"></div>
+		</form>
+	</div>
 </div>

--- a/inc/link-pages/management/advanced-tab/google-tag-tracking.php
+++ b/inc/link-pages/management/advanced-tab/google-tag-tracking.php
@@ -12,49 +12,49 @@ defined( 'ABSPATH' ) || exit;
  * Validate Google Tag ID format (G-* for GA4, AW-* for Google Ads)
  */
 function extrachill_artist_validate_google_tag_id( $tag_id ) {
-    if ( empty( $tag_id ) ) {
-        return true;
-    }
+	if ( empty( $tag_id ) ) {
+		return true;
+	}
 
-    return preg_match( '/^(G|AW)-[a-zA-Z0-9]+$/', $tag_id );
+	return preg_match( '/^(G|AW)-[a-zA-Z0-9]+$/', $tag_id );
 }
 
 function extrachill_artist_get_google_tag_id( $artist_id, $link_page_id ) {
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    return $data['settings']['google_tag_id'] ?? '';
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
+	return $data['settings']['google_tag_id'] ?? '';
 }
 
 function extrachill_artist_is_google_tag_enabled( $artist_id, $link_page_id ) {
-    $tag_id = extrachill_artist_get_google_tag_id( $artist_id, $link_page_id );
-    return ! empty( $tag_id ) && extrachill_artist_validate_google_tag_id( $tag_id );
+	$tag_id = extrachill_artist_get_google_tag_id( $artist_id, $link_page_id );
+	return ! empty( $tag_id ) && extrachill_artist_validate_google_tag_id( $tag_id );
 }
 
 /**
  * Determine tag type from ID prefix
  */
 function extrachill_artist_get_google_tag_type( $tag_id ) {
-    if ( empty( $tag_id ) ) {
-        return 'unknown';
-    }
+	if ( empty( $tag_id ) ) {
+		return 'unknown';
+	}
 
-    if ( strpos( $tag_id, 'G-' ) === 0 ) {
-        return 'ga4';
-    }
+	if ( strpos( $tag_id, 'G-' ) === 0 ) {
+		return 'ga4';
+	}
 
-    if ( strpos( $tag_id, 'AW-' ) === 0 ) {
-        return 'ads';
-    }
+	if ( strpos( $tag_id, 'AW-' ) === 0 ) {
+		return 'ads';
+	}
 
-    return 'unknown';
+	return 'unknown';
 }
 
 function extrachill_artist_get_google_tag_settings( $artist_id, $link_page_id ) {
-    $tag_id = extrachill_artist_get_google_tag_id( $artist_id, $link_page_id );
+	$tag_id = extrachill_artist_get_google_tag_id( $artist_id, $link_page_id );
 
-    return array(
-        'tag_id'      => $tag_id,
-        'is_enabled'  => extrachill_artist_is_google_tag_enabled( $artist_id, $link_page_id ),
-        'is_valid'    => extrachill_artist_validate_google_tag_id( $tag_id ),
-        'tag_type'    => extrachill_artist_get_google_tag_type( $tag_id ),
-    );
+	return array(
+		'tag_id'     => $tag_id,
+		'is_enabled' => extrachill_artist_is_google_tag_enabled( $artist_id, $link_page_id ),
+		'is_valid'   => extrachill_artist_validate_google_tag_id( $tag_id ),
+		'tag_type'   => extrachill_artist_get_google_tag_type( $tag_id ),
+	);
 }

--- a/inc/link-pages/management/advanced-tab/link-expiration.php
+++ b/inc/link-pages/management/advanced-tab/link-expiration.php
@@ -2,58 +2,66 @@
 /**
  * Link Expiration Cron Cleanup for extrch.link Link Pages
  */
-add_action('extrachill_artist_cleanup_expired_links_event', function() {
-    $args = array(
-        'post_type'      => 'artist_link_page',
-        'post_status'    => 'any',
-        'posts_per_page' => -1,
-        'fields'         => 'ids',
-    );
-    $link_pages = get_posts($args);
-    $now = current_time('timestamp');
-    foreach ($link_pages as $link_page_id) {
-        $artist_id = apply_filters('ec_get_artist_id', $link_page_id);
-        if (!$artist_id) {
-            continue;
-        }
+add_action(
+	'extrachill_artist_cleanup_expired_links_event',
+	function () {
+		$args       = array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'any',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		);
+		$link_pages = get_posts( $args );
+		$now        = current_time( 'timestamp' );
+		foreach ( $link_pages as $link_page_id ) {
+			$artist_id = apply_filters( 'ec_get_artist_id', $link_page_id );
+			if ( ! $artist_id ) {
+				continue;
+			}
 
-        $data = ec_get_link_page_data($artist_id, $link_page_id);
-        $expiration_enabled = $data['settings']['link_expiration_enabled'] ?? false;
-        if (!$expiration_enabled) {
-            continue;
-        }
+			$data               = ec_get_link_page_data( $artist_id, $link_page_id );
+			$expiration_enabled = $data['settings']['link_expiration_enabled'] ?? false;
+			if ( ! $expiration_enabled ) {
+				continue;
+			}
 
-        $links = $data['links'] ?? [];
-        if (!is_array($links)) {
-            continue;
-        }
+			$links = $data['links'] ?? array();
+			if ( ! is_array( $links ) ) {
+				continue;
+			}
 
-        $changed = false;
-        foreach ($links as $section_idx => &$section) {
-            if (isset($section['links']) && is_array($section['links'])) {
-                foreach ($section['links'] as $link_idx => $link) {
-                    if (!empty($link['expires_at'])) {
-                        $expires = strtotime($link['expires_at']);
-                        if ($expires !== false && $expires <= $now) {
-                            unset($section['links'][$link_idx]);
-                            $changed = true;
-                        }
-                    }
-                }
-                if (isset($section['links'])) {
-                    $section['links'] = array_values($section['links']);
-                }
-            }
-        }
-        $links = array_values(array_filter($links, function($section) {
-            return !empty($section['links']);
-        }));
-        if ($changed) {
-            update_post_meta($link_page_id, '_link_page_links', $links);
-            do_action('ec_link_page_save', $link_page_id);
-        }
-    }
-});
-if (!wp_next_scheduled('extrachill_artist_cleanup_expired_links_event')) {
-    wp_schedule_event(time(), 'hourly', 'extrachill_artist_cleanup_expired_links_event');
+			$changed = false;
+			foreach ( $links as $section_idx => &$section ) {
+				if ( isset( $section['links'] ) && is_array( $section['links'] ) ) {
+					foreach ( $section['links'] as $link_idx => $link ) {
+						if ( ! empty( $link['expires_at'] ) ) {
+							$expires = strtotime( $link['expires_at'] );
+							if ( $expires !== false && $expires <= $now ) {
+								unset( $section['links'][ $link_idx ] );
+								$changed = true;
+							}
+						}
+					}
+					if ( isset( $section['links'] ) ) {
+						$section['links'] = array_values( $section['links'] );
+					}
+				}
+			}
+			$links = array_values(
+				array_filter(
+					$links,
+					function ( $section ) {
+						return ! empty( $section['links'] );
+					}
+				)
+			);
+			if ( $changed ) {
+				update_post_meta( $link_page_id, '_link_page_links', $links );
+				do_action( 'ec_link_page_save', $link_page_id );
+			}
+		}
+	}
+);
+if ( ! wp_next_scheduled( 'extrachill_artist_cleanup_expired_links_event' ) ) {
+	wp_schedule_event( time(), 'hourly', 'extrachill_artist_cleanup_expired_links_event' );
 }

--- a/inc/link-pages/management/advanced-tab/meta-pixel-tracking.php
+++ b/inc/link-pages/management/advanced-tab/meta-pixel-tracking.php
@@ -18,12 +18,12 @@ defined( 'ABSPATH' ) || exit;
  * @return bool True if valid, false otherwise
  */
 function extrachill_artist_validate_meta_pixel_id( $pixel_id ) {
-    if ( empty( $pixel_id ) ) {
-        return true; // Empty is valid (disabled)
-    }
+	if ( empty( $pixel_id ) ) {
+		return true; // Empty is valid (disabled)
+	}
 
-    // Meta Pixel IDs are typically 15-16 digit numbers
-    return ctype_digit( $pixel_id ) && strlen( $pixel_id ) >= 15 && strlen( $pixel_id ) <= 16;
+	// Meta Pixel IDs are typically 15-16 digit numbers
+	return ctype_digit( $pixel_id ) && strlen( $pixel_id ) >= 15 && strlen( $pixel_id ) <= 16;
 }
 
 /**
@@ -34,8 +34,8 @@ function extrachill_artist_validate_meta_pixel_id( $pixel_id ) {
  * @return string The Meta Pixel ID or empty string if not set
  */
 function extrachill_artist_get_meta_pixel_id( $artist_id, $link_page_id ) {
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    return $data['settings']['meta_pixel_id'] ?? '';
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
+	return $data['settings']['meta_pixel_id'] ?? '';
 }
 
 /**
@@ -50,8 +50,8 @@ function extrachill_artist_get_meta_pixel_id( $artist_id, $link_page_id ) {
  * @return bool True if Meta Pixel is enabled, false otherwise
  */
 function extrachill_artist_is_meta_pixel_enabled( $link_page_id ) {
-    $pixel_id = extrachill_artist_get_meta_pixel_id( $link_page_id );
-    return ! empty( $pixel_id ) && extrachill_artist_validate_meta_pixel_id( $pixel_id );
+	$pixel_id = extrachill_artist_get_meta_pixel_id( $link_page_id );
+	return ! empty( $pixel_id ) && extrachill_artist_validate_meta_pixel_id( $pixel_id );
 }
 
 
@@ -62,9 +62,9 @@ function extrachill_artist_is_meta_pixel_enabled( $link_page_id ) {
  * @return array Array containing Meta Pixel settings
  */
 function extrachill_artist_get_meta_pixel_settings( $link_page_id ) {
-    return array(
-        'pixel_id'    => extrachill_artist_get_meta_pixel_id( $link_page_id ),
-        'is_enabled'  => extrachill_artist_is_meta_pixel_enabled( $link_page_id ),
-        'is_valid'    => extrachill_artist_validate_meta_pixel_id( extrachill_artist_get_meta_pixel_id( $link_page_id ) ),
-    );
+	return array(
+		'pixel_id'   => extrachill_artist_get_meta_pixel_id( $link_page_id ),
+		'is_enabled' => extrachill_artist_is_meta_pixel_enabled( $link_page_id ),
+		'is_valid'   => extrachill_artist_validate_meta_pixel_id( extrachill_artist_get_meta_pixel_id( $link_page_id ) ),
+	);
 }

--- a/inc/link-pages/management/advanced-tab/subscription-settings.php
+++ b/inc/link-pages/management/advanced-tab/subscription-settings.php
@@ -16,11 +16,11 @@ defined( 'ABSPATH' ) || exit;
  * @return array Array of subscription options with values and labels
  */
 function extrachill_artist_get_subscription_display_options() {
-    return array(
-        'icon_modal'   => __( 'Show Subscribe Icon (opens modal)', 'extrachill-artist-platform' ),
-        'inline_form'  => __( 'Show Inline Subscribe Form (below links)', 'extrachill-artist-platform' ),
-        'disabled'     => __( 'Disable Subscription Feature', 'extrachill-artist-platform' ),
-    );
+	return array(
+		'icon_modal'  => __( 'Show Subscribe Icon (opens modal)', 'extrachill-artist-platform' ),
+		'inline_form' => __( 'Show Inline Subscribe Form (below links)', 'extrachill-artist-platform' ),
+		'disabled'    => __( 'Disable Subscription Feature', 'extrachill-artist-platform' ),
+	);
 }
 
 /**
@@ -31,8 +31,8 @@ function extrachill_artist_get_subscription_display_options() {
  * @return string The current subscription display mode
  */
 function extrachill_artist_get_subscription_display_mode( $artist_id, $link_page_id ) {
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    return $data['settings']['subscribe_display_mode'] ?? 'icon_modal';
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
+	return $data['settings']['subscribe_display_mode'] ?? 'icon_modal';
 }
 
 /**
@@ -43,8 +43,8 @@ function extrachill_artist_get_subscription_display_mode( $artist_id, $link_page
  * @return string The subscription form description
  */
 function extrachill_artist_get_subscription_description( $artist_id, $link_page_id ) {
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    return $data['settings']['subscribe_description'] ?? '';
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
+	return $data['settings']['subscribe_description'] ?? '';
 }
 
 /**
@@ -59,8 +59,8 @@ function extrachill_artist_get_subscription_description( $artist_id, $link_page_
  * @return bool True if subscription is enabled, false if disabled
  */
 function extrachill_artist_is_subscription_enabled( $link_page_id ) {
-    $display_mode = extrachill_artist_get_subscription_display_mode( $link_page_id );
-    return $display_mode !== 'disabled';
+	$display_mode = extrachill_artist_get_subscription_display_mode( $link_page_id );
+	return $display_mode !== 'disabled';
 }
 
 /**
@@ -71,10 +71,10 @@ function extrachill_artist_is_subscription_enabled( $link_page_id ) {
  * @return array Array containing all subscription settings
  */
 function extrachill_artist_get_subscription_settings( $link_page_id, $artist_name = '' ) {
-    return array(
-        'display_mode'        => extrachill_artist_get_subscription_display_mode( $link_page_id ),
-        'description'         => extrachill_artist_get_subscription_description( $link_page_id, $artist_name ),
-        'available_modes'     => extrachill_artist_get_subscription_display_options(),
-        'is_enabled'          => extrachill_artist_is_subscription_enabled( $link_page_id ),
-    );
+	return array(
+		'display_mode'    => extrachill_artist_get_subscription_display_mode( $link_page_id ),
+		'description'     => extrachill_artist_get_subscription_description( $link_page_id, $artist_name ),
+		'available_modes' => extrachill_artist_get_subscription_display_options(),
+		'is_enabled'      => extrachill_artist_is_subscription_enabled( $link_page_id ),
+	);
 }

--- a/inc/link-pages/management/advanced-tab/temporary-redirect.php
+++ b/inc/link-pages/management/advanced-tab/temporary-redirect.php
@@ -24,9 +24,9 @@ defined( 'ABSPATH' ) || exit;
  * @return array Array containing redirect settings
  */
 function extrachill_artist_get_temporary_redirect_settings( $artist_id, $link_page_id ) {
-    $data = ec_get_link_page_data( $artist_id, $link_page_id );
-    return array(
-        'enabled' => $data['settings']['redirect_enabled'] ?? false,
-        'target_url' => $data['settings']['redirect_target_url'] ?? '',
-    );
+	$data = ec_get_link_page_data( $artist_id, $link_page_id );
+	return array(
+		'enabled'    => $data['settings']['redirect_enabled'] ?? false,
+		'target_url' => $data['settings']['redirect_target_url'] ?? '',
+	);
 }

--- a/inc/link-pages/management/advanced-tab/youtube-embed-control.php
+++ b/inc/link-pages/management/advanced-tab/youtube-embed-control.php
@@ -17,13 +17,13 @@ defined( 'ABSPATH' ) || exit;
  * @return bool True if YouTube inline embed is enabled, false otherwise
  */
 function extrachill_artist_is_youtube_inline_embed_enabled( $link_page_id ) {
-    if ( empty( $link_page_id ) ) {
-        return true; // Default to enabled
-    }
+	if ( empty( $link_page_id ) ) {
+		return true; // Default to enabled
+	}
 
-    // Check if inline embed is explicitly disabled
-    $is_disabled = get_post_meta( $link_page_id, '_enable_youtube_inline_embed', true );
-    return $is_disabled !== '0';
+	// Check if inline embed is explicitly disabled
+	$is_disabled = get_post_meta( $link_page_id, '_enable_youtube_inline_embed', true );
+	return $is_disabled !== '0';
 }
 
 /**
@@ -38,18 +38,17 @@ function extrachill_artist_is_youtube_inline_embed_enabled( $link_page_id ) {
  * @return array Array containing YouTube embed settings
  */
 function extrachill_artist_get_youtube_embed_settings( $link_page_id ) {
-    if ( empty( $link_page_id ) ) {
-        return array(
-            'inline_enabled' => true,
-            'disable_checkbox_checked' => false,
-        );
-    }
+	if ( empty( $link_page_id ) ) {
+		return array(
+			'inline_enabled'           => true,
+			'disable_checkbox_checked' => false,
+		);
+	}
 
-    $is_enabled = extrachill_artist_is_youtube_inline_embed_enabled( $link_page_id );
-    
-    return array(
-        'inline_enabled' => $is_enabled,
-        'disable_checkbox_checked' => ! $is_enabled, // Checkbox should be checked if feature is disabled
-    );
+	$is_enabled = extrachill_artist_is_youtube_inline_embed_enabled( $link_page_id );
+
+	return array(
+		'inline_enabled'           => $is_enabled,
+		'disable_checkbox_checked' => ! $is_enabled, // Checkbox should be checked if feature is disabled
+	);
 }
-

--- a/inc/link-pages/subscribe-functions.php
+++ b/inc/link-pages/subscribe-functions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Link Page Subscription Functions
- * 
+ *
  * Functionality specific to link page subscriptions.
  * Public subscription handling via REST API (extrachill-api plugin).
  * Template rendering via ExtraChill_Live_Preview_Handler class.


### PR DESCRIPTION
## Summary
- Reduces Homeboy PHPCS findings from 7,092 to 499 with the repository-scoped WordPress PHPCBF pass.
- Applies a targeted SQL sniff suppression where the interpolated table identifier is derived exclusively from the trusted WordPress database prefix; the value predicate remains parameterized with `$wpdb->prepare()`.
- Supersedes the closed stale lint PR #101 for this repository.

## Breakdown
- PHPCBF auto-fixed 8,185 mechanical violations across 71 files: indentation, arrays, ternaries, spacing, and alignment.
- Hand-fixed the remaining interpolated-table false positive in `artist-list-subscribers.php`.
- `phpcs:ignore`: `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` is suppressed only on the prepared subscriber count query because placeholders cannot represent SQL identifiers and `$table` is composed solely from `$wpdb->prefix` plus a constant suffix.

## Verification
- Before: 7,092 PHPCS findings.
- After: 499 PHPCS findings, 0 ESLint findings.
- PHP syntax checks pass for every changed PHP file.
- PHPStan is not treated as a result because its Homeboy runtime is infra-broken (`homeboy-extensions#2230`).

No behavior changed. The remaining Homeboy findings require additional manual remediation; automated attempts were rejected because they changed callback signatures or regressed WordPress formatting, and those unsafe edits were discarded.