### PR TITLE
fix: separate link-page share controls

### DIFF
--- a/assets/css/extrch-links.css
+++ b/assets/css/extrch-links.css
@@ -157,7 +157,7 @@ body {
   width: 100%;
   margin-bottom: 1.5em;
 }
-.extrch-link-page-link {
+.extrch-link-button-wrapper {
   background: var(--link-page-button-bg-color);
   color: var(--link-page-link-text-color);
   padding: 0.95em 1.2em;
@@ -185,16 +185,21 @@ body {
   text-overflow: wrap;
 }
 
-/* New class for the link icon span/element */
-.extrch-link-page-link-icon {
-  flex-shrink: 0; /* Prevent icon from shrinking */
-  display: flex; /* To help align icon if it's complex */
-  align-items: center;
+.extrch-link-page-link {
+  color: inherit;
+  display: flex;
+  flex-grow: 1;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.extrch-link-button-wrapper:hover {
+  background: var(--link-page-button-hover-bg-color);
+  color: var(--link-page-button-bg-color); /* Revert to original button background color for text on hover */
 }
 
 .extrch-link-page-link:hover {
-  background: var(--link-page-button-hover-bg-color);
-  color: var(--link-page-button-bg-color); /* Revert to original button background color for text on hover */
+  color: inherit;
   text-decoration: none;
 }
 .extrch-link-page-links-container{

--- a/assets/css/extrch-share-modal.css
+++ b/assets/css/extrch-share-modal.css
@@ -68,6 +68,7 @@ body .extrch-share-page-trigger:active {
     padding: 0.3em .1em;
     font-size: 1em;
     border-radius: 4px;
+    flex-shrink: 0;
     /* Ensure no unwanted button styles bleed through */
     border: none; 
     box-shadow: none;
@@ -306,7 +307,7 @@ body button.extrch-share-item-trigger:active {
         padding: 8px 12px;
         font-size: 0.9em;
     }
-} 
+}
 
 .extrch-bell-page-trigger {
     position: absolute;
@@ -339,4 +340,4 @@ body .extrch-bell-page-trigger:active {
     font-size: 0.9em;
     display: block;
     line-height: 1;
-} 
+}

--- a/inc/link-pages/live/assets/js/extrch-share-modal.js
+++ b/inc/link-pages/live/assets/js/extrch-share-modal.js
@@ -145,7 +145,6 @@ document.addEventListener('DOMContentLoaded', () => {
             if (trigger.classList.contains('extrch-bell-page-trigger')) return;
             trigger.addEventListener('click', (e) => {
                 e.preventDefault();
-                e.stopPropagation(); // Prevent link navigation if button is inside <a>
                 openModal(trigger); // Pass the trigger element directly
             });
         });
@@ -234,4 +233,4 @@ document.addEventListener('DOMContentLoaded', () => {
             closeModal();
         }
     });
-}); 
+});

--- a/inc/link-pages/live/assets/js/link-page-youtube-embed.js
+++ b/inc/link-pages/live/assets/js/link-page-youtube-embed.js
@@ -33,14 +33,11 @@
      * @returns {HTMLElement} The placeholder div.
      */
     function getOrCreateVideoPlaceholder(linkElement) {
-        let placeholder = linkElement.nextElementSibling;
+        const parentContainer = linkElement.closest('.extrch-link-button-wrapper') || linkElement;
+        let placeholder = parentContainer.nextElementSibling;
         if (!placeholder || !placeholder.classList.contains(YOUTUBE_VIDEO_PLACEHOLDER_CLASS)) {
             placeholder = document.createElement('div');
             placeholder.className = YOUTUBE_VIDEO_PLACEHOLDER_CLASS;
-            // No need for placeholder.style.display = 'none'; CSS handles initial hidden state via max-height
-            // Insert after the button's parent if the button is wrapped, or after the button itself.
-            // Assuming buttons might be wrapped in <li> or <p>
-            const parentContainer = linkElement.parentElement.classList.contains('extrch-link-button-wrapper') ? linkElement.parentElement : linkElement;
             parentContainer.parentNode.insertBefore(placeholder, parentContainer.nextSibling);
         }
         return placeholder;
@@ -56,8 +53,10 @@
             if (event.target.closest('.extrch-share-trigger')) return;
             event.preventDefault();
 
+            const parentContainer = link.closest('.extrch-link-button-wrapper') || link;
+
             // Check if the next sibling is a visible placeholder for this link (toggle close)
-            let placeholder = link.nextElementSibling;
+            let placeholder = parentContainer.nextElementSibling;
             if (placeholder && placeholder.classList.contains('extrch-youtube-video-placeholder')) {
                 if (placeholder.classList.contains('video-visible')) {
                     // Already open, so close (remove video after transition, remove placeholder from DOM)
@@ -87,10 +86,10 @@
                 }
             });
 
-            // Create and insert placeholder after the link
+            // Create and insert placeholder after the link and share-control wrapper.
             placeholder = document.createElement('div');
             placeholder.className = 'extrch-youtube-video-placeholder';
-            link.parentNode.insertBefore(placeholder, link.nextSibling);
+            parentContainer.parentNode.insertBefore(placeholder, parentContainer.nextSibling);
 
             // Extract videoId for embed
             const videoId = getYouTubeVideoId(href);
@@ -121,4 +120,4 @@
         init: initializeGlobalDelegatedYoutubeEmbeds
     };
 
-})(); 
+})();

