### PR TITLE
fix: enforce object-aware artist capabilities

### DIFF
--- a/inc/core/artist-platform-post-types.php
+++ b/inc/core/artist-platform-post-types.php
@@ -50,7 +50,7 @@ function extrachill_register_artist_profile_cpt() {
         'label'                 => __( 'Artist Profile', 'extrachill-artist-platform' ),
         'description'           => __( 'Custom Post Type for Artist Profiles', 'extrachill-artist-platform' ),
         'labels'                => $labels,
-        'supports'              => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+        'supports'              => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'revisions' ),
         'hierarchical'          => false,
         'public'                => true,
         'show_ui'               => true,
@@ -64,6 +64,7 @@ function extrachill_register_artist_profile_cpt() {
         'exclude_from_search'   => false,
         'publicly_queryable'    => true,
         'rewrite'               => array( 'slug' => 'artists', 'with_front' => false ),
+        'capability_type'       => array( 'artist_profile', 'artist_profiles' ),
         'map_meta_cap'          => true,
         'show_in_rest'          => true,
     );

--- a/inc/core/filters/permissions.php
+++ b/inc/core/filters/permissions.php
@@ -62,23 +62,132 @@ function ec_get_permission_can_create_artists( $data ) {
 }
 
 /**
- * WordPress capability filtering for artist permissions
+ * Resolve an artist-owned object to its artist profile.
+ *
+ * Revisions and autosaves inherit ownership from their parent. Future private
+ * artist-owned post types can add their canonical relationship here.
+ *
+ * @param int $object_id Post or revision ID.
+ * @return int Artist profile ID, or 0 when the object is not artist-owned.
  */
-function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
-    $user_id = $user->ID;
-    $cap     = $args[0];
-    $object_id = isset( $args[2] ) ? $args[2] : null;
+function ec_get_artist_id_for_owned_object( $object_id ) {
+	$post = get_post( absint( $object_id ) );
+	if ( ! $post ) {
+		return 0;
+	}
 
-    if ( $object_id && get_post_type( $object_id ) === 'artist_profile' ) {
-        if ( ec_can_manage_artist( $user_id, $object_id ) ) {
-            $post_caps = array( 'edit_post', 'delete_post', 'read_post', 'publish_post' );
-            if ( in_array( $cap, $post_caps ) ) {
-                $allcaps[$cap] = true;
-            }
-        }
-    }
+	if ( 'revision' === $post->post_type ) {
+		$post = get_post( $post->post_parent );
+		if ( ! $post ) {
+			return 0;
+		}
+	}
 
-    return $allcaps;
+	return 'artist_profile' === $post->post_type ? (int) $post->ID : 0;
 }
 
