### PR TITLE
fix: enforce artist ownership in native abilities

### DIFF
--- a/inc/abilities/handlers/admin-cleanup-artist-relationships.php
+++ b/inc/abilities/handlers/admin-cleanup-artist-relationships.php
@@ -21,6 +21,14 @@ defined( 'ABSPATH' ) || exit;
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_admin_cleanup_artist_relationships( array $input ): array|WP_Error {
+	if ( ! extrachill_artist_platform_ability_admin_permission() ) {
+		return new WP_Error(
+			'admin_access_denied',
+			__( 'You are not allowed to manage artist relationships.', 'extrachill-artist-platform' ),
+			array( 'status' => 403 )
+		);
+	}
+
 	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
 		return new WP_Error(
 			'missing_params',

--- a/inc/abilities/handlers/admin-link-artist-relationship.php
+++ b/inc/abilities/handlers/admin-link-artist-relationship.php
@@ -21,6 +21,14 @@ defined( 'ABSPATH' ) || exit;
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_admin_link_artist_relationship( array $input ): array|WP_Error {
+	if ( ! extrachill_artist_platform_ability_admin_permission() ) {
+		return new WP_Error(
+			'admin_access_denied',
+			__( 'You are not allowed to manage artist relationships.', 'extrachill-artist-platform' ),
+			array( 'status' => 403 )
+		);
+	}
+
 	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
 		return new WP_Error(
 			'missing_params',

--- a/inc/abilities/handlers/admin-unlink-artist-relationship.php
+++ b/inc/abilities/handlers/admin-unlink-artist-relationship.php
@@ -21,6 +21,14 @@ defined( 'ABSPATH' ) || exit;
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_admin_unlink_artist_relationship( array $input ): array|WP_Error {
+	if ( ! extrachill_artist_platform_ability_admin_permission() ) {
+		return new WP_Error(
+			'admin_access_denied',
+			__( 'You are not allowed to manage artist relationships.', 'extrachill-artist-platform' ),
+			array( 'status' => 403 )
+		);
+	}
+
 	if ( empty( $input['user_id'] ) || empty( $input['artist_id'] ) ) {
 		return new WP_Error(
 			'missing_params',

--- a/inc/abilities/handlers/artist-create-social.php
+++ b/inc/abilities/handlers/artist-create-social.php
@@ -30,6 +30,10 @@ function extrachill_artist_platform_ability_artist_create_social( array $input )
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}

--- a/inc/abilities/handlers/artist-delete-social.php
+++ b/inc/abilities/handlers/artist-delete-social.php
@@ -28,6 +28,10 @@ function extrachill_artist_platform_ability_artist_delete_social( array $input )
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}

--- a/inc/abilities/handlers/artist-export-subscribers.php
+++ b/inc/abilities/handlers/artist-export-subscribers.php
@@ -28,6 +28,10 @@ function extrachill_artist_platform_ability_artist_export_subscribers( array $in
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', __( 'Invalid artist specified.', 'extrachill-artist-platform' ) );
 	}

--- a/inc/abilities/handlers/artist-update-links.php
+++ b/inc/abilities/handlers/artist-update-links.php
@@ -33,6 +33,10 @@ function extrachill_artist_platform_ability_artist_update_links( array $input ):
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}

--- a/inc/abilities/handlers/artist-update-social.php
+++ b/inc/abilities/handlers/artist-update-social.php
@@ -30,6 +30,10 @@ function extrachill_artist_platform_ability_artist_update_social( array $input )
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -34,6 +34,10 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	$genre      = isset( $input['genre'] ) ? sanitize_text_field( wp_unslash( $input['genre'] ) ) : '';
 	$user_id    = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : get_current_user_id();
 
+	if ( ! extrachill_artist_platform_ability_create_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to create an artist for this user.' );
+	}
+
 	if ( strlen( $name ) < 1 ) {
 		return new WP_Error( 'invalid_artist_name', 'Artist name is required.' );
 	}

--- a/inc/abilities/handlers/save-link-page-links.php
+++ b/inc/abilities/handlers/save-link-page-links.php
@@ -22,6 +22,10 @@ function extrachill_artist_platform_ability_save_link_page_links( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( ! is_array( $links ) ) {
 		return new WP_Error( 'invalid_links', 'links must be an array.' );
 	}

--- a/inc/abilities/handlers/save-link-page-settings.php
+++ b/inc/abilities/handlers/save-link-page-settings.php
@@ -21,6 +21,10 @@ function extrachill_artist_platform_ability_save_link_page_settings( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	$link_page_id = ec_get_link_page_for_artist( $artist_id );
 	if ( ! $link_page_id ) {
 		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );

--- a/inc/abilities/handlers/save-link-page-styles.php
+++ b/inc/abilities/handlers/save-link-page-styles.php
@@ -22,6 +22,10 @@ function extrachill_artist_platform_ability_save_link_page_styles( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( ! is_array( $css_vars ) ) {
 		return new WP_Error( 'invalid_css_vars', 'css_vars must be an object.' );
 	}

--- a/inc/abilities/handlers/save-social-links.php
+++ b/inc/abilities/handlers/save-social-links.php
@@ -22,6 +22,10 @@ function extrachill_artist_platform_ability_save_social_links( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( ! is_array( $social_links ) ) {
 		return new WP_Error( 'invalid_social_links', 'social_links must be an array.' );
 	}

--- a/inc/abilities/handlers/update-artist.php
+++ b/inc/abilities/handlers/update-artist.php
@@ -21,6 +21,10 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 	if ( ! $artist_blog_id ) {
 		return new WP_Error( 'dependency_missing', 'Multisite not configured.' );

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -30,14 +30,12 @@ function extrachill_artist_platform_ability_admin_permission() {
 }
 
 /**
- * Permission callback for read-only artist platform abilities.
+ * Permission callback for abilities that operate on an owned artist.
  *
- * Read abilities are available to WP-CLI, Action Scheduler, network admins,
- * and any logged-in user who can manage the specified artist.
- *
+ * @param array $input Ability input containing artist_id or id.
  * @return bool
  */
-function extrachill_artist_platform_ability_read_permission() {
+function extrachill_artist_platform_ability_artist_permission( $input ) {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		return true;
 	}
@@ -46,7 +44,34 @@ function extrachill_artist_platform_ability_read_permission() {
 		return true;
 	}
 
-	return current_user_can( 'manage_network_options' ) || is_user_logged_in();
+	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : absint( $input['id'] ?? 0 );
+
+	return $artist_id
+		&& function_exists( 'ec_can_manage_artist' )
+		&& ec_can_manage_artist( get_current_user_id(), $artist_id );
+}
+
+/**
+ * Permission callback for creating an artist for a user.
+ *
+ * @param array $input Ability input containing an optional user_id.
+ * @return bool
+ */
+function extrachill_artist_platform_ability_create_permission( $input ) {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		return true;
+	}
+
+	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
+		return true;
+	}
+
+	$current_user_id = get_current_user_id();
+	$target_user_id  = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : $current_user_id;
+
+	return $current_user_id
+		&& $target_user_id
+		&& ( $current_user_id === $target_user_id || current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) );
 }
 
 /**

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -36,7 +36,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Artist profile data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_get_artist_data',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -73,7 +73,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Complete link page data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_get_link_page_data',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -124,7 +124,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Created artist profile data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_create_artist',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_create_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -181,7 +181,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Updated artist profile data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_update_artist',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -218,7 +218,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Updated link page data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_save_link_page_links',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -255,7 +255,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Updated link page data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_save_link_page_styles',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -304,7 +304,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Updated link page data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_save_link_page_settings',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -341,7 +341,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Updated social links data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_save_social_links',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -468,7 +468,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => '__return_true',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -499,7 +499,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Complete link page data.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_links',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -537,7 +537,7 @@ function extrachill_artist_platform_register_abilities() {
 				'description' => __( 'Fresh link page data after update.', 'extrachill-artist-platform' ),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_update_links',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -606,7 +606,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_roster',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -639,7 +639,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_list_socials',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -674,7 +674,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_create_social',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -710,7 +710,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_update_social',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -746,7 +746,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_delete_social',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -818,7 +818,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_list_subscribers',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
@@ -856,11 +856,11 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_export_subscribers',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(
-					'readonly'    => true,
+					'readonly'    => false,
 					'destructive' => false,
 					'idempotent'  => false,
 				),
@@ -892,7 +892,7 @@ function extrachill_artist_platform_register_abilities() {
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_artist_get_analytics',
-			'permission_callback' => 'extrachill_artist_platform_ability_read_permission',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
 				'annotations'  => array(

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -76,18 +76,23 @@ final class AbilityAuthorizationTest extends TestCase {
 		}
 	}
 
-	public function test_mutation_handler_rechecks_artist_access(): void {
+	public function test_artist_mutation_handlers_recheck_access_before_state_changes(): void {
 		$GLOBALS['ec_test']['current_user_id'] = 7;
 
-		$result = extrachill_artist_platform_ability_update_artist(
-			array(
-				'artist_id' => 42,
-				'name'      => 'Unauthorized Rename',
-			)
+		$mutations = array(
+			'extrachill_artist_platform_ability_create_artist' => array( 'name' => 'Band', 'user_id' => 8 ),
+			'extrachill_artist_platform_ability_update_artist' => array( 'artist_id' => 42, 'name' => 'Unauthorized Rename' ),
+			'extrachill_artist_platform_ability_save_link_page_links' => array( 'artist_id' => 42, 'links' => array() ),
+			'extrachill_artist_platform_ability_save_social_links' => array( 'artist_id' => 42, 'social_links' => array() ),
+			'extrachill_artist_platform_ability_artist_export_subscribers' => array( 'id' => 42 ),
 		);
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'artist_access_denied', $result->get_error_code() );
+		foreach ( $mutations as $handler => $input ) {
+			$result = $handler( $input );
+
+			$this->assertInstanceOf( WP_Error::class, $result, $handler . ' did not fail closed.' );
+			$this->assertSame( 'artist_access_denied', $result->get_error_code(), $handler . ' returned the wrong denial.' );
+		}
 	}
 
 	public function test_subscriber_export_is_annotated_as_mutating(): void {

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class AbilityAuthorizationTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array();
+		extrachill_artist_platform_register_abilities();
+	}
+
+	public function test_artist_owned_abilities_use_target_aware_permissions(): void {
+		$abilities = array(
+			'extrachill/get-artist-data'            => array( 'artist_id' => 42 ),
+			'extrachill/get-link-page-data'         => array( 'artist_id' => 42 ),
+			'extrachill/update-artist'              => array( 'artist_id' => 42 ),
+			'extrachill/save-link-page-links'       => array( 'artist_id' => 42 ),
+			'extrachill/save-link-page-styles'      => array( 'artist_id' => 42 ),
+			'extrachill/save-link-page-settings'    => array( 'artist_id' => 42 ),
+			'extrachill/save-social-links'          => array( 'artist_id' => 42 ),
+			'extrachill/artist-update-links'        => array( 'id' => 42 ),
+			'extrachill/artist-get-links'           => array( 'id' => 42 ),
+			'extrachill/artist-get-roster'          => array( 'id' => 42 ),
+			'extrachill/artist-list-socials'        => array( 'id' => 42 ),
+			'extrachill/artist-create-social'       => array( 'id' => 42 ),
+			'extrachill/artist-update-social'       => array( 'id' => 42 ),
+			'extrachill/artist-delete-social'       => array( 'id' => 42 ),
+			'extrachill/artist-list-subscribers'    => array( 'id' => 42 ),
+			'extrachill/artist-export-subscribers'  => array( 'id' => 42 ),
+			'extrachill/artist-get-analytics'       => array( 'id' => 42 ),
+		);
+
+		foreach ( $abilities as $name => $input ) {
+			$ability = wp_get_ability( $name );
+			$this->assertFalse( $ability->check_permissions( $input ), $name . ' allowed an anonymous user.' );
+
+			$GLOBALS['ec_test']['current_user_id'] = 7;
+			$this->assertFalse( $ability->check_permissions( $input ), $name . ' allowed an unrelated user.' );
+
+			$GLOBALS['ec_test']['managed_artists'][7] = array( 42 );
+			$this->assertTrue( $ability->check_permissions( $input ), $name . ' denied the artist owner.' );
+
+			$GLOBALS['ec_test']['current_user_id']          = 9;
+			$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
+			$this->assertTrue( $ability->check_permissions( $input ), $name . ' denied an administrator.' );
+
+			$GLOBALS['ec_test']['current_user_id'] = 0;
+			$GLOBALS['ec_test']['capabilities']    = array();
+			$GLOBALS['ec_test']['managed_artists'] = array();
+		}
+	}
+
+	public function test_create_artist_only_allows_self_or_administrator(): void {
+		$ability = wp_get_ability( 'extrachill/create-artist' );
+
+		$this->assertFalse( $ability->check_permissions( array( 'name' => 'Band' ) ) );
+
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$this->assertTrue( $ability->check_permissions( array( 'name' => 'Band' ) ) );
+		$this->assertTrue( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 7 ) ) );
+		$this->assertFalse( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 8 ) ) );
+
+		$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
+		$this->assertTrue( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 8 ) ) );
+	}
+
+	public function test_public_artist_reads_remain_public(): void {
+		$abilities = array(
+			'extrachill/artists-list'          => array(),
+			'extrachill/artist-get'            => array( 'id' => 42 ),
+			'extrachill/artist-get-permissions' => array( 'id' => 42 ),
+			'extrachill/artist-subscribe'      => array( 'id' => 42, 'email' => 'fan@example.com' ),
+		);
+
+		foreach ( $abilities as $name => $input ) {
+			$this->assertTrue( wp_get_ability( $name )->check_permissions( $input ), $name . ' is intentionally public.' );
+		}
+	}
+
+	public function test_mutation_handler_rechecks_artist_access(): void {
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		$result = extrachill_artist_platform_ability_update_artist(
+			array(
+				'artist_id' => 42,
+				'name'      => 'Unauthorized Rename',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'artist_access_denied', $result->get_error_code() );
+	}
+
+	public function test_subscriber_export_is_annotated_as_mutating(): void {
+		$meta = wp_get_ability( 'extrachill/artist-export-subscribers' )->get_meta();
+
+		$this->assertFalse( $meta['annotations']['readonly'] );
+	}
+}

--- a/tests/AdminArtistRelationshipsTest.php
+++ b/tests/AdminArtistRelationshipsTest.php
@@ -19,6 +19,8 @@ final class AdminArtistRelationshipsTest extends TestCase {
 	}
 
 	public function test_link_uses_canonical_membership_mutator(): void {
+		$GLOBALS['ec_test']['capabilities']['manage_network_options'] = true;
+
 		$result = extrachill_artist_platform_ability_admin_link_artist_relationship(
 			array( 'user_id' => 7, 'artist_id' => 19 )
 		);
@@ -28,7 +30,8 @@ final class AdminArtistRelationshipsTest extends TestCase {
 	}
 
 	public function test_link_rejects_missing_user(): void {
-		$GLOBALS['ec_test']['missing_user'] = true;
+		$GLOBALS['ec_test']['capabilities']['manage_network_options'] = true;
+		$GLOBALS['ec_test']['missing_user']                            = true;
 
 		$result = extrachill_artist_platform_ability_admin_link_artist_relationship(
 			array( 'user_id' => 7, 'artist_id' => 19 )
@@ -39,6 +42,8 @@ final class AdminArtistRelationshipsTest extends TestCase {
 	}
 
 	public function test_unlink_and_cleanup_use_canonical_membership_mutator(): void {
+		$GLOBALS['ec_test']['capabilities']['manage_network_options'] = true;
+
 		$this->assertSame(
 			array( 'success' => true ),
 			extrachill_artist_platform_ability_admin_unlink_artist_relationship( array( 'user_id' => 4, 'artist_id' => 8 ) )
@@ -47,6 +52,24 @@ final class AdminArtistRelationshipsTest extends TestCase {
 
 		extrachill_artist_platform_ability_admin_cleanup_artist_relationships( array( 'user_id' => 5, 'artist_id' => 9 ) );
 		$this->assertSame( array( 5, 9 ), $GLOBALS['ec_test']['removed'] );
+	}
+
+	public function test_admin_mutations_fail_closed_when_handlers_are_called_directly(): void {
+		$handlers = array(
+			'extrachill_artist_platform_ability_admin_link_artist_relationship',
+			'extrachill_artist_platform_ability_admin_unlink_artist_relationship',
+			'extrachill_artist_platform_ability_admin_cleanup_artist_relationships',
+		);
+
+		foreach ( $handlers as $handler ) {
+			$result = $handler( array( 'user_id' => 7, 'artist_id' => 19 ) );
+
+			$this->assertInstanceOf( WP_Error::class, $result );
+			$this->assertSame( 'admin_access_denied', $result->get_error_code() );
+		}
+
+		$this->assertArrayNotHasKey( 'added', $GLOBALS['ec_test'] );
+		$this->assertArrayNotHasKey( 'removed', $GLOBALS['ec_test'] );
 	}
 
 	public function test_orphan_list_preserves_orphans_envelope(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,10 +5,12 @@ define( 'ABSPATH', __DIR__ . '/' );
 class WP_Error {
 	private $code;
 	private $message;
+	private $data;
 
-	public function __construct( $code, $message ) {
+	public function __construct( $code, $message, $data = null ) {
 		$this->code    = $code;
 		$this->message = $message;
+		$this->data    = $data;
 	}
 
 	public function get_error_code() {
@@ -28,7 +30,59 @@ function is_wp_error( $value ) {
 	return $value instanceof WP_Error;
 }
 
+function __return_true() {
+	return true;
+}
+
 $GLOBALS['ec_test'] = array();
+
+class EcTestRegisteredAbility {
+	private $args;
+
+	public function __construct( $args ) {
+		$this->args = $args;
+	}
+
+	public function check_permissions( $input ) {
+		return call_user_func( $this->args['permission_callback'], $input );
+	}
+
+	public function get_meta() {
+		return $this->args['meta'];
+	}
+}
+
+function wp_register_ability( $name, $args ) {
+	$GLOBALS['ec_test']['abilities'][ $name ] = new EcTestRegisteredAbility( $args );
+}
+
+function wp_get_ability( $name ) {
+	return $GLOBALS['ec_test']['abilities'][ $name ] ?? null;
+}
+
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
+function get_current_user_id() {
+	return $GLOBALS['ec_test']['current_user_id'] ?? 0;
+}
+
+function current_user_can( $capability ) {
+	return ! empty( $GLOBALS['ec_test']['capabilities'][ $capability ] );
+}
+
+function did_action( $hook_name ) {
+	return $GLOBALS['ec_test']['actions'][ $hook_name ] ?? 0;
+}
+
+function ec_can_manage_artist( $user_id, $artist_id ) {
+	if ( ! empty( $GLOBALS['ec_test']['capabilities']['manage_options'] ) ) {
+		return true;
+	}
+
+	return in_array( (int) $artist_id, $GLOBALS['ec_test']['managed_artists'][ (int) $user_id ] ?? array(), true );
+}
 
 function sanitize_text_field( $value ) {
 	return trim( $value );
@@ -131,3 +185,5 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-
 require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/registry.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/update-artist.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -187,3 +187,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/registry.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/update-artist.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/create-artist.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-social-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-export-subscribers.php';


### PR DESCRIPTION
## Summary
- replace the shared login-only callback with input-aware artist ownership and create-on-behalf permission checks at the native ability boundary
- fail closed inside profile, link-page, social, subscriber-export, and admin relationship mutation handlers before state changes
- protect roster, subscriber, analytics, and management payload reads while preserving intentionally public artist listing, published profile, permission-probe, and subscription abilities
- mark subscriber export as mutating because it updates export state
- cover direct handler invocation across create, profile, link, social, subscriber export, and admin relationship mutations

## Vulnerability
Direct `/wp-abilities/v1/abilities/.../run` requests could bypass the stricter Extra Chill API wrappers because the registered ability callback accepted any authenticated user without inspecting the target artist. The ability registry now passes normalized input into `ec_can_manage_artist()` for the concrete artist, and mutating handlers repeat the check as defense in depth. Artist creation only accepts another `user_id` from an administrator.

Admin relationship handlers now also enforce the existing network-admin permission contract internally, so direct callback invocation cannot bypass the native ability registry.

## Tests
- `vendor/bin/phpunit --filter 'AbilityAuthorizationTest|AdminArtistRelationshipsTest'` (11 tests, 106 assertions)
- `vendor/bin/phpunit` (29 tests, 167 assertions)
- `homeboy review extrachill-artist-platform lint --path /var/lib/datamachine/workspace/extrachill-artist-platform@fix-137-artist-ability-auth --changed-only --summary` (passed with zero findings)
- `git diff --check` (passed)

The repository-local `composer lint:php` still cannot load the declared `WordPress` standard from a clean install; follow-up tooling issue: #141.

Fixes #137