### PR TITLE
Expose artist subscriptions on canonical profiles

### DIFF
--- a/assets/css/artist-profile-subscribe.css
+++ b/assets/css/artist-profile-subscribe.css
@@ -1,0 +1,54 @@
+.extrch-profile-subscribe-inline-form-container {
+	box-sizing: border-box;
+	width: min(100%, 680px);
+	margin: 0 auto 2em;
+	padding: 1.5em;
+	border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+	border-radius: 8px;
+	background: var(--card-background, #fff);
+	box-shadow: var(--card-shadow, 0 2px 8px rgba(0, 0, 0, 0.08));
+}
+
+.extrch-profile-subscribe-inline-form-container h3,
+.extrch-profile-subscribe-inline-form-container p {
+	margin-top: 0;
+	text-align: center;
+}
+
+.extrch-profile-subscribe-inline-form-container .extrch-subscribe-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 0.75em;
+	align-items: start;
+}
+
+.extrch-profile-subscribe-inline-form-container input[type="email"] {
+	box-sizing: border-box;
+	width: 100%;
+	min-height: 44px;
+}
+
+.extrch-profile-subscribe-inline-form-container button[type="submit"] {
+	min-height: 44px;
+}
+
+.extrch-profile-subscribe-inline-form-container .extrch-form-message {
+	grid-column: 1 / -1;
+	min-height: 1.5em;
+	text-align: center;
+}
+
+@media (max-width: 600px) {
+
+	.extrch-profile-subscribe-inline-form-container {
+		padding: 1.25em 1em;
+	}
+
+	.extrch-profile-subscribe-inline-form-container .extrch-subscribe-form {
+		grid-template-columns: 1fr;
+	}
+
+	.extrch-profile-subscribe-inline-form-container button[type="submit"] {
+		width: 100%;
+	}
+}

--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -84,6 +84,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/breadcrumbs.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/section-registry.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/default-sections.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/subscribe-section.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/shows-section.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/frontend/coverage-section.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/subscribe-data-functions.php';

--- a/inc/artist-profiles/frontend/subscribe-section.php
+++ b/inc/artist-profiles/frontend/subscribe-section.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Artist profile subscription section.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Load the shared subscription behavior and profile-specific presentation.
+ *
+ * @return void
+ */
+function ec_enqueue_artist_profile_subscribe_assets() {
+	if ( ! is_singular( 'artist_profile' ) ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'extrachill-artist-profile-subscribe',
+		EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/artist-profile-subscribe.css',
+		array( 'extrachill-artist-profile' ),
+		EXTRACHILL_ARTIST_PLATFORM_VERSION
+	);
+
+	wp_enqueue_script(
+		'extrachill-subscribe',
+		EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'inc/link-pages/live/assets/js/link-page-subscribe.js',
+		array(),
+		EXTRACHILL_ARTIST_PLATFORM_VERSION,
+		true
+	);
+}
+add_action( 'wp_enqueue_scripts', 'ec_enqueue_artist_profile_subscribe_assets' );
+
+/**
+ * Register the artist-specific subscription form on canonical profiles.
+ *
+ * @param array[] $sections Registered profile sections.
+ * @return array[]
+ */
+function ec_register_artist_profile_subscribe_section( $sections ) {
+	$sections[] = array(
+		'id'       => 'subscribe',
+		'label'    => __( 'Subscribe', 'extrachill-artist-platform' ),
+		'priority' => 15,
+		'as_tab'   => false,
+		'render'   => 'ec_render_artist_profile_subscribe_section',
+		'visible'  => 'ec_is_artist_profile_subscribe_section_visible',
+	);
+
+	return $sections;
+}
+add_filter( 'ec_artist_profile_sections', 'ec_register_artist_profile_subscribe_section', 10, 1 );
+
+/**
+ * Show subscriptions only for public artists that have not disabled the flow.
+ *
+ * @param int $artist_profile_id Artist profile post ID.
+ * @return bool
+ */
+function ec_is_artist_profile_subscribe_section_visible( $artist_profile_id ) {
+	if ( 'publish' !== get_post_status( $artist_profile_id ) ) {
+		return false;
+	}
+
+	$data = ec_get_artist_profile_subscribe_section_data( $artist_profile_id );
+
+	return 'disabled' !== ( $data['_link_page_subscribe_display_mode'] ?? '' );
+}
+
+/**
+ * Get existing link-page subscription settings for the profile form.
+ *
+ * @param int $artist_profile_id Artist profile post ID.
+ * @return array
+ */
+function ec_get_artist_profile_subscribe_section_data( $artist_profile_id ) {
+	$link_page_id = (int) apply_filters( 'ec_get_link_page_id', $artist_profile_id );
+
+	if ( $link_page_id > 0 && function_exists( 'ec_get_link_page_data' ) ) {
+		return ec_get_link_page_data( $artist_profile_id, $link_page_id );
+	}
+
+	return array();
+}
+
+/**
+ * Render the existing artist-specific inline subscription form.
+ *
+ * @param int $artist_profile_id Artist profile post ID.
+ * @return void
+ */
+function ec_render_artist_profile_subscribe_section( $artist_profile_id ) {
+	$endpoint = rest_url( 'extrachill/v1/artists/' . absint( $artist_profile_id ) . '/subscribe' );
+
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The template escapes its values.
+	echo ec_render_template(
+		'subscribe-inline-form',
+		array(
+			'artist_id'         => $artist_profile_id,
+			'artist_name'       => get_the_title( $artist_profile_id ),
+			'data'              => ec_get_artist_profile_subscribe_section_data( $artist_profile_id ),
+			'context'           => 'profile',
+			'subscribe_api_url' => $endpoint,
+		)
+	);
+}

