### PR TITLE
fix: wrap link-page social icons

### DIFF
--- a/assets/css/extrch-links.css
+++ b/assets/css/extrch-links.css
@@ -300,6 +300,7 @@ body {
 
 .extrch-link-page-socials {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.1em;
   justify-content: center;
   margin-bottom: 1.5em;


### PR DESCRIPTION
## Summary
- allow link-page social icons to wrap when they exceed the available width
- preserve centered alignment, existing spacing, icon hit targets, and single-row desktop appearance when icons fit
- verify all 18 supported icons at 320px, 375px, 768px, and 1440px widths

## Testing
- `npm run build`
- PHPUnit: 16 tests, 44 assertions
- `git diff --check`
- max-icon layout contract at 320px, 375px, 768px, and 1440px

## Lint
- `npm run lint:css` remains blocked by 1,567 pre-existing violations; targeted stylesheet lint likewise reports only existing baseline violations

Closes #125