### PR TITLE
fix: resolve phpcs findings in inc/abilities/

### DIFF
--- a/inc/abilities/handlers/admin-cleanup-artist-relationships.php
+++ b/inc/abilities/handlers/admin-cleanup-artist-relationships.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/admin-cleanup-artist-relationships
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/admin-link-artist-relationship.php
+++ b/inc/abilities/handlers/admin-link-artist-relationship.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/admin-link-artist-relationship
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/admin-list-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-artist-relationships.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/admin-list-artist-relationships
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
+++ b/inc/abilities/handlers/admin-list-orphan-artist-relationships.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/admin-list-orphan-artist-relationships
  *
@@ -9,6 +8,8 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -17,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @param array $input Unused — endpoint takes no parameters.
  * @return array|WP_Error
  */
+// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- The ability callback signature requires the input parameter.
 function extrachill_artist_platform_ability_admin_list_orphan_artist_relationships( array $input ): array|WP_Error {
 	$orphans = ec_get_orphaned_artist_relationships();
 	if ( is_wp_error( $orphans ) ) {

--- a/inc/abilities/handlers/admin-unlink-artist-relationship.php
+++ b/inc/abilities/handlers/admin-unlink-artist-relationship.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/admin-unlink-artist-relationship
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-create-social.php
+++ b/inc/abilities/handlers/artist-create-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-create-social
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -58,7 +59,7 @@ function extrachill_artist_platform_ability_artist_create_social( array $input )
 
 	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
 
-	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
+	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ? $link_page_id : 0 );
 	$result    = $social_manager->save( $artist_id, $sanitized );
 
 	if ( is_wp_error( $result ) ) {

--- a/inc/abilities/handlers/artist-delete-social.php
+++ b/inc/abilities/handlers/artist-delete-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-delete-social
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-export-subscribers.php
+++ b/inc/abilities/handlers/artist-export-subscribers.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-export-subscribers
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,7 +48,7 @@ function extrachill_artist_platform_ability_artist_export_subscribers( array $in
 	$export_data            = array();
 
 	foreach ( $subscribers as $subscriber ) {
-		$is_exported = isset( $subscriber->exported ) && $subscriber->exported == 1;
+		$is_exported = isset( $subscriber->exported ) && 1 === (int) $subscriber->exported;
 
 		$export_data[] = array(
 			'email'         => $subscriber->subscriber_email,

--- a/inc/abilities/handlers/artist-get-analytics.php
+++ b/inc/abilities/handlers/artist-get-analytics.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get-analytics
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-get-links.php
+++ b/inc/abilities/handlers/artist-get-links.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get-links
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-get-permissions.php
+++ b/inc/abilities/handlers/artist-get-permissions.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get-permissions
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-get-roster.php
+++ b/inc/abilities/handlers/artist-get-roster.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get-roster
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-get.php
+++ b/inc/abilities/handlers/artist-get.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -34,7 +35,7 @@ function extrachill_artist_platform_ability_artist_get( array $input ): array|WP
 
 	$artist = get_post( $artist_id );
 
-	if ( ! $artist || $artist->post_type !== 'artist_profile' || $artist->post_status !== 'publish' ) {
+	if ( ! $artist || 'artist_profile' !== $artist->post_type || 'publish' !== $artist->post_status ) {
 		if ( $did_switch ) {
 			restore_current_blog();
 		}
@@ -53,13 +54,13 @@ function extrachill_artist_platform_ability_artist_get( array $input ): array|WP
 		'slug'              => $data['slug'],
 		'permalink'         => $data['permalink'],
 		'bio'               => $data['bio'],
-		'local_city'        => $data['local_city'] !== '' ? $data['local_city'] : null,
-		'genre'             => $data['genre'] !== '' ? $data['genre'] : null,
+		'local_city'        => '' !== $data['local_city'] ? $data['local_city'] : null,
+		'genre'             => '' !== $data['genre'] ? $data['genre'] : null,
 		'profile_image_id'  => $data['profile_image_id'] ? (int) $data['profile_image_id'] : null,
-		'profile_image_url' => $data['profile_image_url'] ?: null,
+		'profile_image_url' => $data['profile_image_url'] ? $data['profile_image_url'] : null,
 		'header_image_id'   => $data['header_image_id'] ? (int) $data['header_image_id'] : null,
-		'header_image_url'  => $data['header_image_url'] ?: null,
+		'header_image_url'  => $data['header_image_url'] ? $data['header_image_url'] : null,
 		'official_links'    => $data['social_links'],
-		'link_page_id'      => $data['link_page_id'] ?: null,
+		'link_page_id'      => $data['link_page_id'] ? $data['link_page_id'] : null,
 	);
 }

--- a/inc/abilities/handlers/artist-list-socials.php
+++ b/inc/abilities/handlers/artist-list-socials.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-list-socials
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-list-subscribers.php
+++ b/inc/abilities/handlers/artist-list-subscribers.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-list-subscribers
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,6 +48,7 @@ function extrachill_artist_platform_ability_artist_list_subscribers( array $inpu
 	global $wpdb;
 	$table = $wpdb->prefix . 'artist_subscribers';
 	$total = (int) $wpdb->get_var(
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name uses the trusted WordPress database prefix; artist ID uses a placeholder.
 		$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d", $artist_id )
 	);
 

--- a/inc/abilities/handlers/artist-subscribe.php
+++ b/inc/abilities/handlers/artist-subscribe.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-subscribe
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -42,6 +43,7 @@ function extrachill_artist_platform_ability_artist_subscribe( array $input ): ar
 	// Check for existing subscription.
 	$exists = $wpdb->get_var(
 		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name uses the trusted WordPress database prefix; values use placeholders.
 			"SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d AND subscriber_email = %s",
 			$artist_id,
 			$email

--- a/inc/abilities/handlers/artist-update-links.php
+++ b/inc/abilities/handlers/artist-update-links.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-update-links
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/artist-update-social.php
+++ b/inc/abilities/handlers/artist-update-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-update-social
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -70,7 +71,7 @@ function extrachill_artist_platform_ability_artist_update_social( array $input )
 
 	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
 
-	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
+	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ? $link_page_id : 0 );
 	$result    = $social_manager->save( $artist_id, $sanitized );
 
 	if ( is_wp_error( $result ) ) {

--- a/inc/abilities/handlers/artists-list.php
+++ b/inc/abilities/handlers/artists-list.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artists-list
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -43,7 +44,7 @@ function extrachill_artist_platform_ability_artists_list( array $input ): array|
 		'order'          => 'DESC',
 	);
 
-	if ( $search !== '' ) {
+	if ( '' !== $search ) {
 		$query_args['s'] = $search;
 	}
 
@@ -59,13 +60,15 @@ function extrachill_artist_platform_ability_artists_list( array $input ): array|
 			$profile_image_url = $profile_image_id
 				? wp_get_attachment_image_url( (int) $profile_image_id, 'medium' )
 				: null;
+			$local_city        = get_post_meta( $artist_id, '_local_city', true );
+			$genre             = get_post_meta( $artist_id, '_genre', true );
 
 			$artists[] = array(
 				'id'                => (int) $artist_id,
 				'name'              => get_the_title(),
 				'slug'              => get_post_field( 'post_name', $artist_id ),
-				'local_city'        => get_post_meta( $artist_id, '_local_city', true ) ?: null,
-				'genre'             => get_post_meta( $artist_id, '_genre', true ) ?: null,
+				'local_city'        => $local_city ? $local_city : null,
+				'genre'             => $genre ? $genre : null,
 				'profile_image_url' => $profile_image_url,
 			);
 		}

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -96,11 +96,11 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 		return $artist_id;
 	}
 
-	if ( $local_city !== '' ) {
+	if ( '' !== $local_city ) {
 		update_post_meta( $artist_id, '_local_city', $local_city );
 	}
 
-	if ( $genre !== '' ) {
+	if ( '' !== $genre ) {
 		update_post_meta( $artist_id, '_genre', $genre );
 	}
 

--- a/inc/abilities/handlers/get-artist-data.php
+++ b/inc/abilities/handlers/get-artist-data.php
@@ -31,7 +31,7 @@ function extrachill_artist_platform_ability_get_artist_data( $input ) {
 
 	$artist = get_post( $artist_id );
 
-	if ( ! $artist || $artist->post_type !== 'artist_profile' ) {
+	if ( ! $artist || 'artist_profile' !== $artist->post_type ) {
 		if ( $did_switch ) {
 			restore_current_blog();
 		}
@@ -61,8 +61,8 @@ function extrachill_artist_platform_ability_get_artist_data( $input ) {
 		'name'              => $artist->post_title,
 		'slug'              => $artist->post_name,
 		'bio'               => $artist->post_content,
-		'local_city'        => $local_city !== '' ? $local_city : null,
-		'genre'             => $genre !== '' ? $genre : null,
+		'local_city'        => '' !== $local_city ? $local_city : null,
+		'genre'             => '' !== $genre ? $genre : null,
 		'profile_image_id'  => $profile_image_id ? (int) $profile_image_id : null,
 		'profile_image_url' => $profile_image_url,
 		'header_image_id'   => $header_image_id ? (int) $header_image_id : null,

--- a/inc/abilities/handlers/get-artist-platform-stats.php
+++ b/inc/abilities/handlers/get-artist-platform-stats.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/get-artist-platform-stats
  *
@@ -16,6 +15,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 

--- a/inc/abilities/handlers/update-artist.php
+++ b/inc/abilities/handlers/update-artist.php
@@ -38,17 +38,17 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( isset( $input['name'] ) ) {
 		$post_data['post_title'] = sanitize_text_field( wp_unslash( $input['name'] ) );
-		$has_updates = true;
+		$has_updates             = true;
 	}
 
 	if ( isset( $input['bio'] ) ) {
 		$post_data['post_content'] = wp_kses_post( wp_unslash( $input['bio'] ) );
-		$has_updates = true;
+		$has_updates               = true;
 	}
 
 	if ( array_key_exists( 'local_city', $input ) ) {
 		$local_city = sanitize_text_field( wp_unslash( $input['local_city'] ) );
-		if ( $local_city === '' ) {
+		if ( '' === $local_city ) {
 			delete_post_meta( $artist_id, '_local_city' );
 		} else {
 			update_post_meta( $artist_id, '_local_city', $local_city );
@@ -57,7 +57,7 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( array_key_exists( 'genre', $input ) ) {
 		$genre = sanitize_text_field( wp_unslash( $input['genre'] ) );
-		if ( $genre === '' ) {
+		if ( '' === $genre ) {
 			delete_post_meta( $artist_id, '_genre' );
 		} else {
 			update_post_meta( $artist_id, '_genre', $genre );

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -79,7 +79,7 @@ function extrachill_artist_platform_get_next_id( $link_page_id, $type ) {
 
 	$meta_key   = $map[ $type ];
 	$next_index = (int) get_post_meta( $link_page_id, $meta_key, true );
-	$next_index++;
+	++$next_index;
 	update_post_meta( $link_page_id, $meta_key, $next_index );
 
 	return sprintf( '%d-%s-%d', $link_page_id, $type, $next_index );
@@ -201,7 +201,7 @@ function extrachill_artist_platform_sanitize_css_vars( $vars ) {
 	$sanitized = array();
 
 	foreach ( $vars as $key => $value ) {
-		if ( strpos( $key, '--link-page-' ) !== 0 && $key !== 'overlay' ) {
+		if ( 0 !== strpos( $key, '--link-page-' ) && 'overlay' !== $key ) {
 			continue;
 		}
 

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -57,7 +57,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -96,11 +96,11 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'name' => array(
+					'name'       => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'        => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
@@ -108,11 +108,11 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'      => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
-					'user_id' => array(
+					'user_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'User ID to link as member. Defaults to current user.', 'extrachill-artist-platform' ),
 					),
@@ -145,23 +145,23 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'        => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'name' => array(
+					'name'             => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'              => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
-					'local_city' => array(
+					'local_city'       => array(
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'            => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
@@ -169,7 +169,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'header_image_id' => array(
+					'header_image_id'  => array(
 						'type'        => 'integer',
 						'description' => __( 'Header image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -206,7 +206,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'links' => array(
+					'links'     => array(
 						'type'        => 'array',
 						'description' => __( 'Array of link sections with nested links.', 'extrachill-artist-platform' ),
 					),
@@ -243,7 +243,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'css_vars' => array(
+					'css_vars'  => array(
 						'type'        => 'object',
 						'description' => __( 'CSS variables to save. Merged with existing.', 'extrachill-artist-platform' ),
 					),
@@ -276,15 +276,15 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'           => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'settings' => array(
+					'settings'            => array(
 						'type'        => 'object',
 						'description' => __( 'Settings to save.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'                 => array(
 						'type'        => 'string',
 						'description' => __( 'Short bio displayed on the public link page.', 'extrachill-artist-platform' ),
 					),
@@ -292,7 +292,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Background image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'profile_image_id' => array(
+					'profile_image_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -325,7 +325,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -367,9 +367,21 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
-					'search'   => array( 'type' => 'string', 'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ) ),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -406,7 +418,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'days' => array( 'type' => 'integer', 'minimum' => 0, 'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ) ),
+					'days' => array(
+						'type'        => 'integer',
+						'minimum'     => 0,
+						'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -445,7 +461,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -455,7 +475,10 @@ function extrachill_artist_platform_register_abilities() {
 					'id'                => array( 'type' => 'integer' ),
 					'name'              => array( 'type' => 'string' ),
 					'slug'              => array( 'type' => 'string' ),
-					'permalink'         => array( 'type' => 'string', 'format' => 'uri' ),
+					'permalink'         => array(
+						'type'   => 'string',
+						'format' => 'uri',
+					),
 					'bio'               => array( 'type' => 'string' ),
 					'local_city'        => array( 'type' => array( 'string', 'null' ) ),
 					'genre'             => array( 'type' => array( 'string', 'null' ) ),
@@ -490,7 +513,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -521,14 +548,39 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'                 => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'links'              => array( 'type' => 'array', 'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ) ),
-					'css_vars'           => array( 'type' => 'object', 'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ) ),
-					'settings'           => array( 'type' => 'object', 'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ) ),
-					'socials'            => array( 'type' => 'array', 'description' => __( 'Social link objects.', 'extrachill-artist-platform' ) ),
-					'background_image_id' => array( 'type' => 'integer', 'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ) ),
-					'profile_image_id'   => array( 'type' => 'integer', 'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ) ),
-					'bio'                => array( 'type' => 'string', 'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ) ),
+					'id'                  => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'links'               => array(
+						'type'        => 'array',
+						'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ),
+					),
+					'css_vars'            => array(
+						'type'        => 'object',
+						'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ),
+					),
+					'settings'            => array(
+						'type'        => 'object',
+						'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ),
+					),
+					'socials'             => array(
+						'type'        => 'array',
+						'description' => __( 'Social link objects.', 'extrachill-artist-platform' ),
+					),
+					'background_image_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'profile_image_id'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'bio'                 => array(
+						'type'        => 'string',
+						'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -559,7 +611,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -594,7 +650,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -628,7 +688,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -661,9 +725,20 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'type', 'url' ),
 				'properties'           => array(
-					'id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'type' => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'  => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'type' => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'  => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -696,10 +771,24 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ) ),
-					'type'      => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'       => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ),
+					),
+					'type'      => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'       => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -732,8 +821,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -768,8 +864,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'email' ),
 				'properties'           => array(
-					'id'    => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'email' => array( 'type' => 'string', 'format' => 'email', 'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ) ),
+					'id'    => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'email' => array(
+						'type'        => 'string',
+						'format'      => 'email',
+						'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -802,9 +906,22 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'       => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
+					'id'       => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -840,8 +957,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'               => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'include_exported' => array( 'type' => 'boolean', 'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ) ),
+					'id'               => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'include_exported' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -878,8 +1002,17 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'         => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'date_range' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 90, 'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ) ),
+					'id'         => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'date_range' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -918,8 +1051,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'view'   => array( 'type' => 'string', 'enum' => array( 'artists', 'users' ), 'description' => __( 'View mode.', 'extrachill-artist-platform' ) ),
-					'search' => array( 'type' => 'string', 'description' => __( 'Search term.', 'extrachill-artist-platform' ) ),
+					'view'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'artists', 'users' ),
+						'description' => __( 'View mode.', 'extrachill-artist-platform' ),
+					),
+					'search' => array(
+						'type'        => 'string',
+						'description' => __( 'Search term.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -952,8 +1092,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -986,8 +1134,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1051,8 +1207,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),


### PR DESCRIPTION
## Summary
- Resolve every Homeboy-reported PHPCS finding in `inc/abilities/`.
- Keep changes limited to flagged file-header ordering, comparisons/operators, schema formatting, callback signatures, and trusted table-name interpolation.
- No behavior changed.

## Scope
- Scoped to `inc/abilities/` only, no aggregate-WPCS churn, no reindentation.
- Did not run raw aggregate PHPCS or PHPCBF.
- Did not touch `CHANGELOG.md` or version strings.

## Homeboy Evidence
- Before: 117 PHPCS findings within `inc/abilities/`.
- After: 0 PHPCS findings within `inc/abilities/`.
- Command: `homeboy review extrachill-artist-platform lint --force-hot --allow-local-hot`
- The repository-wide lint phase still reports pre-existing findings outside this assigned slice.

## PHPCS Ignores
- `admin-list-orphan-artist-relationships.php`: preserves the required ability callback `$input` parameter even though this no-input endpoint does not use it.
- `artist-subscribe.php`: the interpolated table identifier is derived from trusted `$wpdb->prefix`; both predicate values remain parameterized with `$wpdb->prepare()`.
- `artist-list-subscribers.php`: the interpolated table identifier is derived from trusted `$wpdb->prefix`; the artist ID remains parameterized with `$wpdb->prepare()`.

## Verification
- Final Homeboy sidecar confirms 0 findings under `inc/abilities/`.
- `php -l` passes for all 25 changed PHP files.
- `git diff --check` passes.
- Test gate not run per task constraints.