### PR TITLE
fix: reject invalid CSS variable values safely

### DIFF
--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -206,6 +206,10 @@ function extrachill_artist_platform_sanitize_css_vars( $vars ) {
 		}
 
 		if ( strpos( $key, 'color' ) !== false || strpos( $key, '-bg' ) !== false ) {
+			if ( ! is_string( $value ) ) {
+				continue;
+			}
+
 			// Accept hex (#rgb, #rrggbb), rgb(), rgba(), hsl(), hsla() — not just hex.
 			$hex = sanitize_hex_color( $value );
 			if ( $hex ) {

--- a/tests/SanitizeCssVarsTest.php
+++ b/tests/SanitizeCssVarsTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class SanitizeCssVarsTest extends TestCase {
+	/**
+	 * Runs a callback capturing PHP deprecations/notices/warnings and asserts none fire.
+	 *
+	 * @param callable $callback
+	 * @return mixed
+	 */
+	private function run_without_warnings( $callback ) {
+		$captured = array();
+		set_error_handler(
+			static function ( $errno, $errstr ) use ( &$captured ) {
+				$captured[] = $errstr;
+				return true;
+			},
+			E_DEPRECATED | E_NOTICE | E_WARNING
+		);
+
+		try {
+			$result = $callback();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $captured, 'No deprecations/notices/warnings expected during sanitization.' );
+
+		return $result;
+	}
+
+	public function test_non_array_input_returns_empty_array(): void {
+		$this->assertSame( array(), extrachill_artist_platform_sanitize_css_vars( null ) );
+		$this->assertSame( array(), extrachill_artist_platform_sanitize_css_vars( 'not-an-array' ) );
+	}
+
+	public function test_null_color_value_is_skipped_silently(): void {
+		$result = $this->run_without_warnings(
+			static function () {
+				return extrachill_artist_platform_sanitize_css_vars(
+					array(
+						'--link-page-text-color' => null,
+						'--link-page-accent-color' => '#ff5733',
+					)
+				);
+			}
+		);
+
+		$this->assertArrayNotHasKey( '--link-page-text-color', $result );
+		$this->assertSame( '#ff5733', $result['--link-page-accent-color'] );
+	}
+
+	public function test_array_color_value_is_skipped_silently(): void {
+		$result = $this->run_without_warnings(
+			static function () {
+				return extrachill_artist_platform_sanitize_css_vars(
+					array(
+						'--link-page-bg' => array( '#ffffff' ),
+						'--link-page-bg-color' => '#000000',
+					)
+				);
+			}
+		);
+
+		$this->assertArrayNotHasKey( '--link-page-bg', $result );
+		$this->assertSame( '#000000', $result['--link-page-bg-color'] );
+	}
+
+	public function test_valid_color_formats_are_preserved(): void {
+		$input = array(
+			'--link-page-short-hex-color'   => '#abc',
+			'--link-page-long-hex-color'    => '#aabbcc',
+			'--link-page-rgb-color'         => 'rgb(255, 0, 0)',
+			'--link-page-rgba-color'        => 'rgba(255, 0, 0, 0.5)',
+			'--link-page-hsl-color'         => 'hsl(120, 100%, 50%)',
+			'--link-page-hsla-color'        => 'hsla(120, 100%, 50%, 0.3)',
+		);
+
+		$result = $this->run_without_warnings(
+			static function () use ( $input ) {
+				return extrachill_artist_platform_sanitize_css_vars( $input );
+			}
+		);
+
+		$this->assertSame( $input, $result );
+	}
+
+	public function test_invalid_color_string_is_skipped_silently(): void {
+		$result = extrachill_artist_platform_sanitize_css_vars(
+			array(
+				'--link-page-text-color' => 'not-a-color',
+				'--link-page-accent-color' => '#00ff00',
+			)
+		);
+
+		$this->assertArrayNotHasKey( '--link-page-text-color', $result );
+		$this->assertSame( '#00ff00', $result['--link-page-accent-color'] );
+	}
+
+	public function test_ordinary_non_color_values_pass_through(): void {
+		$result = extrachill_artist_platform_sanitize_css_vars(
+			array(
+				'overlay'             => '0.5',
+				'--link-page-radius'  => '8px',
+			)
+		);
+
+		$this->assertSame( '0.5', $result['overlay'] );
+		$this->assertSame( '8px', $result['--link-page-radius'] );
+	}
+
+	public function test_keys_outside_allowlist_are_ignored(): void {
+		$result = extrachill_artist_platform_sanitize_css_vars(
+			array(
+				'--evil-injected-css' => 'background:url(javascript:alert(1))',
+				'--link-page-text-color' => '#123456',
+			)
+		);
+
+		$this->assertArrayNotHasKey( '--evil-injected-css', $result );
+		$this->assertSame( '#123456', $result['--link-page-text-color'] );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -103,6 +103,26 @@ function ec_remove_artist_membership( $user_id, $artist_id ) {
 	return true;
 }
 
+function wp_unslash( $value ) {
+	if ( is_string( $value ) ) {
+		return stripslashes( $value );
+	}
+
+	return $value;
+}
+
+function sanitize_hex_color( $color ) {
+	if ( '' === $color ) {
+		return '';
+	}
+
+	if ( preg_match( '|^#([A-Fa-f0-9]{3}){1,2}$|', $color ) ) {
+		return $color;
+	}
+
+	return null;
+}
+
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-link-artist-relationship.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-unlink-artist-relationship.php';
@@ -110,3 +130,4 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-art
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';


### PR DESCRIPTION
## Summary

Guards non-string color values in `extrachill_artist_platform_sanitize_css_vars()` before they reach color validation, eliminating the PHP 8.1+ deprecation/TypeError reported in #115.

Closes #115

## Root cause

`extrachill_artist_platform_sanitize_css_vars()` verified that the outer `$vars` input was an array, but inside the color branch (`inc/abilities/helpers.php`) it forwarded each `$value` straight into `sanitize_hex_color()` (which internally calls `preg_match()`) and then a second `preg_match()`, without confirming the value was a scalar string.

- `null` → `preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated` (E_DEPRECATED on PHP 8.1+, 2 emissions per call)
- `array` → `preg_match(): Argument #2 ($subject) must be of type string, array given` (TypeError)

The live log recorded 16 occurrences in the recent reporting window.

## Behavior preserved

- Valid hex (`#rgb`, `#rrggbb`), `rgb()`, `rgba()`, `hsl()`, `hsla()` strings still pass through unchanged.
- Invalid color strings (e.g. `not-a-color`) are still skipped silently.
- The key allowlist (`--link-page-*` and `overlay`) is unchanged.
- Ordinary non-color values still route through `sanitize_text_field( wp_unslash( $value ) )`.
- The silent-skip contract is preserved: non-scalar color values are dropped rather than throwing.

## Malformed values covered

Added `is_string( $value )` guard at the top of the color branch so any non-string color value (null, array, bool, object, int) is skipped silently before `sanitize_hex_color()` / `preg_match()` are ever reached. The guard is scoped to the color branch only, leaving non-color value handling untouched to avoid any behavior change outside the issue scope.

## Verification performed

- New `tests/SanitizeCssVarsTest.php` (7 tests) covers: non-array input; null color value; array color value; valid hex/rgb/rgba/hsl/hsla formats; invalid color string; ordinary non-color values; key allowlist.
- Full suite: **14 tests, 31 assertions, OK** (`vendor/bin/phpunit`).
- Regression-confirmed the tests are meaningful: with the guard temporarily removed, the null case fails on captured `E_DEPRECATED` and the array case errors on the `TypeError`; restoring the guard → all green.
- `php -l` clean on all changed files.
- Conventional commit; `CHANGELOG.md` and version strings untouched (Homeboy owns those).

> Note: `composer lint:php` (`phpcs --standard=WordPress`) cannot run in a clean install because WPCS is not a declared dependency in `composer.json` (only `squizlabs/php_codesniffer`). This is a pre-existing repo gap, unrelated to this change. Edited code follows the file's existing WordPress tabs/style. There is no test/lint CI workflow on this repo (only a docs-agent workflow).

## Confirmation

No release or deployment was performed. This PR is for review only and has **not** been merged.