### PR TITLE
fix: validate canonical artist memberships

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -77,6 +77,7 @@ class ExtraChillArtistPlatform {
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
 
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/memberships.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/relationship-admin-page.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/permissions.php';

--- a/inc/artist-profiles/memberships.php
+++ b/inc/artist-profiles/memberships.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Canonical Artist Membership Reads
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
+	/**
+	 * Gets published artist profiles canonically linked to a user.
+	 *
+	 * @param int|null $user_id       User ID. Defaults to the current user.
+	 * @param bool     $admin_override Whether administrators may access all artists.
+	 * @return int[] Published artist profile IDs.
+	 */
+	function ec_get_artists_for_user( $user_id = null, $admin_override = false ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		$user_id = absint( $user_id );
+		if ( ! $user_id ) {
+			return array();
+		}
+
+		$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
+		if ( ! $artist_blog_id ) {
+			return array();
+		}
+
+		switch_to_blog( $artist_blog_id );
+		try {
+			if ( $admin_override && user_can( $user_id, 'manage_options' ) ) {
+				return get_posts(
+					array(
+						'post_type'   => 'artist_profile',
+						'post_status' => 'publish',
+						'numberposts' => -1,
+						'fields'      => 'ids',
+					)
+				);
+			}
+
+			$user_artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
+			if ( ! is_array( $user_artist_ids ) ) {
+				return array();
+			}
+
+			$artist_ids = array();
+			foreach ( $user_artist_ids as $artist_id ) {
+				$artist_id = absint( $artist_id );
+				$artist    = $artist_id ? get_post( $artist_id ) : null;
+
+				if ( ! $artist || 'artist_profile' !== $artist->post_type || 'publish' !== $artist->post_status ) {
+					continue;
+				}
+
+				$member_ids = get_post_meta( $artist_id, '_artist_member_ids', true );
+				if ( ! is_array( $member_ids ) || ! in_array( $user_id, array_map( 'absint', $member_ids ), true ) ) {
+					continue;
+				}
+
+				$artist_ids[] = $artist_id;
+			}
+
+			return array_values( array_unique( $artist_ids ) );
+		} finally {
+			restore_current_blog();
+		}
+	}
+}