--- a/inc/link-pages/live/assets/js/link-page-subscribe.js
+++ b/inc/link-pages/live/assets/js/link-page-subscribe.js
@@ -1,130 +1,152 @@
 /**
- * Handles frontend behavior for the Band Link Page Subscription feature.
+ * Handles artist subscription forms on profiles and link pages.
  * Uses REST API for form submission.
  */
 
-document.addEventListener('DOMContentLoaded', function() {
-    const subscribeModal = document.getElementById('extrch-subscribe-modal');
-    const subscribeIconTrigger = document.querySelector('.extrch-subscribe-icon-trigger');
-    const modalCloseButton = subscribeModal ? subscribeModal.querySelector('.extrch-subscribe-modal-close') : null;
-    const modalOverlay = subscribeModal ? subscribeModal.querySelector('.extrch-subscribe-modal-overlay') : null;
-    const modalForm = subscribeModal ? subscribeModal.querySelector('#extrch-subscribe-form-modal') : null;
-    const inlineForm = document.getElementById('extrch-subscribe-form-inline');
+document.addEventListener( 'DOMContentLoaded', function () {
+	const subscribeModal = document.getElementById( 'extrch-subscribe-modal' );
+	const subscribeIconTrigger = document.querySelector(
+		'.extrch-subscribe-icon-trigger'
+	);
+	const modalCloseButton = subscribeModal
+		? subscribeModal.querySelector( '.extrch-subscribe-modal-close' )
+		: null;
+	const modalOverlay = subscribeModal
+		? subscribeModal.querySelector( '.extrch-subscribe-modal-overlay' )
+		: null;
+	const modalForm = subscribeModal
+		? subscribeModal.querySelector( '#extrch-subscribe-form-modal' )
+		: null;
+	const subscribeForms = document.querySelectorAll(
+		'.extrch-subscribe-form'
+	);
 
-    function closeSubscribeModal() {
-        if (subscribeModal) {
-            subscribeModal.classList.add('extrch-modal-hidden');
-            document.body.classList.remove('extrch-modal-open');
-            if (modalForm) {
-                modalForm.reset();
-                const formMessage = modalForm.querySelector('.extrch-form-message');
-                if (formMessage) formMessage.textContent = '';
-            }
-        }
-    }
+	function closeSubscribeModal() {
+		if ( subscribeModal ) {
+			subscribeModal.classList.add( 'extrch-modal-hidden' );
+			document.body.classList.remove( 'extrch-modal-open' );
+			if ( modalForm ) {
+				modalForm.reset();
+				const formMessage = modalForm.querySelector(
+					'.extrch-form-message'
+				);
+				if ( formMessage ) {
+					formMessage.textContent = '';
+				}
+			}
+		}
+	}
 
-    if (subscribeModal && subscribeIconTrigger) {
-        subscribeIconTrigger.addEventListener('click', function() {
-            subscribeModal.classList.remove('extrch-modal-hidden');
-            document.body.classList.add('extrch-modal-open');
-        });
+	if ( subscribeModal && subscribeIconTrigger ) {
+		subscribeIconTrigger.addEventListener( 'click', function () {
+			subscribeModal.classList.remove( 'extrch-modal-hidden' );
+			document.body.classList.add( 'extrch-modal-open' );
+		} );
 
-        if (modalCloseButton) {
-            modalCloseButton.addEventListener('click', closeSubscribeModal);
-        }
-        if (modalOverlay) {
-            modalOverlay.addEventListener('click', closeSubscribeModal);
-        }
+		if ( modalCloseButton ) {
+			modalCloseButton.addEventListener( 'click', closeSubscribeModal );
+		}
+		if ( modalOverlay ) {
+			modalOverlay.addEventListener( 'click', closeSubscribeModal );
+		}
 
-        document.addEventListener('keydown', function(event) {
-            if (event.key === 'Escape') {
-                closeSubscribeModal();
-            }
-        });
-    }
+		document.addEventListener( 'keydown', function ( event ) {
+			if ( event.key === 'Escape' ) {
+				closeSubscribeModal();
+			}
+		} );
+	}
 
-    function handleFormSubmission(event) {
-        event.preventDefault();
+	function handleFormSubmission( event ) {
+		event.preventDefault();
 
-        const form = event.target;
-        const submitButton = form.querySelector('button[type="submit"]');
-        const formMessage = form.querySelector('.extrch-form-message');
-        const emailInput = form.querySelector('input[type="email"]');
+		const form = event.target;
+		const formMessage = form.querySelector( '.extrch-form-message' );
+		const emailInput = form.querySelector( 'input[type="email"]' );
 
-        if (!emailInput || !emailInput.value) {
-            if (formMessage) {
-                formMessage.textContent = 'Please enter your email address.';
-                formMessage.style.color = 'red';
-            }
-            return;
-        }
+		if ( ! emailInput || ! emailInput.value ) {
+			if ( formMessage ) {
+				formMessage.textContent = 'Please enter your email address.';
+				formMessage.style.color = 'red';
+			}
+			return;
+		}
 
-        if (submitButton) {
-            submitButton.disabled = true;
-            submitButton.textContent = 'Subscribing...';
-        }
-        if (formMessage) {
-            formMessage.textContent = '';
-            formMessage.style.color = '';
-        }
+		const submitButton = form.querySelector( 'button[type="submit"]' );
 
-        const subscribeApiUrl = document.body && document.body.dataset ? document.body.dataset.extrchSubscribeApiUrl : '';
-        if (!subscribeApiUrl) {
-            if (formMessage) {
-                formMessage.textContent = 'Subscription is temporarily unavailable.';
-                formMessage.style.color = 'red';
-            }
-            if (submitButton) {
-                submitButton.disabled = false;
-                submitButton.textContent = 'Subscribe';
-            }
-            return;
-        }
+		if ( submitButton ) {
+			submitButton.disabled = true;
+			submitButton.textContent = 'Subscribing...';
+		}
+		form.setAttribute( 'aria-busy', 'true' );
+		if ( formMessage ) {
+			formMessage.textContent = '';
+			formMessage.style.color = '';
+		}
 
-        fetch(subscribeApiUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                email: emailInput.value
-            })
-        })
-        .then(response => {
-            if (!response.ok) {
-                return response.json().then(err => Promise.reject(err));
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (formMessage) {
-                formMessage.textContent = data.message || 'Success!';
-                formMessage.style.color = 'green';
-            }
-            form.reset();
-            if (form.id === 'extrch-subscribe-form-modal') {
-                setTimeout(closeSubscribeModal, 2000);
-            }
-        })
-        .catch(error => {
-            if (formMessage) {
-                formMessage.textContent = error.message || 'An unexpected error occurred.';
-                formMessage.style.color = 'red';
-            }
-        })
-        .finally(() => {
-            if (submitButton) {
-                submitButton.disabled = false;
-                submitButton.textContent = 'Subscribe';
-            }
-        });
-    }
+		const subscribeApiUrl =
+			form.dataset.subscribeApiUrl ||
+			( document.body && document.body.dataset
+				? document.body.dataset.extrchSubscribeApiUrl
+				: '' );
+		if ( ! subscribeApiUrl ) {
+			if ( formMessage ) {
+				formMessage.textContent =
+					'Subscription is temporarily unavailable.';
+				formMessage.style.color = 'red';
+			}
+			if ( submitButton ) {
+				submitButton.disabled = false;
+				submitButton.textContent = 'Subscribe';
+			}
+			form.removeAttribute( 'aria-busy' );
+			return;
+		}
 
-    if (modalForm) {
-        modalForm.addEventListener('submit', handleFormSubmission);
-    }
+		fetch( subscribeApiUrl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( {
+				email: emailInput.value,
+			} ),
+		} )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					return response
+						.json()
+						.then( ( err ) => Promise.reject( err ) );
+				}
+				return response.json();
+			} )
+			.then( ( data ) => {
+				if ( formMessage ) {
+					formMessage.textContent = data.message || 'Success!';
+					formMessage.style.color = 'green';
+				}
+				form.reset();
+				if ( form.id === 'extrch-subscribe-form-modal' ) {
+					setTimeout( closeSubscribeModal, 2000 );
+				}
+			} )
+			.catch( ( error ) => {
+				if ( formMessage ) {
+					formMessage.textContent =
+						error.message || 'An unexpected error occurred.';
+					formMessage.style.color = 'red';
+				}
+			} )
+			.finally( () => {
+				form.removeAttribute( 'aria-busy' );
+				if ( submitButton ) {
+					submitButton.disabled = false;
+					submitButton.textContent = 'Subscribe';
+				}
+			} );
+	}
 
