### PR TITLE
Fix stale artist profile term references on deletion

### DIFF
--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -378,28 +378,48 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 
 	switch_to_blog( $blog_ids['main'] );
 	try {
-		$term_ids = get_terms(
-			array(
-				'taxonomy'   => 'artist',
-				'hide_empty' => false,
-				'fields'     => 'ids',
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Deletion must find every stale inverse reference.
-				'meta_query' => array(
-					array(
-						'key'     => '_artist_profile_id',
-						'value'   => (int) $profile_id,
-						'compare' => '=',
-						'type'    => 'NUMERIC',
+		$batch_size = 100;
+		$offset     = 0;
+		do {
+			$term_ids = get_terms(
+				array(
+					'taxonomy'               => 'artist',
+					'hide_empty'             => false,
+					'fields'                 => 'ids',
+					'number'                 => $batch_size,
+					'offset'                 => $offset,
+					'orderby'                => 'none',
+					'cache_results'          => false,
+					'update_term_meta_cache' => false,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Deletion must find every stale inverse reference.
+					'meta_query'             => array(
+						array(
+							'key'     => '_artist_profile_id',
+							'value'   => (int) $profile_id,
+							'compare' => '=',
+							'type'    => 'NUMERIC',
+						),
 					),
-				),
-			)
-		);
-
-		if ( ! is_wp_error( $term_ids ) ) {
-			foreach ( $term_ids as $term_id ) {
-				delete_term_meta( (int) $term_id, '_artist_profile_id', (int) $profile_id );
+				)
+			);
+			if ( is_wp_error( $term_ids ) || empty( $term_ids ) ) {
+				break;
 			}
-		}
+
+			$deleted = false;
+			foreach ( $term_ids as $term_id ) {
+				$stored_values = get_term_meta( (int) $term_id, '_artist_profile_id', false );
+				foreach ( $stored_values as $stored_value ) {
+					if ( is_numeric( $stored_value ) && (float) $stored_value === (float) $profile_id ) {
+						$deleted = delete_term_meta( (int) $term_id, '_artist_profile_id', $stored_value ) || $deleted;
+					}
+				}
+			}
+
+			if ( ! $deleted ) {
+				$offset += count( $term_ids );
+			}
+		} while ( true );
 	} finally {
 		restore_current_blog();
 	}

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -378,8 +378,9 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 
 	switch_to_blog( $blog_ids['main'] );
 	try {
-		$batch_size = 100;
-		$offset     = 0;
+		$batch_size        = 100;
+		$offset            = 0;
+		$profile_id_string = (string) (int) $profile_id;
 		do {
 			$term_ids = get_terms(
 				array(
@@ -388,7 +389,8 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 					'fields'                 => 'ids',
 					'number'                 => $batch_size,
 					'offset'                 => $offset,
-					'orderby'                => 'none',
+					'orderby'                => 'term_id',
+					'order'                  => 'ASC',
 					'cache_results'          => false,
 					'update_term_meta_cache' => false,
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Deletion must find every stale inverse reference.
@@ -410,7 +412,16 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 			foreach ( $term_ids as $term_id ) {
 				$stored_values = get_term_meta( (int) $term_id, '_artist_profile_id', false );
 				foreach ( $stored_values as $stored_value ) {
-					if ( is_numeric( $stored_value ) && (float) $stored_value === (float) $profile_id ) {
+					if ( ! is_int( $stored_value ) && ! is_string( $stored_value ) ) {
+						continue;
+					}
+					$stored_value_string = (string) $stored_value;
+					if ( 1 !== preg_match( '/^\+?\d+$/D', $stored_value_string ) ) {
+						continue;
+					}
+					$normalized_value = ltrim( ltrim( $stored_value_string, '+' ), '0' );
+					$normalized_value = '' === $normalized_value ? '0' : $normalized_value;
+					if ( $normalized_value === $profile_id_string ) {
 						$deleted = delete_term_meta( (int) $term_id, '_artist_profile_id', $stored_value ) || $deleted;
 					}
 				}

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -360,7 +360,7 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 1 );
 
 /**
- * Remove the reciprocal term reference before an artist profile is deleted.
+ * Remove all term references before an artist profile is deleted.
  *
  * @param int $profile_id Post ID being deleted.
  * @return void
@@ -372,11 +372,36 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 	}
 
 	$profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
-	if ( ! empty( $profile ) && $profile['term_id'] > 0 ) {
-		$term = ec_artist_binding_read_term( $profile['term_id'], $blog_ids['main'] );
-		if ( ! empty( $term ) && $term['profile_id'] === (int) $profile_id ) {
-			ec_artist_binding_delete_term_meta( $profile['term_id'], (int) $profile_id, $blog_ids['main'] );
+	if ( empty( $profile ) ) {
+		return;
+	}
+
+	switch_to_blog( $blog_ids['main'] );
+	try {
+		$term_ids = get_terms(
+			array(
+				'taxonomy'   => 'artist',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Deletion must find every stale inverse reference.
+				'meta_query' => array(
+					array(
+						'key'     => '_artist_profile_id',
+						'value'   => (int) $profile_id,
+						'compare' => '=',
+						'type'    => 'NUMERIC',
+					),
+				),
+			)
+		);
+
+		if ( ! is_wp_error( $term_ids ) ) {
+			foreach ( $term_ids as $term_id ) {
+				delete_term_meta( (int) $term_id, '_artist_profile_id', (int) $profile_id );
+			}
 		}
+	} finally {
+		restore_current_blog();
 	}
 }
 add_action( 'before_delete_post', 'ec_delete_artist_profile_term_binding', 10, 1 );

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -148,6 +148,52 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
 
+	public function test_profile_deletion_cleans_noncanonical_numeric_term_references(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'stale-band', 12 );
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = '012';
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+	}
+
+	public function test_profile_deletion_uses_complete_bounded_uncached_batches(): void {
+		$this->addProfile( 12, 'the-band' );
+		for ( $term_id = 1000; $term_id < 1205; ++$term_id ) {
+			$this->addTerm( $term_id, 'stale-band-' . $term_id, 12 );
+		}
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		foreach ( range( 1000, 1204 ) as $term_id ) {
+			$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][ $term_id ] );
+		}
+		foreach ( $GLOBALS['ec_test']['get_terms_calls'] as $args ) {
+			$this->assertSame( 100, $args['number'] );
+			$this->assertSame( 'none', $args['orderby'] );
+			$this->assertFalse( $args['cache_results'] );
+			$this->assertFalse( $args['update_term_meta_cache'] );
+		}
+	}
+
+	public function test_profile_deletion_skips_malformed_numeric_cast_matches_without_looping(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'malformed-band', 12 );
+		$this->addTerm( 102, 'stale-band', 12 );
+		$this->addTerm( 103, 'different-numeric-band', 12 );
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = '12broken';
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][103]['_artist_profile_id'] = '12.5';
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][102] );
+		$this->assertSame( '12.5', $GLOBALS['ec_test']['blogs'][1]['term_meta'][103]['_artist_profile_id'] );
+		$this->assertCount( 3, $GLOBALS['ec_test']['get_terms_calls'] );
+		$this->assertSame( 2, $GLOBALS['ec_test']['get_terms_calls'][2]['offset'] );
+	}
+
 	public function test_profile_deletion_does_not_mutate_wrong_taxonomy_or_unrelated_terms(): void {
 		$this->addProfile( 12, 'the-band', 101 );
 		$this->addTerm( 101, 'the-band', 12 );

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -37,10 +37,10 @@ final class ArtistTermBindingTest extends TestCase {
 		}
 	}
 
-	private function addTerm( $id, $slug, $profile_id = 0 ) {
+	private function addTerm( $id, $slug, $profile_id = 0, $taxonomy = 'artist' ) {
 		$GLOBALS['ec_test']['blogs'][1]['terms'][ $id ] = (object) array(
 			'term_id'  => $id,
-			'taxonomy' => 'artist',
+			'taxonomy' => $taxonomy,
 			'slug'     => $slug,
 		);
 		if ( $profile_id > 0 ) {
@@ -129,12 +129,64 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 	}
 
-	public function test_profile_deletion_cleans_the_reciprocal_term_reference(): void {
+	public function test_profile_deletion_cleans_reciprocal_and_additional_stale_term_references(): void {
 		$this->addProfile( 12, 'the-band', 101 );
 		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'stale-band', 12 );
 
 		ec_delete_artist_profile_term_binding( 12 );
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][102] );
+	}
+
+	public function test_profile_deletion_cleans_term_references_without_profile_metadata(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'stale-band', 12 );
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+	}
+
+	public function test_profile_deletion_does_not_mutate_wrong_taxonomy_or_unrelated_terms(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'genre-term', 12, 'genre' );
+		$this->addTerm( 103, 'other-band', 13 );
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
+		$this->assertSame( 13, $GLOBALS['ec_test']['blogs'][1]['term_meta'][103]['_artist_profile_id'] );
+	}
+
+	public function test_profile_deletion_does_not_mutate_a_colliding_main_blog_post(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['blogs'][1]['posts'][12] = (object) array(
+			'ID'          => 12,
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+			'post_title'  => 'Unrelated post',
+			'post_name'   => 'unrelated-post',
+		);
+		$GLOBALS['ec_test']['blogs'][1]['post_meta'][12]['_artist_profile_id'] = 'unchanged';
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+		$this->assertSame( 'unchanged', $GLOBALS['ec_test']['blogs'][1]['post_meta'][12]['_artist_profile_id'] );
+	}
+
+	public function test_profile_deletion_restores_the_callers_artist_blog(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band', 12 );
+
+		ec_delete_artist_profile_term_binding( 12 );
+
+		$this->assertSame( 4, $GLOBALS['ec_test']['current_blog_id'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
 	}
 
 	public function test_slug_renames_do_not_break_a_valid_id_binding(): void {

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -158,23 +158,48 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
 
-	public function test_profile_deletion_uses_complete_bounded_uncached_batches(): void {
+	public function test_profile_deletion_uses_stable_complete_bounded_uncached_batches(): void {
 		$this->addProfile( 12, 'the-band' );
-		for ( $term_id = 1000; $term_id < 1205; ++$term_id ) {
+		for ( $term_id = 1000; $term_id < 1100; ++$term_id ) {
+			$this->addTerm( $term_id, 'malformed-band-' . $term_id, 12 );
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][ $term_id ]['_artist_profile_id'] = '12broken';
+		}
+		for ( $term_id = 1100; $term_id < 1305; ++$term_id ) {
 			$this->addTerm( $term_id, 'stale-band-' . $term_id, 12 );
 		}
 
 		ec_delete_artist_profile_term_binding( 12 );
 
-		foreach ( range( 1000, 1204 ) as $term_id ) {
+		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1000]['_artist_profile_id'] );
+		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1099]['_artist_profile_id'] );
+		foreach ( range( 1100, 1304 ) as $term_id ) {
 			$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][ $term_id ] );
 		}
 		foreach ( $GLOBALS['ec_test']['get_terms_calls'] as $args ) {
 			$this->assertSame( 100, $args['number'] );
-			$this->assertSame( 'none', $args['orderby'] );
+			$this->assertSame( 'term_id', $args['orderby'] );
+			$this->assertSame( 'ASC', $args['order'] );
 			$this->assertFalse( $args['cache_results'] );
 			$this->assertFalse( $args['update_term_meta_cache'] );
 		}
+		$this->assertSame( array( 0, 100, 100, 100, 100 ), array_column( $GLOBALS['ec_test']['get_terms_calls'], 'offset' ) );
+	}
+
+	public function test_profile_deletion_keeps_adjacent_large_integer_references_distinct(): void {
+		$profile_id = 9007199254740993;
+		$this->addProfile( $profile_id, 'large-id-band' );
+		$this->addTerm( 101, 'large-id-band', $profile_id );
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = array(
+			'09007199254740993',
+			'9007199254740992',
+		);
+
+		ec_delete_artist_profile_term_binding( $profile_id );
+
+		$this->assertSame(
+			array( '9007199254740992' ),
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id']
+		);
 	}
 
 	public function test_profile_deletion_skips_malformed_numeric_cast_matches_without_looping(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -432,6 +432,29 @@ function get_term_by( $field, $value, $taxonomy ) {
 	return false;
 }
 
+function get_terms( $args = array() ) {
+	$term_ids   = array();
+	$meta_query = $args['meta_query'][0] ?? array();
+	foreach ( ec_test_blog_store( 'terms' ) as $term_id => $term ) {
+		if ( isset( $args['taxonomy'] ) && $term->taxonomy !== $args['taxonomy'] ) {
+			continue;
+		}
+		if ( ! empty( $meta_query ) ) {
+			$value = get_term_meta( $term_id, $meta_query['key'], true );
+			if ( 'NUMERIC' === ( $meta_query['type'] ?? '' ) ) {
+				$matches = (int) $value === (int) $meta_query['value'];
+			} else {
+				$matches = (string) $value === (string) $meta_query['value'];
+			}
+			if ( ! $matches ) {
+				continue;
+			}
+		}
+		$term_ids[] = (int) $term_id;
+	}
+	return $term_ids;
+}
+
 function get_term_meta( $term_id, $key, $single = false ) {
 	$meta  = ec_test_blog_store( 'term_meta' );
 	$value = $meta[ $term_id ][ $key ] ?? ( $single ? '' : array() );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -441,17 +441,28 @@ function get_terms( $args = array() ) {
 			continue;
 		}
 		if ( ! empty( $meta_query ) ) {
-			$value = get_term_meta( $term_id, $meta_query['key'], true );
-			if ( 'NUMERIC' === ( $meta_query['type'] ?? '' ) ) {
-				$matches = (int) $value === (int) $meta_query['value'];
-			} else {
-				$matches = (string) $value === (string) $meta_query['value'];
+			$matches = false;
+			foreach ( get_term_meta( $term_id, $meta_query['key'], false ) as $value ) {
+				if ( 'NUMERIC' === ( $meta_query['type'] ?? '' ) ) {
+					$matches = (int) $value === (int) $meta_query['value'];
+				} else {
+					$matches = (string) $value === (string) $meta_query['value'];
+				}
+				if ( $matches ) {
+					break;
+				}
 			}
 			if ( ! $matches ) {
 				continue;
 			}
 		}
 		$term_ids[] = (int) $term_id;
+	}
+	if ( 'term_id' === ( $args['orderby'] ?? '' ) ) {
+		sort( $term_ids, SORT_NUMERIC );
+		if ( 'DESC' === ( $args['order'] ?? 'ASC' ) ) {
+			$term_ids = array_reverse( $term_ids );
+		}
 	}
 	return array_slice( $term_ids, (int) ( $args['offset'] ?? 0 ), $args['number'] ?? null );
 }
@@ -461,7 +472,8 @@ function get_term_meta( $term_id, $key, $single = false ) {
 	if ( ! array_key_exists( $key, $meta[ $term_id ] ?? array() ) ) {
 		return $single ? '' : array();
 	}
-	return $single ? $meta[ $term_id ][ $key ] : array( $meta[ $term_id ][ $key ] );
+	$values = is_array( $meta[ $term_id ][ $key ] ) ? $meta[ $term_id ][ $key ] : array( $meta[ $term_id ][ $key ] );
+	return $single ? ( $values[0] ?? '' ) : $values;
 }
 
 function update_term_meta( $term_id, $key, $value ) {
@@ -473,6 +485,25 @@ function update_term_meta( $term_id, $key, $value ) {
 function delete_term_meta( $term_id, $key, $value = '' ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] ?? null;
+	if ( is_array( $current ) && '' !== $value ) {
+		$remaining = array_values(
+			array_filter(
+				$current,
+				static function ( $stored_value ) use ( $value ) {
+					return (string) $stored_value !== (string) $value;
+				}
+			)
+		);
+		if ( count( $remaining ) === count( $current ) ) {
+			return false;
+		}
+		if ( empty( $remaining ) ) {
+			unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] );
+		} else {
+			$GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] = $remaining;
+		}
+		return true;
+	}
 	if ( '' === $value || (string) $current === (string) $value ) {
 		unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] );
 		return true;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -433,6 +433,7 @@ function get_term_by( $field, $value, $taxonomy ) {
 }
 
 function get_terms( $args = array() ) {
+	$GLOBALS['ec_test']['get_terms_calls'][] = $args;
 	$term_ids   = array();
 	$meta_query = $args['meta_query'][0] ?? array();
 	foreach ( ec_test_blog_store( 'terms' ) as $term_id => $term ) {
@@ -452,13 +453,15 @@ function get_terms( $args = array() ) {
 		}
 		$term_ids[] = (int) $term_id;
 	}
-	return $term_ids;
+	return array_slice( $term_ids, (int) ( $args['offset'] ?? 0 ), $args['number'] ?? null );
 }
 
 function get_term_meta( $term_id, $key, $single = false ) {
-	$meta  = ec_test_blog_store( 'term_meta' );
-	$value = $meta[ $term_id ][ $key ] ?? ( $single ? '' : array() );
-	return $value;
+	$meta = ec_test_blog_store( 'term_meta' );
+	if ( ! array_key_exists( $key, $meta[ $term_id ] ?? array() ) ) {
+		return $single ? '' : array();
+	}
+	return $single ? $meta[ $term_id ][ $key ] : array( $meta[ $term_id ][ $key ] );
 }
 
 function update_term_meta( $term_id, $key, $value ) {


### PR DESCRIPTION
## Summary
- Remove every main-site `artist` term `_artist_profile_id` reference matching a deleting artist profile, not only the term named by profile-side metadata.
- Delete the exact raw stored value after unsigned decimal-integer normalization so non-canonical references such as `012` are removed without conflating adjacent large IDs.
- Process deterministic `term_id ASC` batches of 100 with query caching and term-meta cache priming disabled, advancing past malformed non-deletable matches to guarantee termination.
- Keep cleanup scoped to validated Artist-blog `artist_profile` deletions and the main-site `artist` taxonomy, with explicit blog restoration.

## Root Cause
The deletion lifecycle followed only the profile's `_artist_term_id`, so additional stale inverse references survived. The initial correction also deleted only the canonical integer value, queried all matches synchronously, then used unstable offset pagination and float comparison. Those details could leave non-canonical references behind, skip rows after malformed survivors, or conflate adjacent IDs above `2^53`.

## Correction
The existing binding deletion hook queries only main-site `artist` terms by `_artist_profile_id` in bounded, stably ordered batches. For each result it reads raw metadata, normalizes only unsigned decimal integer values, compares normalized strings, and passes the exact matching stored value to `delete_term_meta()`. Successful deletion keeps the query on the current page as rows shrink; a no-progress batch advances the offset over deterministic survivors so malformed numeric-cast matches cannot cause an infinite loop.

## Test Evidence
- `vendor/bin/phpunit tests/ArtistTermBindingTest.php` (18 tests, 278 assertions)
- `vendor/bin/phpunit` (91 tests, 625 assertions)
- WordPress PHPCS on `inc/core/artist-term-binding.php`
- PHP syntax lint on all modified PHP files
- `git diff --check`

Regression coverage includes reciprocal and additional stale references, missing profile metadata, non-canonical numeric storage, mixed malformed and valid rows across multiple stable batches, adjacent large integer strings above `2^53`, malformed numeric-cast survivors, wrong taxonomies, unrelated terms, colliding numeric post IDs, and caller-blog restoration.

Closes #148