### PR TITLE
fix: restore share overlay background

### DIFF
--- a/assets/css/extrch-share-modal.css
+++ b/assets/css/extrch-share-modal.css
@@ -129,7 +129,7 @@ body button.extrch-share-item-trigger:active {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: var(--link-page-overlay-color)); /* Use theme variable */
+    background-color: var(--link-page-overlay-color); /* Use theme variable */
     z-index: 1000;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;

--- a/tests/LinkPageShareMarkupTest.php
+++ b/tests/LinkPageShareMarkupTest.php
@@ -67,4 +67,11 @@ final class LinkPageShareMarkupTest extends TestCase {
 		$this->assertStringContainsString( 'openModal(trigger);', $script );
 		$this->assertStringNotContainsString( 'e.stopPropagation();', $script );
 	}
+
+	public function test_share_modal_overlay_has_a_valid_background_color_declaration(): void {
+		$styles = file_get_contents( dirname( __DIR__ ) . '/assets/css/extrch-share-modal.css' );
+
+		$this->assertStringContainsString( 'background-color: var(--link-page-overlay-color);', $styles );
+		$this->assertStringNotContainsString( 'var(--link-page-overlay-color));', $styles );
+	}
 }


### PR DESCRIPTION
## Summary
- remove the extra closing parenthesis from the share-modal overlay background declaration
- add a focused regression assertion for the valid CSS variable syntax

## Browser impact
Browsers previously discarded the malformed `background-color` declaration, leaving the share overlay without its intended themed background. The corrected declaration now resolves `--link-page-overlay-color` normally.

## Verification
- `vendor/bin/phpunit --filter test_share_modal_overlay_has_a_valid_background_color_declaration tests/LinkPageShareMarkupTest.php` - passes (1 test, 2 assertions)
- `npm run lint:css -- assets/css/extrch-share-modal.css` - reaches the targeted stylesheet; fails on 274 pre-existing style violations, with no new violation from the corrected declaration
- `git diff --check` - passes
- Build not applicable: `assets/css/extrch-share-modal.css` is the directly served public stylesheet referenced by the live link-page and editor-preview PHP, not a webpack-transformed asset

Closes #124