--- a/tests/ArtistMembershipsTest.php
+++ b/tests/ArtistMembershipsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistMembershipsTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'posts'     => array(),
+			'meta'      => array(),
+			'user_meta' => array(),
+		);
+	}
+
+	public function test_valid_bidirectional_membership_resolves(): void {
+		$this->add_artist( 10, 'publish', array( 4 ) );
+		$this->set_user_artists( 4, array( 10 ) );
+
+		$this->assertSame( array( 10 ), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_user_side_only_stale_id_is_excluded(): void {
+		$this->add_artist( 10, 'publish', array() );
+		$this->set_user_artists( 4, array( 10 ) );
+
+		$this->assertSame( array(), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_artist_side_only_stale_id_does_not_create_membership(): void {
+		$this->add_artist( 10, 'publish', array( 4 ) );
+		$this->set_user_artists( 4, array() );
+
+		$this->assertSame( array(), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_published_wrong_post_type_is_excluded(): void {
+		$GLOBALS['ec_test']['posts'][ 10 ] = (object) array(
+			'ID'          => 10,
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+		);
+		$GLOBALS['ec_test']['meta'][ 10 ]['_artist_member_ids'] = array( array( 4 ) );
+		$this->set_user_artists( 4, array( 10 ) );
+
+		$this->assertSame( array(), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_deleted_and_private_profiles_are_excluded(): void {
+		$this->add_artist( 10, 'private', array( 4 ) );
+		$this->set_user_artists( 4, array( 10, 11 ) );
+
+		$this->assertSame( array(), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_multiple_memberships_are_preserved(): void {
+		$this->add_artist( 10, 'publish', array( 4 ) );
+		$this->add_artist( 11, 'publish', array( 4, 7 ) );
+		$this->set_user_artists( 4, array( 10, 11 ) );
+
+		$this->assertSame( array( 10, 11 ), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_relationship_resolves_after_both_sides_are_repaired(): void {
+		$this->add_artist( 10, 'publish', array() );
+		$this->set_user_artists( 4, array( 10 ) );
+		$this->assertSame( array(), ec_get_artists_for_user( 4 ) );
+
+		$GLOBALS['ec_test']['meta'][ 10 ]['_artist_member_ids'] = array( array( '4' ) );
+
+		$this->assertSame( array( 10 ), ec_get_artists_for_user( 4 ) );
+	}
+
+	public function test_admin_override_preserves_published_artist_query_contract(): void {
+		$GLOBALS['ec_test']['user_caps'][ 4 ]['manage_options'] = true;
+		$GLOBALS['ec_test']['get_posts_result']                 = array( 10, 11 );
+
+		$this->assertSame( array( 10, 11 ), ec_get_artists_for_user( 4, true ) );
+		$this->assertSame(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			),
+			$GLOBALS['ec_test']['get_posts_args'][ 0 ]
+		);
+	}
+
+	private function add_artist( int $artist_id, string $status, array $member_ids ): void {
+		$GLOBALS['ec_test']['posts'][ $artist_id ] = (object) array(
+			'ID'          => $artist_id,
+			'post_type'   => 'artist_profile',
+			'post_status' => $status,
+		);
+		$GLOBALS['ec_test']['meta'][ $artist_id ]['_artist_member_ids'] = array( $member_ids );
+	}
+
+	private function set_user_artists( int $user_id, array $artist_ids ): void {
+		$GLOBALS['ec_test']['user_meta'][ $user_id ]['_artist_profile_ids'] = $artist_ids;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,10 @@ function sanitize_text_field( $value ) {
 	return trim( $value );
 }
 
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
 function get_post_type( $post_id ) {
 	return $GLOBALS['ec_test']['posts'][ $post_id ]->post_type ?? '';
 }
@@ -69,6 +73,40 @@ function get_permalink( $post_id ) {
 
 function get_post( $post_id ) {
 	return $GLOBALS['ec_test']['posts'][ $post_id ] ?? null;
+}
+
+function get_current_user_id() {
+	return $GLOBALS['ec_test']['current_user_id'] ?? 0;
+}
+
+function get_user_meta( $user_id, $key, $single = false ) {
+	$value = $GLOBALS['ec_test']['user_meta'][ $user_id ][ $key ] ?? ( $single ? '' : array() );
+	return $value;
+}
+
+function ec_get_blog_id( $site ) {
+	return 'artist' === $site ? ( $GLOBALS['ec_test']['artist_blog_id'] ?? 7 ) : null;
+}
+
+function switch_to_blog( $blog_id ) {
+	$GLOBALS['ec_test']['switched_to'][] = $blog_id;
+}
+
+function restore_current_blog() {
+	$GLOBALS['ec_test']['restore_count'] = ( $GLOBALS['ec_test']['restore_count'] ?? 0 ) + 1;
+}
+
+function get_current_blog_id() {
+	return $GLOBALS['ec_test']['current_blog_id'] ?? 1;
+}
+
+function user_can( $user_id, $capability ) {
+	return ! empty( $GLOBALS['ec_test']['user_caps'][ $user_id ][ $capability ] );
+}
+
+function get_posts( $args ) {
+	$GLOBALS['ec_test']['get_posts_args'][] = $args;
+	return $GLOBALS['ec_test']['get_posts_result'] ?? array();
 }
 
 function wp_get_attachment_url( $attachment_id ) {
@@ -128,6 +166,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-link-artist-rel
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-unlink-artist-relationship.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';
+require_once dirname( __DIR__ ) . '/inc/artist-profiles/memberships.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';


### PR DESCRIPTION
## Summary
- move the canonical `ec_get_artists_for_user()` implementation into the Artist Platform membership owner
- fail closed unless user-side and artist-side records agree on a real published `artist_profile`
- preserve multiple memberships, numeric legacy IDs, the published-ID return contract, and the existing administrator override without changing or repairing writes

## Membership contract
Ordinary membership reads now require all of the following:

- `_artist_profile_ids` contains the artist ID for the user
- the referenced post exists
- the post type is `artist_profile`
- the profile status is `publish`
- `_artist_member_ids` on the artist contains the user ID

One-sided, deleted, private, and wrong-post-type records remain untouched but are excluded. Existing `ec_add_artist_membership()` and `ec_remove_artist_membership()` semantics are unchanged, and a relationship becomes readable again after both canonical sides are repaired. The `function_exists()` boundary keeps the owner implementation safe during the existing cross-plugin ownership transition.

## Consumer impact
Authorization-sensitive consumers receive only validated canonical artist IDs instead of trusting user meta alone. Multiple valid projects continue to resolve in stored order, and management screens using the explicit administrator override continue to receive every published artist profile.

## Tests
- `vendor/bin/phpunit tests/ArtistMembershipsTest.php` (8 tests, 10 assertions)
- `vendor/bin/phpunit` (31 tests, 81 assertions)
- `homeboy review lint ... --file inc/artist-profiles/memberships.php` (pass)
- `homeboy review lint ... --file tests/ArtistMembershipsTest.php` (pass)
- `php -l` on changed PHP files (pass)
- `git diff --check` (pass)
- `npm run build` (pass)

Repository-wide JS/CSS lint remains red on pre-existing frontend findings. Homeboy's sandbox test profile could not initialize its PHPUnit harness, while the repository's direct full PHPUnit suite passed.

Closes #134