-    if (inlineForm) {
-        inlineForm.addEventListener('submit', handleFormSubmission);
-    }
-});
+	subscribeForms.forEach( function ( form ) {
+		form.addEventListener( 'submit', handleFormSubmission );
+	} );
+} );

--- a/inc/link-pages/live/templates/subscribe-inline-form.php
+++ b/inc/link-pages/live/templates/subscribe-inline-form.php
@@ -1,38 +1,86 @@
 <?php
 /**
- * Inline Subscribe Form for Artist Link Page
- * Used in extrch-link-page-template.php when display mode is 'inline_form'.
+ * Shared inline artist subscription form.
  *
- * Assumes $artist_id is set by the including template.
+ * Assumes $artist_id is set by the template renderer.
+ *
+ * @package ExtraChillArtistPlatform
  */
 
 defined( 'ABSPATH' ) || exit;
 
-$current_artist_id = apply_filters('ec_get_artist_id', isset($artist_id) ? compact('artist_id') : []);
+$current_artist_id = apply_filters( 'ec_get_artist_id', isset( $artist_id ) ? compact( 'artist_id' ) : array() );
 
-if (empty($current_artist_id)) {
-    return;
+if ( empty( $current_artist_id ) ) {
+	return;
 }
 
-$artist_name = isset($artist_name) ? $artist_name : (isset($data['display_title']) ? $data['display_title'] : '');
+$data              = isset( $data ) && is_array( $data ) ? $data : array();
+$artist_name       = isset( $artist_name ) ? $artist_name : ( $data['display_title'] ?? '' );
+$context           = isset( $context ) && 'profile' === $context ? 'profile' : 'link-page';
+$form_id           = 'extrch-subscribe-form-' . $context . '-' . absint( $current_artist_id );
+$email_id          = 'subscriber-email-' . $context . '-' . absint( $current_artist_id );
+$description_id    = $form_id . '-description';
+$message_id        = $form_id . '-message';
+$subscribe_api_url = isset( $subscribe_api_url ) ? $subscribe_api_url : '';
+
+if ( ! empty( $data['_link_page_subscribe_description'] ) ) {
+	$subscribe_description = $data['_link_page_subscribe_description'];
+} else {
+	$subscribe_description = sprintf(
+		/* translators: %s: artist name. */
+		__( 'Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform' ),
+		$artist_name
+	);
+}
+
+if ( empty( $artist_name ) ) {
+	$subscribe_heading = __( 'Subscribe', 'extrachill-artist-platform' );
+} else {
+	/* translators: %s: artist name. */
+	$subscribe_heading = sprintf( __( 'Subscribe to %s', 'extrachill-artist-platform' ), $artist_name );
+}
 ?>
 
-<div class="extrch-link-page-subscribe-inline-form-container">
-    <h3 class="extrch-subscribe-header">
-        Subscribe<?php if (!empty($artist_name)) echo ' to ' . esc_html($artist_name); ?>
-    </h3>
-    <p><?php 
-    $subscribe_description = isset($data['_link_page_subscribe_description']) && $data['_link_page_subscribe_description'] !== '' ? $data['_link_page_subscribe_description'] : sprintf(__('Enter your email address to receive occasional news and updates from %s.', 'extrachill-artist-platform'), $artist_name);
-    echo esc_html($subscribe_description);
-    ?></p>
+<section
+	class="extrch-subscribe-inline-form-container extrch-<?php echo esc_attr( $context ); ?>-subscribe-inline-form-container"
+	aria-labelledby="<?php echo esc_attr( $form_id ); ?>-heading"
+>
+	<h3 id="<?php echo esc_attr( $form_id ); ?>-heading" class="extrch-subscribe-header">
+		<?php echo esc_html( $subscribe_heading ); ?>
+	</h3>
+	<p id="<?php echo esc_attr( $description_id ); ?>"><?php echo esc_html( $subscribe_description ); ?></p>
 
-    <form id="extrch-subscribe-form-inline" class="extrch-subscribe-form">
-        <div class="form-group">
-            <input type="email" name="subscriber_email" id="subscriber_email_inline" placeholder="<?php esc_attr_e('Your email address', 'extrachill-artist-platform'); ?>" required aria-label="<?php esc_attr_e('Email Address', 'extrachill-artist-platform'); ?>">
-        </div>
+	<form
+		id="<?php echo esc_attr( $form_id ); ?>"
+		class="extrch-subscribe-form"
+		data-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>"
+		aria-describedby="<?php echo esc_attr( $description_id ); ?>"
+	>
+		<div class="form-group">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $email_id ); ?>">
+				<?php esc_html_e( 'Email Address', 'extrachill-artist-platform' ); ?>
+			</label>
+			<input
+				type="email"
+				name="subscriber_email"
+				id="<?php echo esc_attr( $email_id ); ?>"
+				placeholder="<?php esc_attr_e( 'Your email address', 'extrachill-artist-platform' ); ?>"
+				required
+				autocomplete="email"
+				aria-describedby="<?php echo esc_attr( $description_id ); ?>"
+			>
+		</div>
 