+/**
+ * Check object access against the canonical reciprocal membership reader.
+ *
+ * @param int $user_id   User ID.
+ * @param int $artist_id Artist profile ID.
+ * @return bool Whether the user may manage the artist.
+ */
+function ec_user_can_manage_artist_object( $user_id, $artist_id ) {
+	if ( user_can( $user_id, 'manage_options' ) ) {
+		return true;
+	}
+
+	if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
+		return false;
+	}
+
+	return in_array( (int) $artist_id, ec_get_artists_for_user( $user_id ), true );
+}
+
+/**
+ * Map revision deletion to the owning artist profile.
+ *
+ * Core already maps edit/read checks on revisions to the parent, but deliberately
+ * maps revision deletion to do_not_allow. The revisions REST controller checks
+ * both parent and revision deletion, so artist revisions need the parent's map.
+ *
+ * @param string[] $caps    Primitive capabilities required by WordPress.
+ * @param string   $cap     Requested capability.
+ * @param int      $user_id User ID.
+ * @param array    $args    Capability arguments, beginning with object ID.
+ * @return string[] Required primitive capabilities.
+ */
+function ec_map_artist_object_capabilities( $caps, $cap, $user_id, $args ) {
+	if ( 'delete_post' !== $cap || empty( $args[0] ) ) {
+		return $caps;
+	}
+
+	$post = get_post( absint( $args[0] ) );
+	if ( ! $post || 'revision' !== $post->post_type || ! ec_get_artist_id_for_owned_object( $post->ID ) ) {
+		return $caps;
+	}
+
+	return map_meta_cap( 'delete_post', $user_id, $post->post_parent );
+}
+add_filter( 'map_meta_cap', 'ec_map_artist_object_capabilities', 10, 4 );
+
+/**
+ * Satisfy WordPress's mapped primitive caps for an artist-owned object.
+ *
+ * @param bool[]   $allcaps User's available primitive capabilities.
+ * @param string[] $caps   Primitive capabilities required by WordPress.
+ * @param array    $args    Requested capability, user ID, and object ID.
+ * @param WP_User  $user    User object.
+ * @return bool[] Filtered primitive capabilities.
+ */
+function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
+	$admin_caps = array(
+		'edit_artist_profiles',
+		'edit_others_artist_profiles',
+		'edit_private_artist_profiles',
+		'edit_published_artist_profiles',
+		'delete_artist_profiles',
+		'delete_others_artist_profiles',
+		'delete_private_artist_profiles',
+		'delete_published_artist_profiles',
+		'publish_artist_profiles',
+		'read_private_artist_profiles',
+	);
+	$object_caps = array(
+		'edit_post',
+		'read_post',
+		'delete_post',
+		'publish_post',
+		'edit_artist_profile',
+		'read_artist_profile',
+		'delete_artist_profile',
+		'edit_post_meta',
+		'add_post_meta',
+		'delete_post_meta',
+	);
+	$cap         = $args[0] ?? '';
+	$object_id   = isset( $args[2] ) ? absint( $args[2] ) : 0;
+	if ( in_array( $cap, $admin_caps, true ) && user_can( $user->ID, 'manage_options' ) ) {
+		$allcaps[ $cap ] = true;
+		return $allcaps;
+	}
+
+	if ( ! $object_id || ! in_array( $cap, $object_caps, true ) ) {
+		return $allcaps;
+	}
+
+	$artist_id = ec_get_artist_id_for_owned_object( $object_id );
+	if ( ! $artist_id || ! ec_user_can_manage_artist_object( $user->ID, $artist_id ) ) {
+		return $allcaps;
+	}
+
+	foreach ( $caps as $primitive_cap ) {
+		if ( 'do_not_allow' !== $primitive_cap ) {
+			$allcaps[ $primitive_cap ] = true;
+		}
+	}
+
+	return $allcaps;
+}
 add_filter( 'user_has_cap', 'ec_filter_user_capabilities', 10, 4 );

