### PR TITLE
fix: declare block sources as build-only

### DIFF
--- a/homeboy.json
+++ b/homeboy.json
@@ -6,6 +6,14 @@
   },
   "id": "extrachill-artist-platform",
   "remote_path": "wp-content/plugins/extrachill-artist-platform",
+  "scopes": {
+    "release": {
+      "exclude": [
+        "src/**",
+        "webpack.config.js"
+      ]
+    }
+  },
   "version_targets": [
     {
       "file": "extrachill-artist-platform.php",


### PR DESCRIPTION
## Summary
- mark `src/**` and `webpack.config.js` as frontend build inputs in the release scope
- retain source files in git and during builds
- require the generated `build/` assets in the production package instead of raw source

Closes #119

## Verification
- `jq empty homeboy.json`
- `git diff --check`