### PR TITLE
feat: link pages to canonical artist profiles

### DIFF
--- a/assets/css/extrch-links.css
+++ b/assets/css/extrch-links.css
@@ -206,12 +206,34 @@ body {
   width: 100%;
  }
 
-.extrch-link-page-powered {
-  margin-top: 2em;
-  font-size: 0.98em;
+.extrch-link-page-footer {
+  width: 100%;
+  margin-top: auto;
+  padding: 2em 0 1em;
   color: var(--link-page-muted-text-color);
-  font-family: var(--link-page-body-font-family); /* Directly apply body font */
+  font-family: var(--link-page-body-font-family);
   text-align: center;
+}
+
+.extrch-link-page-profile-continuation {
+  display: inline-flex;
+  min-height: 44px;
+  max-width: 100%;
+  align-items: center;
+  color: var(--link-page-link-text-color);
+  font-weight: 600;
+  overflow-wrap: anywhere;
+  text-decoration: underline;
+}
+
+.extrch-link-page-profile-continuation:hover {
+  color: var(--link-page-button-hover-bg-color);
+}
+
+.extrch-link-page-powered {
+  margin-top: 0.5em;
+  font-size: 0.875em;
+  color: var(--link-page-muted-text-color);
 }
 .extrch-link-page-powered a {
   color: var(--link-page-link-text-color); /* Consistent link text color */
@@ -294,6 +316,9 @@ body {
   .extrch-link-page-link {
     font-size: 1em;
     padding: 0.85em .95em;
+  }
+  .extrch-link-page-footer {
+    padding-bottom: 0.5em;
   }
 }
 

--- a/inc/core/filters/templates.php
+++ b/inc/core/filters/templates.php
@@ -46,6 +46,10 @@ function ec_template_handler( $output, $template_name, $args = array() ) {
             'file' => 'inc/link-pages/live/templates/components/link-section.php',
             'required' => array( 'links' )
         ),
+        'profile-continuation' => array(
+            'file' => 'inc/link-pages/live/templates/components/profile-continuation.php',
+            'required' => array()
+        ),
         'social-icon' => array(
             'file' => 'inc/link-pages/live/templates/components/social-icon.php',
             'required' => array( 'social_data' )

--- a/inc/link-pages/live/templates/components/profile-continuation.php
+++ b/inc/link-pages/live/templates/components/profile-continuation.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Link page footer with a canonical artist profile continuation.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$args = wp_parse_args(
+	$args ?? array(),
+	array(
+		'artist_profile' => null,
+		'powered_by'     => true,
+	)
+);
+
+$artist_profile = $args['artist_profile'];
+$profile_url    = '';
+$profile_label  = '';
+
+if (
+	is_object( $artist_profile )
+	&& ! empty( $artist_profile->ID )
+	&& 'artist_profile' === ( $artist_profile->post_type ?? '' )
+	&& 'publish' === ( $artist_profile->post_status ?? '' )
+) {
+	$artist_name = get_the_title( $artist_profile->ID );
+	$profile_url = get_permalink( $artist_profile->ID );
+
+	if ( $artist_name && $profile_url ) {
+		/* translators: %s: artist name. */
+		$profile_label = sprintf( __( 'View %s on Extra Chill', 'extrachill-artist-platform' ), $artist_name );
+	}
+}
+
+if ( ! $profile_label && ! $args['powered_by'] ) {
+	return;
+}
+
+$powered_by_url = $args['powered_by']
+	? ec_get_site_url( 'main' ) . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power'
+	: '';
+?>
+<footer class="extrch-link-page-footer">
+	<?php if ( $profile_label ) : ?>
+		<a
+			class="extrch-link-page-profile-continuation"
+			href="<?php echo esc_url( $profile_url ); ?>"
+			rel="noopener"
+		><span class="extrch-link-page-link-text"><?php echo esc_html( $profile_label ); ?></span></a>
+	<?php endif; ?>
+	<?php if ( $args['powered_by'] ) : ?>
+		<div class="extrch-link-page-powered">
+			<a href="<?php echo esc_url( $powered_by_url ); ?>" rel="noopener">Powered by Extra Chill</a>
+		</div>
+	<?php endif; ?>
+</footer>

--- a/inc/link-pages/live/templates/extrch-link-page-template.php
+++ b/inc/link-pages/live/templates/extrch-link-page-template.php
@@ -196,15 +196,15 @@ $body_bg_style = '';
         }
         ?>
 
-        <?php if ($data['powered_by']):
-            // Route the generic footer credit to the main site's network discovery page,
-            // with UTM params for attribution.
-            $powered_by_url = ec_get_site_url('main') . '/power/?utm_source=linkpage&utm_medium=footer&utm_campaign=power';
+        <?php
+        echo ec_render_template(
+            'profile-continuation',
+            array(
+                'artist_profile' => $data['artist_profile'] ?? null,
+                'powered_by'     => $data['powered_by'],
+            )
+        );
         ?>
-        <div class="extrch-link-page-powered" style="margin-top:auto; padding-top:1em; padding-bottom:1em;">
-            <a href="<?php echo esc_url($powered_by_url); ?>" rel="noopener">Powered by Extra Chill</a>
-        </div>
-        <?php endif; ?>
     </div>
 
     <?php

--- a/tests/LinkPageProfileContinuationTest.php
+++ b/tests/LinkPageProfileContinuationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'wp_parse_args' ) ) {
+	function wp_parse_args( $args, $defaults ) {
+		return array_merge( $defaults, $args );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'ec_get_site_url' ) ) {
+	function ec_get_site_url( $site ) {
+		return 'main' === $site ? 'https://extrachill.com' : '';
+	}
+}
+
+final class LinkPageProfileContinuationTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'posts'      => array(),
+			'permalinks' => array(),
+		);
+	}
+
+	private function render_continuation( $artist_profile, bool $powered_by = true ): string {
+		$args = array(
+			'artist_profile' => $artist_profile,
+			'powered_by'     => $powered_by,
+		);
+
+		ob_start();
+		require dirname( __DIR__ ) . '/inc/link-pages/live/templates/components/profile-continuation.php';
+		return ob_get_clean();
+	}
+
+	private function add_artist( string $status = 'publish', string $title = 'The Chill Band' ): object {
+		$artist = (object) array(
+			'ID'          => 127,
+			'post_type'   => 'artist_profile',
+			'post_status' => $status,
+			'post_title'  => $title,
+			'post_name'   => 'the-chill-band',
+		);
+
+		$GLOBALS['ec_test']['posts'][ 127 ] = $artist;
+		return $artist;
+	}
+
+	public function test_published_relationship_renders_canonical_profile_before_secondary_branding(): void {
+		$html = $this->render_continuation( $this->add_artist() );
+
+		$this->assertStringContainsString( 'View The Chill Band on Extra Chill', $html );
+		$this->assertStringContainsString( 'https://artist.example/artists/the-chill-band/', $html );
+		$this->assertLessThan(
+			strpos( $html, 'Powered by Extra Chill' ),
+			strpos( $html, 'View The Chill Band on Extra Chill' )
+		);
+	}
+
+	public function test_unpublished_relationship_keeps_only_secondary_branding(): void {
+		$html = $this->render_continuation( $this->add_artist( 'draft' ) );
+
+		$this->assertStringNotContainsString( 'extrch-link-page-profile-continuation', $html );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $html );
+	}
+
+	public function test_missing_relationship_keeps_only_secondary_branding(): void {
+		$html = $this->render_continuation( null );
+
+		$this->assertStringNotContainsString( 'extrch-link-page-profile-continuation', $html );
+		$this->assertStringContainsString( 'Powered by Extra Chill', $html );
+	}
+
+	public function test_custom_domain_permalink_and_artist_name_are_escaped(): void {
+		$artist = $this->add_artist( 'publish', 'A & B <script>alert("x")</script>' );
+		$GLOBALS['ec_test']['permalinks'][ 127 ] = 'https://artist.custom.example/a-and-b/?from=link&page=footer';
+
+		$html = $this->render_continuation( $artist );
+
+		$this->assertStringContainsString(
+			'https://artist.custom.example/a-and-b/?from=link&amp;page=footer',
+			$html
+		);
+		$this->assertStringContainsString(
+			'View A &amp; B &lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; on Extra Chill',
+			$html
+		);
+		$this->assertStringNotContainsString( '<script>', $html );
+	}
+
+	public function test_profile_continuation_has_semantic_footer_and_descriptive_accessible_name(): void {
+		$html = $this->render_continuation( $this->add_artist() );
+		$document = new DOMDocument();
+		$use_internal_errors = libxml_use_internal_errors( true );
+		$document->loadHTML( '<!DOCTYPE html><html><body>' . $html . '</body></html>' );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $use_internal_errors );
+		$xpath = new DOMXPath( $document );
+		$link = $xpath->query(
+			'//footer[contains(concat(" ", normalize-space(@class), " "), " extrch-link-page-footer ")]/a[contains(concat(" ", normalize-space(@class), " "), " extrch-link-page-profile-continuation ")]'
+		)->item( 0 );
+
+		$this->assertNotNull( $link );
+		$this->assertSame( 'View The Chill Band on Extra Chill', trim( $link->textContent ) );
+		$this->assertSame( 'noopener', $link->getAttribute( 'rel' ) );
+	}
+
+	public function test_footer_remains_outside_curated_link_section_rendering(): void {
+		$template = file_get_contents( dirname( __DIR__ ) . '/inc/link-pages/live/templates/extrch-link-page-template.php' );
+
+		$this->assertGreaterThan(
+			strpos( $template, 'foreach ($link_sections as $section)' ),
+			strpos( $template, "'profile-continuation'" )
+		);
+	}
+
+	public function test_footer_has_mobile_safe_wrapping_and_touch_target_styles(): void {
+		$styles = file_get_contents( dirname( __DIR__ ) . '/assets/css/extrch-links.css' );
+
+		$this->assertMatchesRegularExpression(
+			'/\\.extrch-link-page-profile-continuation\\s*\\{[^}]*min-height:\\s*44px;[^}]*overflow-wrap:\\s*anywhere;/s',
+			$styles
+		);
+		$this->assertMatchesRegularExpression(
+			'/@media \\(max-width:\s*600px\\)[^{]*\\{.*\\.extrch-link-page-footer\\s*\\{/s',
+			$styles
+		);
+	}
+
+	public function test_footer_links_keep_delegated_click_text_tracking(): void {
+		$html = $this->render_continuation( $this->add_artist() );
+		$script = file_get_contents( dirname( __DIR__ ) . '/inc/link-pages/live/assets/js/link-page-public-tracking.js' );
+
+		$this->assertStringContainsString( 'class="extrch-link-page-link-text"', $html );
+		$this->assertStringContainsString( "event.target.closest('a')", $script );
+		$this->assertStringContainsString( 'destination_url: linkElement.href', $script );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,6 +64,10 @@ function get_post_field( $field, $post_id ) {
 }
 
 function get_permalink( $post_id ) {
+	if ( isset( $GLOBALS['ec_test']['permalinks'][ $post_id ] ) ) {
+		return $GLOBALS['ec_test']['permalinks'][ $post_id ];
+	}
+
 	return 'https://artist.example/artists/' . get_post_field( 'post_name', $post_id ) . '/';
 }
 


### PR DESCRIPTION
## Summary
- add a primary `View [Artist] on Extra Chill` footer continuation for related published artist profiles
- use the profile's canonical WordPress permalink so mapped/custom domains remain intact, while keeping Powered by Extra Chill secondary
- keep the continuation outside artist-curated link sections and compatible with existing delegated click analytics
- cover relationship state, custom domains, escaping, accessibility, mobile behavior, render output, and curated ordering

## Verification
- `vendor/bin/phpunit --do-not-cache-result` (24 tests, 63 assertions)
- `npm run build`
- changed PHP syntax checks with `php -l`
- live WordPress runtime render smoke against the Extra Chill profile and canonical permalink
- public route HTTP smoke: `https://extrachill.link/extra-chill/` resolves successfully
- `git diff --check`

## Lint Baseline
- repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by existing baseline violations (2,200 JS findings and 1,583 CSS findings)
- PHP_CodeSniffer is installed by Composer, but this repository does not include the referenced WordPress coding standard
- no headless browser executable or bundled Playwright browser is available on the host; DOM render assertions, mobile CSS assertions, live runtime rendering, and HTTP routing were used for smoke coverage

Closes #127