--- a/inc/link-pages/live/templates/components/single-link.php
+++ b/inc/link-pages/live/templates/components/single-link.php
@@ -31,15 +31,16 @@ if ( $youtube_embed ) {
     $link_classes .= ' extrch-youtube-embed-link';
 }
 ?>
-<a href="<?php echo esc_url( $display_url ); ?>" class="<?php echo esc_attr( $link_classes ); ?>" rel="ugc noopener">
-    <span class="extrch-link-page-link-text"><?php echo esc_html( $display_text ); ?></span>
-    <span class="extrch-link-page-link-icon">
-        <button class="extrch-share-trigger extrch-share-item-trigger"
-                aria-label="Share this link"
-                data-share-type="link"
-                data-share-url="<?php echo esc_url( $share_url ); ?>"
-                data-share-title="<?php echo esc_attr( $share_title ); ?>">
-            <i class="fas fa-ellipsis-v"></i>
-        </button>
-    </span>
-</a>
+<div class="extrch-link-button-wrapper">
+    <a href="<?php echo esc_url( $display_url ); ?>" class="<?php echo esc_attr( $link_classes ); ?>" rel="ugc noopener">
+        <span class="extrch-link-page-link-text"><?php echo esc_html( $display_text ); ?></span>
+    </a>
+    <button type="button"
+            class="extrch-share-trigger extrch-share-item-trigger"
+            aria-label="Share this link"
+            data-share-type="link"
+            data-share-url="<?php echo esc_url( $share_url ); ?>"
+            data-share-title="<?php echo esc_attr( $share_title ); ?>">
+        <i class="fas fa-ellipsis-v"></i>
+    </button>
+</div>

--- a/tests/LinkPageShareMarkupTest.php
+++ b/tests/LinkPageShareMarkupTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	function wp_parse_args( $args, $defaults ) {
+		return array_merge( $defaults, $args );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+final class LinkPageShareMarkupTest extends TestCase {
+	private function render_single_link( array $args ): string {
+		ob_start();
+		require dirname( __DIR__ ) . '/inc/link-pages/live/templates/components/single-link.php';
+		return ob_get_clean();
+	}
+
+	public function test_link_and_share_button_are_independent_interactive_controls(): void {
+		$html = $this->render_single_link(
+			array(
+				'link_url'  => 'https://example.com/listen',
+				'link_text' => 'Listen now',
+			)
+		);
+
+		$document = new DOMDocument();
+		$document->loadHTML( '<!DOCTYPE html><html><body>' . $html . '</body></html>' );
+		$xpath = new DOMXPath( $document );
+		$wrapper = $xpath->query( '//div[contains(concat(" ", normalize-space(@class), " "), " extrch-link-button-wrapper ")]' )->item( 0 );
+		$link    = $xpath->query( './a[contains(concat(" ", normalize-space(@class), " "), " extrch-link-page-link ")]', $wrapper )->item( 0 );
+		$button  = $xpath->query( './button[contains(concat(" ", normalize-space(@class), " "), " extrch-share-item-trigger ")]', $wrapper )->item( 0 );
+
+		$this->assertNotNull( $wrapper );
+		$this->assertNotNull( $link );
+		$this->assertNotNull( $button );
+		$this->assertSame( $wrapper, $link->parentNode );
+		$this->assertSame( $wrapper, $button->parentNode );
+		$this->assertSame( 0, $xpath->query( './/a//button', $wrapper )->length );
+		$this->assertSame( 'https://example.com/listen', $link->getAttribute( 'href' ) );
+		$this->assertSame( 'button', $button->getAttribute( 'type' ) );
+		$this->assertSame( 'Share this link', $button->getAttribute( 'aria-label' ) );
+	}
+
+	public function test_share_trigger_retains_its_modal_click_handler_without_link_propagation_workaround(): void {
+		$script = file_get_contents( dirname( __DIR__ ) . '/inc/link-pages/live/assets/js/extrch-share-modal.js' );
+
+		$this->assertStringContainsString( "trigger.addEventListener('click'", $script );
+		$this->assertStringContainsString( 'e.preventDefault();', $script );
+		$this->assertStringContainsString( 'openModal(trigger);', $script );
+		$this->assertStringNotContainsString( 'e.stopPropagation();', $script );
+	}
+}


### PR DESCRIPTION
## Summary
- Render each public link and its share action as sibling native controls inside the existing visual button shell.
- Preserve link tracking and update YouTube embed placement to remain after the new link/share wrapper.
- Add focused template and share-handler coverage for independent link and share activation.

## Markup and Accessibility
Before: the share `<button>` was nested inside the destination `<a>`, which is invalid interactive markup and could activate the link when sharing.

After: the destination `<a>` and `type="button"` share control are siblings. Both remain native keyboard controls; the link retains its href and the share action retains its modal click handler without propagation suppression.

## Verification
- `vendor/bin/phpunit --do-not-cache-result` (16 tests, 44 assertions)
- `php -l tests/LinkPageShareMarkupTest.php`
- `php -l inc/link-pages/live/templates/components/single-link.php`
- `node --check inc/link-pages/live/assets/js/extrch-share-modal.js`
- `node --check inc/link-pages/live/assets/js/link-page-youtube-embed.js`
- `npm run build`

Repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by pre-existing project violations (2,211 JS errors and 1,574 CSS errors); scoped direct lint commands cannot run because the project has no root ESLint or Stylelint configuration.

Fixes #117