### PR TITLE
refactor: remove legacy link-page view beacon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ add_action( 'init', 'extrachill_artist_platform_register_blocks' );
 
 #### Public Link Page Scripts
 **Directory**: `inc/link-pages/live/assets/js/`
-- `link-page-public-tracking.js` - Analytics and click tracking
+- `link-page-public-tracking.js` - Link click tracking
 - `link-page-subscribe.js` - Subscription form functionality
 - `link-page-youtube-embed.js` - YouTube video embed handling
 - `extrch-share-modal.js` - Native Web Share API with social fallbacks
@@ -419,7 +419,7 @@ add_action( 'init', 'extrachill_artist_platform_register_blocks' );
 
 **Key JavaScript Modules**:
 - `join-flow-ui.js` - Join flow modal UI (login/register)
-- `link-page-public-tracking.js` - Link page view + click tracking
+- `link-page-public-tracking.js` - Link page click tracking
 - `link-page-subscribe.js` - Link page subscription form handling
 - `link-page-youtube-embed.js` - YouTube embed handling
 - `extrch-share-modal.js` - Share modal UI

--- a/docs/analytics/analytics-system.md
+++ b/docs/analytics/analytics-system.md
@@ -64,7 +64,7 @@ The tracking flow follows this pattern:
 
 Location: `inc/link-pages/live/assets/js/link-page-public-tracking.js`
 