-        <button type="submit" class="button-1 button-medium"><?php esc_html_e('Subscribe', 'extrachill-artist-platform'); ?></button>
+		<button type="submit" class="button-1 button-medium">
+			<?php esc_html_e( 'Subscribe', 'extrachill-artist-platform' ); ?>
+		</button>
 
-        <div class="extrch-form-message" aria-live="polite"></div>
-    </form>
-</div>
+		<div
+			id="<?php echo esc_attr( $message_id ); ?>"
+			class="extrch-form-message"
+			role="status"
+			aria-live="polite"
+		></div>
+	</form>
+</section>

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "wp-scripts build",
     "start": "wp-scripts start",
+    "test:js": "wp-scripts test-unit-js --runInBand",
     "lint:js": "wp-scripts lint-js",
     "lint:css": "wp-scripts lint-style",
     "format": "wp-scripts format",

--- a/tests/ArtistProfileSubscribeTest.php
+++ b/tests/ArtistProfileSubscribeTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook, $value ) {
+		if ( 'ec_get_artist_id' === $hook && is_array( $value ) ) {
+			return (int) ( $value['artist_id'] ?? 0 );
+		}
+
+		if ( 'ec_get_link_page_id' === $hook ) {
+			return (int) ( $GLOBALS['ec_test']['link_page_id'] ?? 0 );
+		}
+
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_post_status' ) ) {
+	function get_post_status( $post_id ) {
+		return $GLOBALS['ec_test']['posts'][ $post_id ]->post_status ?? false;
+	}
+}
+
+if ( ! function_exists( 'ec_get_link_page_data' ) ) {
+	function ec_get_link_page_data() {
+		return $GLOBALS['ec_test']['subscribe_data'] ?? array();
+	}
+}
+
+if ( ! function_exists( 'ec_get_link_page_defaults_for' ) ) {
+	function ec_get_link_page_defaults_for() {
+		return array(
+			'--link-page-card-bg-color'         => '#fff',
+			'--link-page-link-text-color'        => '#000',
+			'--link-page-title-font-family'      => 'sans-serif',
+			'--link-page-body-font-family'       => 'sans-serif',
+			'--link-page-background-type'        => 'color',
+			'--link-page-background-color'       => '#fff',
+			'--link-page-button-hover-bg-color'  => '#000',
+			'--link-page-button-border-color'    => '#000',
+			'--link-page-button-bg-color'        => '#fff',
+			'--link-page-muted-text-color'       => '#555',
+			'--link-page-input-bg'               => '#fff',
+			'--link-page-button-radius'          => '4px',
+		);
+	}
+}
+
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( $path = '' ) {
+		return 'https://artist.example/wp-json/' . ltrim( $path, '/' );
+	}
+}
+
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $value ) {
+		return abs( (int) $value );
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $value ) {
+		return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+	}
+}
+
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $value ) {
+		echo esc_html( $value );
+	}
+}
+
+if ( ! function_exists( 'esc_attr_e' ) ) {
+	function esc_attr_e( $value ) {
+		echo esc_attr( $value );
+	}
+}
+
+if ( ! function_exists( 'is_user_logged_in' ) ) {
+	function is_user_logged_in() {
+		return ! empty( $GLOBALS['ec_test']['logged_in'] );
+	}
+}
+
+if ( ! function_exists( 'ec_render_template' ) ) {
+	function ec_render_template( $template_name, $args = array() ) {
+		if ( 'subscribe-inline-form' !== $template_name ) {
+			return '';
+		}
+
+		extract( $args, EXTR_SKIP );
+		ob_start();
+		include dirname( __DIR__ ) . '/inc/link-pages/live/templates/subscribe-inline-form.php';
+		return ob_get_clean();
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/artist-profiles/frontend/subscribe-section.php';
+
+final class ArtistProfileSubscribeTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'posts'          => array(
+				42 => (object) array(
+					'ID'          => 42,
+					'post_title'  => 'Test Artist',
+					'post_status' => 'publish',
+				),
+			),
+			'link_page_id'   => 84,
+			'meta'           => array( 84 => array() ),
+			'subscribe_data' => array(),
+		);
+	}
+
+	public function test_registers_a_bounded_profile_section(): void {
+		$sections = ec_register_artist_profile_subscribe_section( array() );
+
+		$this->assertSame( 'subscribe', $sections[0]['id'] );
+		$this->assertSame( 15, $sections[0]['priority'] );
+		$this->assertSame( 'ec_render_artist_profile_subscribe_section', $sections[0]['render'] );
+		$this->assertSame( 'ec_is_artist_profile_subscribe_section_visible', $sections[0]['visible'] );
+	}
+
+	public function test_visibility_rejects_unpublished_and_disabled_artists(): void {
+		$this->assertTrue( ec_is_artist_profile_subscribe_section_visible( 42 ) );
+
+		$GLOBALS['ec_test']['meta'][84]['_link_page_subscribe_display_mode'] = array( 'disabled' );
+		$this->assertFalse( ec_is_artist_profile_subscribe_section_visible( 42 ) );
+
+		$GLOBALS['ec_test']['meta'][84] = array();
+		$GLOBALS['ec_test']['posts'][42]->post_status = 'draft';
+		$this->assertFalse( ec_is_artist_profile_subscribe_section_visible( 42 ) );
+	}
+
+	/**
+	 * @dataProvider authentication_states
+	 */
+	public function test_profile_form_is_public_and_accessible( bool $logged_in ): void {
+		$GLOBALS['ec_test']['logged_in'] = $logged_in;
+
+		ob_start();
+		ec_render_artist_profile_subscribe_section( 42 );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'Subscribe to Test Artist', $html );
+		$this->assertStringContainsString( 'data-subscribe-api-url="https://artist.example/wp-json/extrachill/v1/artists/42/subscribe"', $html );
+		$this->assertStringContainsString( 'autocomplete="email"', $html );
+
+		$document = new DOMDocument();
+		libxml_use_internal_errors( true );
+		$document->loadHTML( '<!DOCTYPE html><html><body>' . $html . '</body></html>' );
+		libxml_clear_errors();
+		$xpath = new DOMXPath( $document );
+		$input = $xpath->query( '//input[@type="email"]' )->item( 0 );
+		$label = $xpath->query( '//label[@for="' . $input->getAttribute( 'id' ) . '"]' )->item( 0 );
+		$status = $xpath->query( '//*[@role="status" and @aria-live="polite"]' )->item( 0 );
+
+		$this->assertNotNull( $label );
+		$this->assertNotNull( $status );
+		$this->assertSame( 'Email Address', trim( $label->textContent ) );
+	}
+
+	public static function authentication_states(): array {
+		return array(
+			'logged out' => array( false ),
+			'logged in'  => array( true ),
+		);
+	}
+
+	public function test_reused_form_preserves_custom_description_and_domain_endpoint(): void {
+		$html = ec_render_template(
+			'subscribe-inline-form',
+			array(
+				'artist_id'         => 42,
+				'artist_name'       => 'Test Artist',
+				'data'              => array( '_link_page_subscribe_description' => 'Artist-approved updates only.' ),
+				'subscribe_api_url' => 'https://artist.example/wp-json/extrachill/v1/artists/42/subscribe',
+			)
+		);
+
+		$this->assertStringContainsString( 'Artist-approved updates only.', $html );
+		$this->assertStringContainsString( 'extrch-link-page-subscribe-inline-form-container', $html );
+		$this->assertStringContainsString( 'https://artist.example/wp-json/extrachill/v1/artists/42/subscribe', $html );
+	}
+
+	public function test_profile_styles_include_mobile_single_column_layout(): void {
+		$styles = file_get_contents( dirname( __DIR__ ) . '/assets/css/artist-profile-subscribe.css' );
+
+		$this->assertStringContainsString( '@media (max-width: 600px)', $styles );
+		$this->assertStringContainsString( '.extrch-profile-subscribe-inline-form-container', $styles );
+		$this->assertStringContainsString( 'grid-template-columns: 1fr;', $styles );
+	}
+}