--- a/inc/core/filters/permissions.php
+++ b/inc/core/filters/permissions.php
@@ -87,7 +87,7 @@ function ec_get_artist_id_for_owned_object( $object_id ) {
 }
 
 /**
- * Check object access against the canonical reciprocal membership reader.
+ * Check object access against both sides of the reciprocal membership.
  *
  * @param int $user_id   User ID.
  * @param int $artist_id Artist profile ID.
@@ -98,11 +98,13 @@ function ec_user_can_manage_artist_object( $user_id, $artist_id ) {
 		return true;
 	}
 
-	if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
-		return false;
-	}
+	$user_artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
+	$artist_user_ids = get_post_meta( $artist_id, '_artist_member_ids', true );
 
-	return in_array( (int) $artist_id, ec_get_artists_for_user( $user_id ), true );
+	return is_array( $user_artist_ids )
+		&& is_array( $artist_user_ids )
+		&& in_array( (int) $artist_id, array_map( 'intval', $user_artist_ids ), true )
+		&& in_array( (int) $user_id, array_map( 'intval', $artist_user_ids ), true );
 }
 
 /**
@@ -166,6 +168,17 @@ function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
 		'add_post_meta',
 		'delete_post_meta',
 	);
+	$meta_caps = array(
+		'edit_post_meta',
+		'add_post_meta',
+		'delete_post_meta',
+	);
+	$meta_edit_caps = array(
+		'edit_artist_profiles',
+		'edit_others_artist_profiles',
+		'edit_private_artist_profiles',
+		'edit_published_artist_profiles',
+	);
 	$cap         = $args[0] ?? '';
 	$object_id   = isset( $args[2] ) ? absint( $args[2] ) : 0;
 	if ( in_array( $cap, $admin_caps, true ) && user_can( $user->ID, 'manage_options' ) ) {
@@ -183,7 +196,11 @@ function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
 	}
 
 	foreach ( $caps as $primitive_cap ) {
-		if ( 'do_not_allow' !== $primitive_cap ) {
+		if ( in_array( $cap, $meta_caps, true ) ) {
+			if ( in_array( $primitive_cap, $meta_edit_caps, true ) ) {
+				$allcaps[ $primitive_cap ] = true;
+			}
+		} elseif ( 'do_not_allow' !== $primitive_cap ) {
 			$allcaps[ $primitive_cap ] = true;
 		}
 	}

--- a/tests/ArtistObjectCapabilitiesTest.php
+++ b/tests/ArtistObjectCapabilitiesTest.php
@@ -15,11 +15,33 @@ final class ArtistObjectCapabilitiesTest extends TestCase {
 							'post_type'   => 'artist_profile',
 							'post_status' => 'publish',
 						),
+						21 => (object) array(
+							'ID'          => 21,
+							'post_type'   => 'artist_profile',
+							'post_status' => 'draft',
+						),
+						22 => (object) array(
+							'ID'          => 22,
+							'post_type'   => 'artist_profile',
+							'post_status' => 'pending',
+						),
 						30 => (object) array(
 							'ID'          => 30,
 							'post_type'   => 'revision',
 							'post_status' => 'inherit',
 							'post_parent' => 20,
+						),
+						31 => (object) array(
+							'ID'          => 31,
+							'post_type'   => 'revision',
+							'post_status' => 'inherit',
+							'post_parent' => 21,
+						),
+						32 => (object) array(
+							'ID'          => 32,
+							'post_type'   => 'revision',
+							'post_status' => 'inherit',
+							'post_parent' => 22,
 						),
 						40 => (object) array(
 							'ID'          => 40,
@@ -29,16 +51,20 @@ final class ArtistObjectCapabilitiesTest extends TestCase {
 					),
 					'post_meta' => array(
 						20 => array( '_artist_member_ids' => array( 7 ) ),
+						21 => array( '_artist_member_ids' => array( 7 ) ),
+						22 => array( '_artist_member_ids' => array( 7 ) ),
 					),
 				),
 			),
 			'user_meta' => array(
-				7 => array( '_artist_profile_ids' => array( 20 ) ),
+				7 => array( '_artist_profile_ids' => array( 20, 21, 22 ) ),
 				8 => array( '_artist_profile_ids' => array( 20 ) ),
 			),
 			'mapped_caps' => array(
 				'delete_post' => array(
 					20 => array( 'delete_others_artist_profiles', 'delete_published_artist_profiles' ),
+					21 => array( 'delete_others_artist_profiles' ),
+					22 => array( 'delete_others_artist_profiles' ),
 				),
 			),
 		);
@@ -69,6 +95,31 @@ final class ArtistObjectCapabilitiesTest extends TestCase {
 		$this->assertTrue( $args['map_meta_cap'] );
 		$this->assertTrue( $args['show_in_rest'] );
 		$this->assertContains( 'revisions', $args['supports'] );
+	}
+
+	public function test_protected_meta_keeps_core_denial_while_nested_edit_caps_are_granted(): void {
+		$user = (object) array( 'ID' => 7 );
+		foreach ( array( 'edit_post_meta', 'add_post_meta', 'delete_post_meta' ) as $requested ) {
+			$required = array( 'edit_others_artist_profiles', 'edit_published_artist_profiles', $requested );
+			$allcaps  = ec_filter_user_capabilities( array(), $required, array( $requested, 7, 20, '_artist_member_ids' ), $user );
+
+			$this->assertTrue( $allcaps['edit_others_artist_profiles'] );
+			$this->assertTrue( $allcaps['edit_published_artist_profiles'] );
+			$this->assertArrayNotHasKey( $requested, $allcaps );
+		}
+	}
+
+	public function test_unprotected_meta_receives_only_nested_artist_edit_caps(): void {
+		$required = array( 'edit_others_artist_profiles', 'edit_published_artist_profiles' );
+		$allcaps  = ec_filter_user_capabilities( array(), $required, array( 'edit_post_meta', 7, 20, 'public_key' ), (object) array( 'ID' => 7 ) );
+
+		$this->assertSame(
+			array(
+				'edit_others_artist_profiles'    => true,
+				'edit_published_artist_profiles' => true,
+			),
+			$allcaps
+		);
 	}
 
 	public function test_one_sided_membership_and_generic_editor_caps_do_not_grant_access(): void {
@@ -121,6 +172,33 @@ final class ArtistObjectCapabilitiesTest extends TestCase {
 		$allcaps = ec_filter_user_capabilities( array(), $mapped, array( 'delete_post', 7, 30 ), (object) array( 'ID' => 7 ) );
 		$this->assertTrue( $allcaps['delete_others_artist_profiles'] );
 		$this->assertTrue( $allcaps['delete_published_artist_profiles'] );
+	}
+
+	public function test_draft_and_pending_profiles_keep_crud_revision_and_autosave_access(): void {
+		$user = (object) array( 'ID' => 7 );
+
+		foreach ( array( 21 => 31, 22 => 32 ) as $artist_id => $revision_id ) {
+			$this->assertTrue( ec_user_can_manage_artist_object( 7, $artist_id ) );
+			$this->assertSame( $artist_id, ec_get_artist_id_for_owned_object( $revision_id ) );
+
+			foreach ( array( 'read_post', 'edit_post' ) as $requested ) {
+				$required = array( 'edit_others_artist_profiles' );
+				$allcaps  = ec_filter_user_capabilities( array(), $required, array( $requested, 7, $artist_id ), $user );
+				$this->assertTrue( $allcaps['edit_others_artist_profiles'] );
+
+				$revision_caps = ec_filter_user_capabilities( array(), $required, array( $requested, 7, $revision_id ), $user );
+				$this->assertTrue( $revision_caps['edit_others_artist_profiles'] );
+			}
+
+			$delete_caps   = map_meta_cap( 'delete_post', 7, $artist_id );
+			$parent_delete = ec_filter_user_capabilities( array(), $delete_caps, array( 'delete_post', 7, $artist_id ), $user );
+			$this->assertTrue( $parent_delete['delete_others_artist_profiles'] );
+
+			$revision_delete_caps = ec_map_artist_object_capabilities( array( 'do_not_allow' ), 'delete_post', 7, array( $revision_id ) );
+			$this->assertSame( array( 'delete_others_artist_profiles' ), $revision_delete_caps );
+			$revision_delete = ec_filter_user_capabilities( array(), $revision_delete_caps, array( 'delete_post', 7, $revision_id ), $user );
+			$this->assertTrue( $revision_delete['delete_others_artist_profiles'] );
+		}
 	}
 
 	public function test_non_artist_objects_are_untouched(): void {

--- a/tests/ArtistObjectCapabilitiesTest.php
+++ b/tests/ArtistObjectCapabilitiesTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistObjectCapabilitiesTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'blogs'           => array(
+				4 => array(
+					'posts'     => array(
+						20 => (object) array(
+							'ID'          => 20,
+							'post_type'   => 'artist_profile',
+							'post_status' => 'publish',
+						),
+						30 => (object) array(
+							'ID'          => 30,
+							'post_type'   => 'revision',
+							'post_status' => 'inherit',
+							'post_parent' => 20,
+						),
+						40 => (object) array(
+							'ID'          => 40,
+							'post_type'   => 'post',
+							'post_status' => 'publish',
+						),
+					),
+					'post_meta' => array(
+						20 => array( '_artist_member_ids' => array( 7 ) ),
+					),
+				),
+			),
+			'user_meta' => array(
+				7 => array( '_artist_profile_ids' => array( 20 ) ),
+				8 => array( '_artist_profile_ids' => array( 20 ) ),
+			),
+			'mapped_caps' => array(
+				'delete_post' => array(
+					20 => array( 'delete_others_artist_profiles', 'delete_published_artist_profiles' ),
+				),
+			),
+		);
+	}
+
+	public function test_reciprocal_member_receives_mapped_primitives_for_core_rest_crud(): void {
+		$user = (object) array( 'ID' => 7 );
+		$crud = array(
+			'read_post'    => array( 'read' ),
+			'edit_post'    => array( 'edit_others_artist_profiles', 'edit_published_artist_profiles' ),
+			'publish_post' => array( 'publish_artist_profiles' ),
+			'delete_post'  => array( 'delete_others_artist_profiles', 'delete_published_artist_profiles' ),
+		);
+
+		foreach ( $crud as $requested => $required ) {
+			$allcaps = ec_filter_user_capabilities( array(), $required, array( $requested, 7, 20 ), $user );
+			foreach ( $required as $primitive ) {
+				$this->assertTrue( $allcaps[ $primitive ], $requested . ' did not grant ' . $primitive );
+			}
+		}
+	}
+
+	public function test_artist_profiles_register_isolated_caps_and_revision_support(): void {
+		extrachill_register_artist_profile_cpt();
+		$args = $GLOBALS['ec_test']['registered_post_types']['artist_profile'];
+
+		$this->assertSame( array( 'artist_profile', 'artist_profiles' ), $args['capability_type'] );
+		$this->assertTrue( $args['map_meta_cap'] );
+		$this->assertTrue( $args['show_in_rest'] );
+		$this->assertContains( 'revisions', $args['supports'] );
+	}
+
+	public function test_one_sided_membership_and_generic_editor_caps_do_not_grant_access(): void {
+		$editor_caps = array(
+			'edit_posts'           => true,
+			'edit_others_posts'    => true,
+			'edit_published_posts' => true,
+		);
+		$required    = array( 'edit_others_artist_profiles', 'edit_published_artist_profiles' );
+		$allcaps     = ec_filter_user_capabilities( $editor_caps, $required, array( 'edit_post', 8, 20 ), (object) array( 'ID' => 8 ) );
+
+		$this->assertArrayNotHasKey( 'edit_others_artist_profiles', $allcaps );
+		$this->assertArrayNotHasKey( 'edit_published_artist_profiles', $allcaps );
+
+		$create_caps = ec_filter_user_capabilities( $editor_caps, array( 'edit_artist_profiles' ), array( 'edit_artist_profiles', 8 ), (object) array( 'ID' => 8 ) );
+		$this->assertArrayNotHasKey( 'edit_artist_profiles', $create_caps );
+	}
+
+	public function test_administrator_receives_object_primitives(): void {
+		$GLOBALS['ec_test']['user_capabilities'][99]['manage_options'] = true;
+		$allcaps = ec_filter_user_capabilities(
+			array( 'manage_options' => true ),
+			array( 'edit_others_artist_profiles', 'edit_published_artist_profiles' ),
+			array( 'edit_post', 99, 20 ),
+			(object) array( 'ID' => 99 )
+		);
+
+		$this->assertTrue( $allcaps['edit_others_artist_profiles'] );
+		$this->assertTrue( $allcaps['edit_published_artist_profiles'] );
+	}
+
+	public function test_administrator_receives_objectless_core_rest_collection_and_create_caps(): void {
+		$GLOBALS['ec_test']['user_capabilities'][99]['manage_options'] = true;
+		$user = (object) array( 'ID' => 99 );
+
+		$create_caps = ec_filter_user_capabilities( array(), array( 'edit_artist_profiles' ), array( 'edit_artist_profiles', 99 ), $user );
+		$this->assertTrue( $create_caps['edit_artist_profiles'] );
+
+		$publish_caps = ec_filter_user_capabilities( array(), array( 'publish_artist_profiles' ), array( 'publish_artist_profiles', 99 ), $user );
+		$this->assertTrue( $publish_caps['publish_artist_profiles'] );
+	}
+
+	public function test_revisions_and_autosaves_resolve_to_the_artist_parent(): void {
+		$this->assertSame( 20, ec_get_artist_id_for_owned_object( 30 ) );
+		$this->assertSame( 20, ec_get_artist_id_for_owned_object( 20 ) );
+
+		$mapped = ec_map_artist_object_capabilities( array( 'do_not_allow' ), 'delete_post', 7, array( 30 ) );
+		$this->assertSame( array( 'delete_others_artist_profiles', 'delete_published_artist_profiles' ), $mapped );
+
+		$allcaps = ec_filter_user_capabilities( array(), $mapped, array( 'delete_post', 7, 30 ), (object) array( 'ID' => 7 ) );
+		$this->assertTrue( $allcaps['delete_others_artist_profiles'] );
+		$this->assertTrue( $allcaps['delete_published_artist_profiles'] );
+	}
+
+	public function test_non_artist_objects_are_untouched(): void {
+		$allcaps = array( 'edit_posts' => true );
+		$this->assertSame(
+			$allcaps,
+			ec_filter_user_capabilities( $allcaps, array( 'edit_others_posts' ), array( 'edit_post', 7, 40 ), (object) array( 'ID' => 7 ) )
+		);
+		$this->assertSame(
+			array( 'do_not_allow' ),
+			ec_map_artist_object_capabilities( array( 'do_not_allow' ), 'delete_post', 7, array( 40 ) )
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -60,6 +60,10 @@ function __( $text ) {
 	return $text;
 }
 
+function _x( $text ) {
+	return $text;
+}
+
 function is_wp_error( $value ) {
 	return $value instanceof WP_Error;
 }
@@ -110,6 +114,11 @@ function add_filter() {
 	return true;
 }
 
+function register_post_type( $post_type, $args ) {
+	$GLOBALS['ec_test']['registered_post_types'][ $post_type ] = $args;
+	return (object) $args;
+}
+
 function remove_filter() {
 	return true;
 }
@@ -152,6 +161,33 @@ function get_current_user_id() {
 
 function current_user_can( $capability ) {
 	return ! empty( $GLOBALS['ec_test']['capabilities'][ $capability ] );
+}
+
+function user_can( $user_id, $capability ) {
+	return ! empty( $GLOBALS['ec_test']['user_capabilities'][ (int) $user_id ][ $capability ] );
+}
+
+function map_meta_cap( $capability, $user_id, ...$args ) {
+	$object_id = isset( $args[0] ) ? (int) $args[0] : 0;
+	return $GLOBALS['ec_test']['mapped_caps'][ $capability ][ $object_id ] ?? array( $capability );
+}
+
+function ec_get_artists_for_user( $user_id ) {
+	$user_id    = (int) $user_id;
+	$artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
+	if ( ! is_array( $artist_ids ) ) {
+		return array();
+	}
+
+	$artists = array();
+	foreach ( array_map( 'intval', $artist_ids ) as $artist_id ) {
+		$member_ids = get_post_meta( $artist_id, '_artist_member_ids', true );
+		if ( 'artist_profile' === get_post_type( $artist_id ) && 'publish' === get_post_status( $artist_id ) && is_array( $member_ids ) && in_array( $user_id, array_map( 'intval', $member_ids ), true ) ) {
+			$artists[] = $artist_id;
+		}
+	}
+
+	return $artists;
 }
 
 function did_action( $hook_name ) {
@@ -565,6 +601,8 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-unlink-artist-r
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
+require_once dirname( __DIR__ ) . '/inc/core/filters/permissions.php';
+require_once dirname( __DIR__ ) . '/inc/core/artist-platform-post-types.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-term-binding.php';


### PR DESCRIPTION
## Summary
- isolate `artist_profile` behind its own WordPress capability namespace so generic editorial roles no longer inherit write access
- resolve profiles, revisions, and autosaves to the owning artist, then grant the exact primitive capabilities produced by core only for administrators or validated reciprocal members
- preserve core protected-meta denial and draft/pending member access while enabling core revision support

## Architecture

`artist_profile` now uses `array( 'artist_profile', 'artist_profiles' )` as its `capability_type` with `map_meta_cap` enabled. Core therefore maps object checks to artist-specific primitives rather than shared post primitives.

The `user_has_cap` filter no longer writes meta capabilities after mapping. It resolves the checked object to its canonical artist profile, directly validates both reciprocal records (`_artist_profile_ids` and `_artist_member_ids`) without a publish-status constraint, and grants only the primitive capabilities in core's `$caps` result. It does not consult `post_author`.

For `edit_post_meta`, `add_post_meta`, and `delete_post_meta`, the filter grants only nested `edit_*_artist_profiles` primitives. If core appends the original meta capability to deny a protected key such as `_artist_member_ids`, that original capability remains unsatisfied.

Core already maps revision edit/read checks to the parent. A narrow `map_meta_cap` filter maps artist revision deletion to the parent's delete mapping because core otherwise returns `do_not_allow`, while its revisions REST controller explicitly checks both parent and revision deletion.

Administrators receive only the generated objectless `artist_profiles` primitives needed by core collection, create, and publish checks. Ordinary members remain object-bound; objectless creation continues through the existing artist creation ability, which can establish reciprocal membership atomically.

## Behavioral Matrix

| Actor / surface | Public read | Existing profile update/delete | Revision/autosave | Protected metadata | Core REST create/collection edit |
| --- | --- | --- | --- | --- | --- |
| Reciprocal ordinary member | Yes | Yes for publish, draft, and pending objects | Yes, inherited from artist parent | Core denial preserved | No; uses dedicated creation flow |
| One-sided/stale member | Public read only | No | No | No | No |
| Unrelated generic editor | Public read only | No, generic post caps do not satisfy artist primitives | No | No | No |
| Administrator | Yes | Yes | Yes | Core metadata policy applies | Yes |
| Non-artist post | Unchanged | Unchanged | Unchanged | Unchanged | Unchanged |

Core REST item GET remains public for published profiles. Editable-context GET, PUT/PATCH, DELETE, revision routes, and autosave routes flow through core's object checks and the mapped artist primitives.

## Tests
- `vendor/bin/phpunit` (`83 tests, 376 assertions`)
- focused protected-meta tests cover `edit_post_meta`, `add_post_meta`, and `delete_post_meta`
- focused lifecycle tests cover draft/pending parent CRUD plus revision/autosave inheritance
- `php -l` on all changed PHP files
- `git diff --check`
- Homeboy changed-file lint and direct PHPCS were invoked, but the installed WordPress extension runtime fails before analyzing files (`ReflectionException: Class \"\" does not exist`; missing PHPCS base sniff; corrupted PHPStan phar, tracked as `homeboy-extensions#2233`). Syntax and PHPUnit are the usable local gates.

Fixes #139