-Tracks page views and link clicks using sendBeacon API for reliable delivery with Fetch API fallback.
+Tracks link clicks using sendBeacon API for reliable delivery with Fetch API fallback. Page views are recorded by the signed first-party tracker attached to the minimal-head lifecycle.
 
 **Click Tracking Payload**:
 ```javascript

--- a/inc/link-pages/live/assets/js/link-page-public-tracking.js
+++ b/inc/link-pages/live/assets/js/link-page-public-tracking.js
@@ -1,63 +1,69 @@
 /**
- * Public Link Page Tracking - Views and Link Clicks
+ * Public Link Page Click Tracking
  *
- * Tracks page views and link clicks for artist link pages via REST API.
- * Views: Fires on page load, tracked to both all-time counter and 90-day rolling table.
- * Clicks: Fires on link click, URL normalization handled server-side.
+ * Tracks link clicks for artist link pages via REST API.
+ * URL normalization is handled server-side.
  */
 
-(function() {
-    'use strict';
+/* global navigator */
 
-    const body = document.body;
-    const dataset = body && body.dataset ? body.dataset : null;
+( function () {
+	'use strict';
 
-    const clickRestUrl = dataset ? dataset.extrchTrackingClickUrl : '';
-    const viewRestUrl = dataset ? dataset.extrchTrackingViewUrl : '';
-    const linkPageId = dataset ? dataset.extrchLinkPageId : '';
+	const body = document.body;
+	const dataset = body && body.dataset ? body.dataset : null;
 
-    if (!clickRestUrl || !viewRestUrl || !linkPageId) {
-        return;
-    }
+	const clickRestUrl = dataset ? dataset.extrchTrackingClickUrl : '';
+	const linkPageId = dataset ? dataset.extrchLinkPageId : '';
 
-    function sendBeacon(url, data) {
-        const jsonData = JSON.stringify(data);
-        if (navigator.sendBeacon) {
-            navigator.sendBeacon(url, new Blob([jsonData], { type: 'application/json' }));
-        } else {
-            fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: jsonData,
-                keepalive: true
-            }).catch(() => {});
-        }
-    }
+	if ( ! clickRestUrl || ! linkPageId ) {
+		return;
+	}
 
-    // Track page view on load
-    if (viewRestUrl) {
-        sendBeacon(viewRestUrl, { post_id: linkPageId });
-    }
+	function sendBeacon( url, data ) {
+		const jsonData = JSON.stringify( data );
+		if ( navigator.sendBeacon ) {
+			navigator.sendBeacon(
+				url,
+				new Blob( [ jsonData ], { type: 'application/json' } )
+			);
+		} else {
+			fetch( url, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: jsonData,
+				keepalive: true,
+			} ).catch( () => {} );
+		}
+	}
 
-    // Track link clicks
-    if (clickRestUrl) {
-        const linkContainer = document.querySelector('.extrch-link-page-content-wrapper');
-        if (linkContainer) {
-            linkContainer.addEventListener('click', (event) => {
-                const linkElement = event.target.closest('a');
-                if (linkElement && linkElement.href && !linkElement.classList.contains('extrch-link-page-edit-btn')) {
-                    const linkTextEl = linkElement.querySelector('.extrch-link-page-link-text');
-                    const linkText = linkTextEl ? linkTextEl.textContent.trim() : '';
+	// Track link clicks
+	const linkContainer = document.querySelector(
+		'.extrch-link-page-content-wrapper'
+	);
+	if ( linkContainer ) {
+		linkContainer.addEventListener( 'click', ( event ) => {
+			const linkElement = event.target.closest( 'a' );
+			if (
+				linkElement &&
+				linkElement.href &&
+				! linkElement.classList.contains( 'extrch-link-page-edit-btn' )
+			) {
+				const linkTextEl = linkElement.querySelector(
+					'.extrch-link-page-link-text'
+				);
+				const linkText = linkTextEl
+					? linkTextEl.textContent.trim()
+					: '';
 
-                    sendBeacon(clickRestUrl, {
-                        click_type: 'link_page_link',
-                        link_page_id: linkPageId,
-                        source_url: window.location.href,
-                        destination_url: linkElement.href,
-                        element_text: linkText
-                    });
-                }
-            });
-        }
-    }
-})();
+				sendBeacon( clickRestUrl, {
+					click_type: 'link_page_link',
+					link_page_id: linkPageId,
+					source_url: window.location.href,
+					destination_url: linkElement.href,
+					element_text: linkText,
+				} );
+			}
+		} );
+	}
+} )();

--- a/inc/link-pages/live/templates/single-artist_link_page.php
+++ b/inc/link-pages/live/templates/single-artist_link_page.php
@@ -86,14 +86,13 @@ $api_base = $artist_site_url . '/wp-json/extrachill/v1';
 $permissions_api_url = $api_base . '/artists/' . $artist_id . '/permissions';
 $subscribe_api_url = $api_base . '/artists/' . $artist_id . '/subscribe';
 $tracking_click_url = $api_base . '/analytics/click';
-$tracking_view_url = $api_base . '/analytics/view';
 // Bearer-token mint handoff on the artist site, where the .extrachill.com auth
 // cookie is first-party. The edit-button JS redirects here once to obtain a
 // short-lived token, which comes back in the URL fragment (see
 // extrachill-api/inc/auth/extrachill-link-token-handoff.php).
 $token_handoff_url = $artist_site_url . '/wp-admin/admin-post.php?action=ec_link_token_handoff';
 ?>
-<body class="extrch-link-page"<?php if ($body_bg_style) echo ' style="' . esc_attr( $body_bg_style ) . '"'; ?> data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-token-handoff-url="<?php echo esc_url( $token_handoff_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>" data-extrch-tracking-view-url="<?php echo esc_url( $tracking_view_url ); ?>">
+<body class="extrch-link-page"<?php if ($body_bg_style) echo ' style="' . esc_attr( $body_bg_style ) . '"'; ?> data-extrch-artist-id="<?php echo esc_attr( (string) absint( $artist_id ) ); ?>" data-extrch-link-page-id="<?php echo esc_attr( (string) absint( $link_page_id ) ); ?>" data-extrch-permissions-api-url="<?php echo esc_url( $permissions_api_url ); ?>" data-extrch-token-handoff-url="<?php echo esc_url( $token_handoff_url ); ?>" data-extrch-subscribe-api-url="<?php echo esc_url( $subscribe_api_url ); ?>" data-extrch-tracking-click-url="<?php echo esc_url( $tracking_click_url ); ?>">
 <?php
 // Google Tag Manager (noscript)
 ?>
@@ -125,4 +124,4 @@ $token_handoff_url = $artist_site_url . '/wp-admin/admin-post.php?action=ec_link
     ?>
     <?php wp_print_footer_scripts(); // Output scripts enqueued for footer ?>
 </body>
-</html> 
+</html>

--- a/tests/js/link-page-public-tracking.test.js
+++ b/tests/js/link-page-public-tracking.test.js
@@ -1,0 +1,52 @@
+/* global MouseEvent, navigator */
+
+function mountTrackingPage() {
+	document.body.innerHTML = `
+		<div class="extrch-link-page-content-wrapper">
+			<a href="https://destination.example/song">
+				<span class="extrch-link-page-link-text">Listen now</span>
+			</a>
+		</div>
+	`;
+	document.body.dataset.extrchTrackingClickUrl =
+		'https://artist.example/analytics/click';
+	document.body.dataset.extrchLinkPageId = '42';
+}
+
+describe( 'public link page tracking', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		global.fetch = jest.fn().mockResolvedValue( {} );
+		Object.defineProperty( navigator, 'sendBeacon', {
+			configurable: true,
+			value: undefined,
+		} );
+		mountTrackingPage();
+	} );
+
+	test( 'tracks clicks without a legacy view endpoint', () => {
+		require( '../../inc/link-pages/live/assets/js/link-page-public-tracking.js' );
+
+		document.querySelector( 'a' ).dispatchEvent(
+			new MouseEvent( 'click', {
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch ).toHaveBeenCalledWith(
+			'https://artist.example/analytics/click',
+			expect.objectContaining( {
+				method: 'POST',
+				body: JSON.stringify( {
+					click_type: 'link_page_link',
+					link_page_id: '42',
+					source_url: window.location.href,
+					destination_url: 'https://destination.example/song',
+					element_text: 'Listen now',
+				} ),
+			} )
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary
- remove construction and canonical-page injection of the obsolete `/analytics/view` endpoint
- remove the page-load `post_id` beacon and initialize public tracking from only the click endpoint and link-page identity
- preserve the existing click request payload and behavior, with focused coverage proving clicks initialize without a view URL
- update current documentation that pinned the public script to dual view/click tracking

## Coordinated rollout
Analytics PR Extra-Chill/extrachill-analytics#197 supplies the replacement signed first-party pageview tracker through the minimal-head lifecycle. This PR removes the legacy artist-platform consumer, and Extra-Chill/extrachill-api#117 removes the obsolete route.

Ship all three together: ensure the signed analytics tracker is present before or alongside this removal, then remove the API route only after this consumer is gone. No compatibility path is retained.

## Verification
- `npm run test:js -- --runTestsByPath tests/js/link-page-public-tracking.test.js` (1 test passed)
- `npm run test:js` (2 suites, 5 tests passed)
- `npx wp-scripts lint-js inc/link-pages/live/assets/js/link-page-public-tracking.js tests/js/link-page-public-tracking.test.js` (passed; stale Browserslist data warning only)
- `php -l inc/link-pages/live/templates/single-artist_link_page.php` (passed)
- targeted repository search confirms no `tracking-view-url`, `extrchTrackingViewUrl`, `/analytics/view`, `viewRestUrl`, or page-load `post_id` beacon remains; remaining `artist-analytics/view` matches are the unrelated dashboard block
- `git diff --check` (passed)
- build not run: the changed public script is served directly from `inc/link-pages/live/assets/js/` and has no generated counterpart
- PHPUnit not run: this worktree has no Composer `vendor/` directory or `composer.lock`, and no system `phpunit`; there is no focused PHP test covering this template

Closes #132