--- a/tests/js/artist-subscribe.test.js
+++ b/tests/js/artist-subscribe.test.js
@@ -1,0 +1,98 @@
+require( '../../inc/link-pages/live/assets/js/link-page-subscribe.js' );
+
+function mountForm( endpoint = '' ) {
+	document.body.innerHTML = `
+		<form class="extrch-subscribe-form" data-subscribe-api-url="${ endpoint }">
+			<input type="email" value="fan@example.com">
+			<button type="submit">Subscribe</button>
+			<div class="extrch-form-message" role="status" aria-live="polite"></div>
+		</form>
+	`;
+
+	document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+
+	return document.querySelector( 'form' );
+}
+
+async function submit( form ) {
+	form.dispatchEvent(
+		new Event( 'submit', { bubbles: true, cancelable: true } )
+	);
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+describe( 'artist subscription form', () => {
+	beforeEach( () => {
+		document.body.removeAttribute( 'data-extrch-subscribe-api-url' );
+		global.fetch = jest.fn();
+	} );
+
+	test( 'submits to the form endpoint and reports success', async () => {
+		fetch.mockResolvedValue( {
+			ok: true,
+			json: () =>
+				Promise.resolve( { message: 'Thank you for subscribing!' } ),
+		} );
+		const form = mountForm( 'https://artist.example/subscribe' );
+
+		await submit( form );
+
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://artist.example/subscribe',
+			expect.objectContaining( {
+				method: 'POST',
+				body: JSON.stringify( { email: 'fan@example.com' } ),
+			} )
+		);
+		expect( form.querySelector( '[role="status"]' ).textContent ).toBe(
+			'Thank you for subscribing!'
+		);
+		expect( form.hasAttribute( 'aria-busy' ) ).toBe( false );
+	} );
+
+	test( 'reports the existing duplicate-subscription response', async () => {
+		fetch.mockResolvedValue( {
+			ok: false,
+			json: () =>
+				Promise.resolve( {
+					message: 'You are already subscribed to this artist.',
+				} ),
+		} );
+		const form = mountForm( 'https://artist.example/subscribe' );
+
+		await submit( form );
+
+		expect( form.querySelector( '[role="status"]' ).textContent ).toBe(
+			'You are already subscribed to this artist.'
+		);
+	} );
+
+	test( 'fails accessibly without an endpoint and does not submit', async () => {
+		const form = mountForm();
+
+		await submit( form );
+
+		expect( fetch ).not.toHaveBeenCalled();
+		expect( form.querySelector( '[role="status"]' ).textContent ).toBe(
+			'Subscription is temporarily unavailable.'
+		);
+		expect( form.querySelector( 'button' ).disabled ).toBe( false );
+	} );
+
+	test( 'prefers the per-form endpoint over the custom-domain body fallback', async () => {
+		document.body.dataset.extrchSubscribeApiUrl =
+			'https://custom.example/body-endpoint';
+		fetch.mockResolvedValue( {
+			ok: true,
+			json: () => Promise.resolve( { message: 'Subscribed' } ),
+		} );
+		const form = mountForm( 'https://artist.example/form-endpoint' );
+
+		await submit( form );
+
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://artist.example/form-endpoint',
+			expect.any( Object )
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary
- register a bounded, hero-adjacent subscription section on published canonical artist profiles
- reuse the existing artist subscriber storage, REST adapter, inline form, artist settings, and submission behavior
- preserve accessible status handling, duplicate/error responses, custom-domain endpoint fallback, and responsive profile styling

## Reuse boundary
- no global newsletter form, new subscriber table, ability, or REST route was introduced
- the profile section posts to the existing `/artists/{id}/subscribe` adapter and respects the artist's existing disabled mode and custom description
- the shared form now supports unique profile/link-page instances and per-form endpoints while link pages retain their existing body endpoint fallback

## Tests
- `vendor/bin/phpunit --do-not-cache-result` (22 tests, 69 assertions)
- `npm run test:js` (4 tests: success, duplicate, missing endpoint, custom-domain endpoint precedence)
- changed JS lint and profile subscription CSS lint
- focused WPCS lint for the new section, shared template, and PHP tests
- `npm run build`
- Chromium smoke at 1280px and 390px, including accessible labeling, responsive layout, and successful submission
- `git diff --check`

The file-scoped Homeboy lint also reports 213 pre-existing PHPCS findings in the legacy plugin bootstrap; all new and substantively changed source files pass focused lint.

Closes #126