### PR TITLE
feat: add claimable external artist onboarding

### DIFF
--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/registry.php';
 require_once __DIR__ . '/handlers/get-artist-data.php';
 require_once __DIR__ . '/handlers/get-link-page-data.php';
 require_once __DIR__ . '/handlers/create-artist.php';
+require_once __DIR__ . '/handlers/onboard-external-artist.php';
 require_once __DIR__ . '/handlers/artist-invitation.php';
 require_once __DIR__ . '/handlers/update-artist.php';
 require_once __DIR__ . '/handlers/save-link-page-links.php';

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -104,7 +104,7 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 		$membership_failure = function_exists( 'ec_get_artist_membership_failure' ) ? ec_get_artist_membership_failure() : null;
 		if ( ! wp_delete_post( $artist_id, true ) ) {
 			restore_current_blog();
-			return new WP_Error( 'artist_creation_rollback_failed', 'Artist membership and profile rollback both failed. Manual reconciliation is required.', array( 'artist_id' => (int) $artist_id ) );
+			return new WP_Error( 'artist_creation_rollback_failed', 'Artist membership and profile rollback both failed. Manual reconciliation is required.', array( 'artist_id' => (int) $artist_id, 'retryable' => false ) );
 		}
 		restore_current_blog();
 		return $membership_failure ? $membership_failure : new WP_Error( 'artist_membership_failed', 'Artist membership could not be established. No profile was created.' );

--- a/inc/abilities/handlers/onboard-external-artist.php
+++ b/inc/abilities/handlers/onboard-external-artist.php
@@ -180,6 +180,27 @@ function extrachill_artist_platform_external_onboarding_response( $outcome, $con
 }
 
 /**
+ * Authorize internal callers of the external onboarding contract.
+ *
+ * Anonymous product flows must explicitly opt in through the filter after
+ * enforcing their own request validation and anti-abuse controls. The ability
+ * remains unavailable through the generic REST ability transport.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_artist_platform_ability_external_onboarding_permission( $input ) {
+	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) ) {
+		return true;
+	}
+	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
+		return true;
+	}
+
+	return (bool) apply_filters( 'extrachill_allow_external_artist_onboarding', false, $input );
+}
+
+/**
  * Provision a claimable artist lead from a generic external product flow.
  *
  * Account creation and claim delivery remain owned by extrachill-users. Artist
@@ -393,6 +414,10 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 			return extrachill_artist_platform_external_onboarding_response( 'membership_request_required', $context );
 		}
 		if ( $profile_id && $term_id && ! ec_reconcile_artist_profile_term_pair( $profile_id, $term_id ) ) {
+			$binding_failure = ec_get_artist_binding_failure();
+			if ( $binding_failure ) {
+				return $binding_failure;
+			}
 			return new WP_Error( 'conflicting_artist_identity', __( 'The artist profile and term could not be safely bound.', 'extrachill-artist-platform' ) );
 		}
 
@@ -452,7 +477,7 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 					$membership_removed = ec_remove_artist_membership( $user_id, $profile_id );
 					$profile_removed    = $membership_removed ? wp_delete_post( $profile_id, true ) : false;
 					if ( ! $membership_removed || ! $profile_removed ) {
-						return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Artist onboarding provenance and rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
+						return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Artist onboarding provenance and rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
 					}
 				}
 				return new WP_Error( 'artist_onboarding_source_failed', __( 'Artist onboarding provenance could not be stored.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
@@ -460,11 +485,43 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 			if ( ! $term_id ) {
 				$binding_result = ec_sync_artist_profile_term_binding( $profile_id );
 				if ( is_wp_error( $binding_result ) ) {
+					if ( in_array( $binding_result->get_error_code(), array( 'artist_binding_compensation_failed', 'artist_term_binding_rollback_failed' ), true ) ) {
+						return $binding_result;
+					}
 					if ( $artist_created ) {
 						$membership_removed = ec_remove_artist_membership( $user_id, $profile_id );
 						$profile_removed    = $membership_removed ? wp_delete_post( $profile_id, true ) : false;
 						if ( ! $membership_removed || ! $profile_removed ) {
-							return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Canonical artist binding and profile rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
+							return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Canonical artist binding and profile rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+						}
+						$main_blog_id = ec_get_blog_id( 'main' );
+						switch_to_blog( $main_blog_id );
+						try {
+							$remaining_terms = get_terms(
+								array(
+									'taxonomy'   => 'artist',
+									'hide_empty' => false,
+									'fields'     => 'ids',
+									'number'     => 1,
+									'meta_query' => array(
+										array(
+											'key'     => '_artist_profile_id',
+											'value'   => $profile_id,
+											'compare' => '=',
+											'type'    => 'NUMERIC',
+										),
+									),
+								)
+							);
+						} finally {
+							restore_current_blog();
+						}
+						if ( is_wp_error( $remaining_terms ) || ! empty( $remaining_terms ) ) {
+							return new WP_Error(
+								'artist_onboarding_rollback_failed',
+								__( 'The profile was removed, but canonical artist references remain. Manual reconciliation is required.', 'extrachill-artist-platform' ),
+								array( 'profile_id' => $profile_id, 'retryable' => false )
+							);
 						}
 					}
 					return $binding_result;

--- a/inc/abilities/handlers/onboard-external-artist.php
+++ b/inc/abilities/handlers/onboard-external-artist.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Handler: extrachill/onboard-external-artist
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve canonical artist identity without creating or rebinding anything.
+ *
+ * @param string $name       Submitted artist name.
+ * @param int    $profile_id Optional artist profile ID.
+ * @param int    $term_id    Optional main-site artist term ID.
+ * @return array|WP_Error Resolved profile and term IDs.
+ */
+function extrachill_artist_platform_resolve_external_artist( $name, $profile_id = 0, $term_id = 0 ) {
+	$blog_ids = ec_artist_binding_blog_ids();
+	if ( empty( $blog_ids ) ) {
+		return new WP_Error( 'artist_identity_unavailable', __( 'Artist identity resolution is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	$profile_id = absint( $profile_id );
+	$term_id    = absint( $term_id );
+	$slug       = sanitize_title( $name );
+	$profile    = $profile_id ? ec_artist_binding_read_profile( $profile_id, $blog_ids['artist'] ) : array();
+	$term       = $term_id ? ec_artist_binding_read_term( $term_id, $blog_ids['main'] ) : array();
+	if ( ( $profile_id && empty( $profile ) ) || ( $term_id && empty( $term ) ) ) {
+		return new WP_Error( 'invalid_artist_identity', __( 'The supplied artist identity does not exist.', 'extrachill-artist-platform' ) );
+	}
+	if ( ( $profile_id && $profile['slug'] !== $slug ) || ( $term_id && $term['slug'] !== $slug ) ) {
+		return new WP_Error( 'conflicting_artist_identity', __( 'The supplied artist identity does not match the submitted artist name.', 'extrachill-artist-platform' ) );
+	}
+
+	if ( $term_id && ! $profile_id ) {
+		$profile_id = (int) $term['profile_id'];
+		$profile    = $profile_id ? ec_artist_binding_read_profile( $profile_id, $blog_ids['artist'] ) : array();
+		if ( empty( $profile ) ) {
+			$profile_id = 0;
+		}
+	}
+	if ( $profile_id && ! $term_id ) {
+		$term_id = (int) $profile['term_id'];
+		$term    = $term_id ? ec_artist_binding_read_term( $term_id, $blog_ids['main'] ) : array();
+		if ( empty( $term ) ) {
+			$term_id = 0;
+		}
+	}
+
+	if ( ! $term_id && $slug ) {
+		switch_to_blog( $blog_ids['main'] );
+		try {
+			$matched_term = get_term_by( 'slug', $slug, 'artist' );
+			$term_id      = $matched_term && ! is_wp_error( $matched_term ) ? (int) $matched_term->term_id : 0;
+			$term         = $term_id ? ec_artist_binding_read_term( $term_id, $blog_ids['main'] ) : array();
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	if ( ! $profile_id && $term_id ) {
+		$profile_id = (int) ( $term['profile_id'] ?? 0 );
+		$profile    = $profile_id ? ec_artist_binding_read_profile( $profile_id, $blog_ids['artist'] ) : array();
+		if ( empty( $profile ) ) {
+			$profile_id = 0;
+		}
+	}
+	if ( ! $profile_id && $slug ) {
+		switch_to_blog( $blog_ids['artist'] );
+		try {
+			$matches    = get_posts(
+				array(
+					'post_type'      => 'artist_profile',
+					'name'           => $slug,
+					'post_status'    => 'publish',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			$profile_id = empty( $matches ) ? 0 : (int) $matches[0];
+			$profile    = $profile_id ? ec_artist_binding_read_profile( $profile_id, $blog_ids['artist'] ) : array();
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	if ( $profile_id ) {
+		if ( empty( $profile ) || $profile['slug'] !== $slug ) {
+			return new WP_Error( 'conflicting_artist_identity', __( 'The resolved artist profile does not match the submitted artist name.', 'extrachill-artist-platform' ) );
+		}
+		$profile_term_id = (int) ( $profile['term_id'] ?? 0 );
+		if ( $term_id && $profile_term_id && $term_id !== $profile_term_id ) {
+			return new WP_Error( 'conflicting_artist_identity', __( 'The resolved artist profile is bound to a different artist term.', 'extrachill-artist-platform' ) );
+		}
+		$term_id = $profile_term_id ? $profile_term_id : $term_id;
+	}
+	if ( $term_id ) {
+		$term = empty( $term ) ? ec_artist_binding_read_term( $term_id, $blog_ids['main'] ) : $term;
+		if ( empty( $term ) || $term['slug'] !== $slug ) {
+			return new WP_Error( 'conflicting_artist_identity', __( 'The resolved artist term does not match the submitted artist name.', 'extrachill-artist-platform' ) );
+		}
+		$term_profile_id = (int) ( $term['profile_id'] ?? 0 );
+		if ( $profile_id && $term_profile_id && $profile_id !== $term_profile_id ) {
+			return new WP_Error( 'conflicting_artist_identity', __( 'The resolved artist term is bound to a different artist profile.', 'extrachill-artist-platform' ) );
+		}
+	}
+
+	return array(
+		'profile_id' => $profile_id,
+		'term_id'    => $term_id,
+	);
+}
+
+/**
+ * Acquire a named orchestration lock.
+ *
+ * @param string $lock_name Lock name, limited to 64 characters by MySQL.
+ * @return bool Whether the lock was acquired.
+ */
+function extrachill_artist_platform_acquire_external_lock( $lock_name ) {
+	global $wpdb;
+	return '1' === (string) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Serializes cross-row orchestration where no single row lock is sufficient.
+}
+
+/**
+ * Acquire the artist-name lock used around profile and link-page provisioning.
+ *
+ * @param string $name Artist name.
+ * @return string|false Lock name, or false when unavailable.
+ */
+function extrachill_artist_platform_acquire_external_artist_lock( $name ) {
+	$lock_name = 'ec_external_artist_' . md5( sanitize_title( $name ) );
+	$acquired  = extrachill_artist_platform_acquire_external_lock( $lock_name );
+	return $acquired ? $lock_name : false;
+}
+
+/**
+ * Release an external artist provisioning lock.
+ *
+ * @param string $lock_name Lock name returned by the acquire helper.
+ * @return void
+ */
+function extrachill_artist_platform_release_external_artist_lock( $lock_name ) {
+	global $wpdb;
+	$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the matching provisioning lock.
+}
+
+/**
+ * Build a stable external-onboarding response.
+ *
+ * @param string $outcome Response outcome.
+ * @param array  $context Resolved response context.
+ * @return array
+ */
+function extrachill_artist_platform_external_onboarding_response( $outcome, $context ) {
+	return array(
+		'outcome'     => $outcome,
+		'user'        => $context['user'],
+		'artist'      => $context['artist'],
+		'membership'  => $context['membership'],
+		'claim'       => $context['claim'],
+		'link_page'   => $context['link_page'],
+		'source'      => $context['source'],
+		'return_url'  => $context['return_url'],
+		'next_action' => $context['next_action'],
+	);
+}
+
+/**
+ * Provision a claimable artist lead from a generic external product flow.
+ *
+ * Account creation and claim delivery remain owned by extrachill-users. Artist
+ * creation, canonical binding, membership, and link-page creation delegate to
+ * their existing Artist Platform contracts.
+ *
+ * @param array $input Ability input.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
+	$name            = trim( sanitize_text_field( $input['artist_name'] ?? '' ) );
+	$email           = sanitize_email( $input['submitter_email'] ?? '' );
+	$user_id         = absint( $input['submitter_user_id'] ?? 0 );
+	$source_type     = sanitize_key( $input['source_type'] ?? '' );
+	$source_id       = sanitize_text_field( $input['source_id'] ?? '' );
+	$return_url      = esc_url_raw( $input['return_url'] ?? '' );
+	$consent         = isset( $input['consent'] ) && is_array( $input['consent'] ) ? $input['consent'] : array();
+	$profile_consent = ! empty( $consent['profile_creation'] );
+	$link_consent    = ! empty( $consent['link_page'] );
+	$disclosure      = sanitize_text_field( $consent['disclosure_version'] ?? '' );
+
+	if ( '' === $name || '' === $source_type || '' === $source_id || ( ! $user_id && ! is_email( $email ) ) ) {
+		return new WP_Error( 'invalid_external_artist_lead', __( 'Submitter identity, artist name, source type, and source ID are required.', 'extrachill-artist-platform' ) );
+	}
+	if ( '' === sanitize_title( $name ) ) {
+		return new WP_Error( 'invalid_artist_name', __( 'Artist name must contain letters or numbers.', 'extrachill-artist-platform' ) );
+	}
+	if ( $email && ! is_email( $email ) ) {
+		return new WP_Error( 'invalid_submitter_email', __( 'The submitter email address is invalid.', 'extrachill-artist-platform' ) );
+	}
+	if ( ( $profile_consent || $link_consent ) && '' === $disclosure ) {
+		return new WP_Error( 'missing_consent_disclosure', __( 'A disclosure version is required when consent is asserted.', 'extrachill-artist-platform' ) );
+	}
+
+	$requested_profile_id = absint( $input['artist_profile_id'] ?? 0 );
+	$requested_term_id    = absint( $input['artist_term_id'] ?? 0 );
+	$identity             = extrachill_artist_platform_resolve_external_artist( $name, $requested_profile_id, $requested_term_id );
+	if ( is_wp_error( $identity ) ) {
+		return $identity;
+	}
+
+	$user = $user_id ? get_userdata( $user_id ) : false;
+	if ( $user_id && ! $user ) {
+		return new WP_Error( 'invalid_submitter_user', __( 'The supplied submitter user does not exist.', 'extrachill-artist-platform' ) );
+	}
+	if ( $user && $email && strtolower( $user->user_email ) !== strtolower( $email ) ) {
+		return new WP_Error( 'conflicting_submitter_identity', __( 'The supplied user and email address do not match.', 'extrachill-artist-platform' ) );
+	}
+	if ( ! $user && $email ) {
+		$existing_user_id = email_exists( $email );
+		$user             = $existing_user_id ? get_userdata( $existing_user_id ) : false;
+		$user_id          = $user ? (int) $user->ID : 0;
+	}
+
+	$account_created = false;
+	$claim_delivery  = 'not_required';
+	if ( ! $user ) {
+		$create_user = wp_get_ability( 'extrachill/create-user' );
+		if ( ! $create_user || ! function_exists( 'ec_generate_username_from_email' ) ) {
+			return new WP_Error( 'account_creation_unavailable', __( 'Claimable account creation is unavailable.', 'extrachill-artist-platform' ) );
+		}
+
+		$created_user_id = $create_user->execute(
+			array(
+				'email'               => $email,
+				'password'            => wp_generate_password( 24 ),
+				'username'            => ec_generate_username_from_email( $email ),
+				'role'                => 'subscriber',
+				'unclaimed'           => true,
+				'registration_page'   => $return_url,
+				'registration_source' => $source_type,
+				'registration_method' => 'external_artist_onboarding',
+			)
+		);
+		if ( is_wp_error( $created_user_id ) ) {
+			$existing_user_id = email_exists( $email );
+			if ( ! $existing_user_id ) {
+				return $created_user_id;
+			}
+			$created_user_id = $existing_user_id;
+		}
+
+		$user            = get_userdata( $created_user_id );
+		$user_id         = $user ? (int) $user->ID : 0;
+		$account_created = (bool) $user_id && ! $existing_user_id;
+		if ( ! $user ) {
+			return new WP_Error( 'account_creation_failed', __( 'The claimable account could not be loaded.', 'extrachill-artist-platform' ) );
+		}
+	}
+
+	$unclaimed = '1' === (string) get_user_meta( $user_id, 'ec_unclaimed', true );
+	if ( $unclaimed ) {
+		$claim_lock = 'ec_artist_claim_' . $user_id;
+		if ( ! extrachill_artist_platform_acquire_external_lock( $claim_lock ) ) {
+			$claim_delivery = 'busy';
+		} else {
+			try {
+				$claim_record = get_user_meta( $user_id, '_ec_artist_onboarding_claim_delivery', true );
+				$claim_state  = is_array( $claim_record ) ? ( $claim_record['state'] ?? '' ) : $claim_record;
+				$claim_started = is_array( $claim_record ) ? absint( $claim_record['started_at'] ?? 0 ) : 0;
+				if ( 'sent' === $claim_state || 1 === $claim_state || '1' === $claim_state ) {
+					$claim_delivery = 'previously_sent';
+				} elseif ( 'pending' === $claim_state && $claim_started > time() - ( 15 * MINUTE_IN_SECONDS ) ) {
+					$claim_delivery = 'pending';
+				} elseif ( ! update_user_meta( $user_id, '_ec_artist_onboarding_claim_delivery', array( 'state' => 'pending', 'started_at' => time() ) ) ) {
+					$claim_delivery = 'failed';
+				} else {
+					$claim_result = retrieve_password( $user->user_login );
+					if ( is_wp_error( $claim_result ) ) {
+						update_user_meta( $user_id, '_ec_artist_onboarding_claim_delivery', '' );
+						$claim_delivery = 'failed';
+					} elseif ( update_user_meta( $user_id, '_ec_artist_onboarding_claim_delivery', array( 'state' => 'sent', 'sent_at' => time() ) ) ) {
+						$claim_delivery = 'sent';
+					} else {
+						$claim_delivery = 'sent_unconfirmed';
+					}
+				}
+			} finally {
+				extrachill_artist_platform_release_external_artist_lock( $claim_lock );
+			}
+		}
+	}
+
+	$profile_id = (int) $identity['profile_id'];
+	$term_id    = (int) $identity['term_id'];
+	$managed    = $profile_id && function_exists( 'ec_can_manage_artist' ) && ec_can_manage_artist( $user_id, $profile_id );
+	$trusted    = get_current_user_id() === $user_id
+		|| current_user_can( 'manage_options' )
+		|| current_user_can( 'manage_network_options' )
+		|| ( defined( 'WP_CLI' ) && WP_CLI )
+		|| ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) );
+
+	$context = array(
+		'user'        => array(
+			'id'      => $user_id,
+			'state'   => $unclaimed ? 'unclaimed' : ( $account_created ? 'created' : 'existing' ),
+			'created' => $account_created,
+		),
+		'artist'      => array(
+			'name'       => $name,
+			'profile_id' => $profile_id ?: null,
+			'term_id'    => $term_id ?: null,
+			'state'      => $profile_id ? 'existing_profile' : ( $term_id ? 'existing_canonical_identity' : 'new_eligible' ),
+		),
+		'membership'  => array( 'state' => $managed ? 'managed' : ( $profile_id || $term_id ? 'request_required' : 'not_applicable' ) ),
+		'claim'       => array(
+			'required' => $unclaimed,
+			'delivery' => $unclaimed ? ( 'not_required' === $claim_delivery ? 'previously_provisioned' : $claim_delivery ) : 'not_required',
+		),
+		'link_page'   => array( 'state' => 'unavailable', 'id' => null ),
+		'source'      => array( 'type' => $source_type, 'id' => $source_id ),
+		'return_url'  => $return_url,
+		'next_action' => 'none',
+	);
+	if ( $disclosure ) {
+		$context['artist']['disclosure_version'] = $disclosure;
+	}
+
+	if ( $unclaimed ) {
+		$context['artist']['state'] = $profile_id || $term_id ? $context['artist']['state'] : 'eligible_after_claim_and_consent';
+		$context['next_action']     = 'claim_account';
+		return extrachill_artist_platform_external_onboarding_response( 'account_claim_required', $context );
+	}
+
+	if ( ( $profile_id || $term_id ) && ! $managed ) {
+		$context['next_action'] = 'request_membership';
+		return extrachill_artist_platform_external_onboarding_response( 'membership_request_required', $context );
+	}
+
+	if ( ! $trusted ) {
+		$context['artist']['state'] = 'eligible_after_authentication_and_consent';
+		$context['next_action']     = 'authenticate';
+		return extrachill_artist_platform_external_onboarding_response( 'authentication_required', $context );
+	}
+
+	if ( ! $profile_id && ! $profile_consent ) {
+		$context['artist']['state'] = 'eligible_after_consent';
+		$context['next_action']     = 'confirm_profile_creation';
+		return extrachill_artist_platform_external_onboarding_response( 'artist_consent_required', $context );
+	}
+
+	$lock_name = extrachill_artist_platform_acquire_external_artist_lock( $name );
+	if ( ! $lock_name ) {
+		return new WP_Error( 'artist_onboarding_busy', __( 'Artist onboarding is already in progress. Retry the operation.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+	}
+
+	try {
+		$locked_identity = extrachill_artist_platform_resolve_external_artist( $name, $requested_profile_id, $requested_term_id );
+		if ( is_wp_error( $locked_identity ) ) {
+			return $locked_identity;
+		}
+		$profile_id = (int) $locked_identity['profile_id'];
+		$term_id    = (int) $locked_identity['term_id'];
+		$managed    = $profile_id && function_exists( 'ec_can_manage_artist' ) && ec_can_manage_artist( $user_id, $profile_id );
+		$context['artist'] = array(
+			'name'       => $name,
+			'profile_id' => $profile_id ?: null,
+			'term_id'    => $term_id ?: null,
+			'state'      => $profile_id ? 'existing_profile' : ( $term_id ? 'existing_canonical_identity' : 'new_eligible' ),
+		);
+		if ( $disclosure ) {
+			$context['artist']['disclosure_version'] = $disclosure;
+		}
+		$context['membership']['state'] = $managed ? 'managed' : ( $profile_id || $term_id ? 'request_required' : 'not_applicable' );
+		if ( ( $profile_id || $term_id ) && ! $managed ) {
+			$context['next_action'] = 'request_membership';
+			return extrachill_artist_platform_external_onboarding_response( 'membership_request_required', $context );
+		}
+		if ( $profile_id && $term_id && ! ec_reconcile_artist_profile_term_pair( $profile_id, $term_id ) ) {
+			return new WP_Error( 'conflicting_artist_identity', __( 'The artist profile and term could not be safely bound.', 'extrachill-artist-platform' ) );
+		}
+
+		$artist_created = false;
+		if ( ! $profile_id ) {
+			$create_artist = wp_get_ability( 'extrachill/create-artist' );
+			if ( ! $create_artist ) {
+				return new WP_Error( 'artist_creation_unavailable', __( 'Artist profile creation is unavailable.', 'extrachill-artist-platform' ) );
+			}
+			$created_artist = $create_artist->execute( array( 'name' => $name, 'user_id' => $user_id ) );
+			if ( is_wp_error( $created_artist ) ) {
+				return $created_artist;
+			}
+			$profile_id = absint( is_array( $created_artist ) ? ( $created_artist['id'] ?? 0 ) : $created_artist );
+			if ( ! $profile_id ) {
+				return new WP_Error( 'artist_creation_failed', __( 'Artist profile creation returned no profile ID.', 'extrachill-artist-platform' ) );
+			}
+			$artist_created = true;
+			$context['artist'] = array(
+				'name'       => $name,
+				'profile_id' => $profile_id,
+				'term_id'    => null,
+				'state'      => 'created',
+			);
+			$context['membership']['state'] = 'managed';
+		}
+
+		$artist_blog_id = ec_get_blog_id( 'artist' );
+		if ( ! $artist_blog_id ) {
+			return new WP_Error( 'artist_site_unavailable', __( 'The artist site is unavailable.', 'extrachill-artist-platform' ) );
+		}
+		switch_to_blog( $artist_blog_id );
+		try {
+			$source_key = hash( 'sha256', $source_type . ':' . $source_id );
+			$sources    = get_post_meta( $profile_id, '_ec_external_onboarding_sources', true );
+			$sources    = is_array( $sources ) ? $sources : array();
+			$existing_source = isset( $sources[ $source_key ] ) && is_array( $sources[ $source_key ] ) ? $sources[ $source_key ] : array();
+			$disclosures    = isset( $existing_source['disclosure_versions'] ) && is_array( $existing_source['disclosure_versions'] ) ? $existing_source['disclosure_versions'] : array();
+			if ( ! empty( $existing_source['disclosure_version'] ) ) {
+				$disclosures[] = $existing_source['disclosure_version'];
+			}
+			if ( $disclosure ) {
+				$disclosures[] = $disclosure;
+			}
+			$disclosures = array_values( array_unique( array_filter( $disclosures ) ) );
+			$sources[ $source_key ] = array(
+				'type'                => $source_type,
+				'id'                  => $source_id,
+				'return_url'          => $existing_source['return_url'] ?? $return_url,
+				'profile_creation'    => ! empty( $existing_source['profile_creation'] ) || $profile_consent,
+				'link_page'           => ! empty( $existing_source['link_page'] ) || $link_consent,
+				'disclosure_versions' => $disclosures,
+			);
+			$source_updated = update_post_meta( $profile_id, '_ec_external_onboarding_sources', $sources );
+			if ( ! $source_updated && maybe_serialize( get_post_meta( $profile_id, '_ec_external_onboarding_sources', true ) ) !== maybe_serialize( $sources ) ) {
+				if ( $artist_created ) {
+					$membership_removed = ec_remove_artist_membership( $user_id, $profile_id );
+					$profile_removed    = $membership_removed ? wp_delete_post( $profile_id, true ) : false;
+					if ( ! $membership_removed || ! $profile_removed ) {
+						return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Artist onboarding provenance and rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
+					}
+				}
+				return new WP_Error( 'artist_onboarding_source_failed', __( 'Artist onboarding provenance could not be stored.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+			}
+			if ( ! $term_id ) {
+				ec_sync_artist_profile_term_binding( $profile_id );
+				$term_id                     = ec_get_artist_term_id( $profile_id );
+				$context['artist']['term_id'] = $term_id ?: null;
+				if ( ! $term_id ) {
+					if ( $artist_created ) {
+						$membership_removed = ec_remove_artist_membership( $user_id, $profile_id );
+						$profile_removed    = $membership_removed ? wp_delete_post( $profile_id, true ) : false;
+						if ( ! $membership_removed || ! $profile_removed ) {
+							return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Canonical artist binding and rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
+						}
+					}
+					return new WP_Error( 'artist_identity_binding_failed', __( 'The artist profile could not be bound to its canonical artist identity.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+				}
+			}
+
+			$existing_link_id = function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $profile_id ) : 0;
+			if ( $existing_link_id ) {
+				$context['link_page'] = array( 'state' => 'existing', 'id' => $existing_link_id );
+			} elseif ( $link_consent ) {
+				$link_page_id = ec_create_link_page( $profile_id );
+				if ( is_wp_error( $link_page_id ) ) {
+					return $link_page_id;
+				}
+				$context['link_page'] = array( 'state' => 'created', 'id' => (int) $link_page_id );
+			} else {
+				$context['link_page']['state'] = 'offered';
+			}
+		} finally {
+			restore_current_blog();
+		}
+
+		$context['next_action'] = 'manage_artist';
+		return extrachill_artist_platform_external_onboarding_response( $artist_created ? 'artist_created' : 'managed_artist', $context );
+	} finally {
+		extrachill_artist_platform_release_external_artist_lock( $lock_name );
+	}
+}

--- a/inc/abilities/handlers/onboard-external-artist.php
+++ b/inc/abilities/handlers/onboard-external-artist.php
@@ -58,6 +58,18 @@ function extrachill_artist_platform_resolve_external_artist( $name, $profile_id 
 			restore_current_blog();
 		}
 	}
+	if ( $term_id && ! $profile_id && 0 === (int) ( $term['profile_id'] ?? 0 ) && 0 === (int) ( $term['count'] ?? 0 ) ) {
+		switch_to_blog( $blog_ids['main'] );
+		try {
+			$recoverable_slug = (string) get_term_meta( $term_id, '_ec_artist_binding_recoverable', true );
+		} finally {
+			restore_current_blog();
+		}
+		if ( $slug === $recoverable_slug ) {
+			$term_id = 0;
+			$term    = array();
+		}
+	}
 
 	if ( ! $profile_id && $term_id ) {
 		$profile_id = (int) ( $term['profile_id'] ?? 0 );
@@ -209,7 +221,8 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 		return $identity;
 	}
 
-	$user = $user_id ? get_userdata( $user_id ) : false;
+	$existing_user_id = 0;
+	$user             = $user_id ? get_userdata( $user_id ) : false;
 	if ( $user_id && ! $user ) {
 		return new WP_Error( 'invalid_submitter_user', __( 'The supplied submitter user does not exist.', 'extrachill-artist-platform' ) );
 	}
@@ -268,7 +281,10 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 				$claim_record = get_user_meta( $user_id, '_ec_artist_onboarding_claim_delivery', true );
 				$claim_state  = is_array( $claim_record ) ? ( $claim_record['state'] ?? '' ) : $claim_record;
 				$claim_started = is_array( $claim_record ) ? absint( $claim_record['started_at'] ?? 0 ) : 0;
-				if ( 'sent' === $claim_state || 1 === $claim_state || '1' === $claim_state ) {
+				$claim_sent_at = is_array( $claim_record ) ? absint( $claim_record['sent_at'] ?? 0 ) : 0;
+				$claim_lifetime = (int) apply_filters( 'password_reset_expiration', DAY_IN_SECONDS );
+				$active_sent = 'sent' === $claim_state && $claim_sent_at > time() - $claim_lifetime;
+				if ( $active_sent ) {
 					$claim_delivery = 'previously_sent';
 				} elseif ( 'pending' === $claim_state && $claim_started > time() - ( 15 * MINUTE_IN_SECONDS ) ) {
 					$claim_delivery = 'pending';
@@ -442,22 +458,25 @@ function extrachill_artist_platform_ability_onboard_external_artist( $input ) {
 				return new WP_Error( 'artist_onboarding_source_failed', __( 'Artist onboarding provenance could not be stored.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
 			}
 			if ( ! $term_id ) {
-				ec_sync_artist_profile_term_binding( $profile_id );
-				$term_id                     = ec_get_artist_term_id( $profile_id );
-				$context['artist']['term_id'] = $term_id ?: null;
-				if ( ! $term_id ) {
+				$binding_result = ec_sync_artist_profile_term_binding( $profile_id );
+				if ( is_wp_error( $binding_result ) ) {
 					if ( $artist_created ) {
 						$membership_removed = ec_remove_artist_membership( $user_id, $profile_id );
 						$profile_removed    = $membership_removed ? wp_delete_post( $profile_id, true ) : false;
 						if ( ! $membership_removed || ! $profile_removed ) {
-							return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Canonical artist binding and rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
+							return new WP_Error( 'artist_onboarding_rollback_failed', __( 'Canonical artist binding and profile rollback both failed. Manual reconciliation is required.', 'extrachill-artist-platform' ) );
 						}
 					}
-					return new WP_Error( 'artist_identity_binding_failed', __( 'The artist profile could not be bound to its canonical artist identity.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+					return $binding_result;
 				}
+				$term_id                     = (int) $binding_result;
+				$context['artist']['term_id'] = $term_id;
 			}
 
-			$existing_link_id = function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $profile_id ) : 0;
+			$existing_link_id = function_exists( 'ec_get_reciprocal_link_page_id' ) ? ec_get_reciprocal_link_page_id( $profile_id ) : 0;
+			if ( is_wp_error( $existing_link_id ) ) {
+				return $existing_link_id;
+			}
 			if ( $existing_link_id ) {
 				$context['link_page'] = array( 'state' => 'existing', 'id' => $existing_link_id );
 			} elseif ( $link_consent ) {

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -88,6 +88,63 @@ function extrachill_artist_platform_register_abilities() {
 	// --- Write abilities ---
 
 	wp_register_ability(
+		'extrachill/onboard-external-artist',
+		array(
+			'label'               => __( 'Onboard External Artist', 'extrachill-artist-platform' ),
+			'description'         => __( 'Resolve or provision a consent-aware artist onboarding offer from a generic external source.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artist-platform',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'artist_name', 'source_type', 'source_id' ),
+				'properties'           => array(
+					'submitter_user_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+					'submitter_email'   => array( 'type' => 'string', 'format' => 'email' ),
+					'artist_name'       => array( 'type' => 'string', 'minLength' => 1 ),
+					'artist_term_id'    => array( 'type' => 'integer', 'minimum' => 1 ),
+					'artist_profile_id' => array( 'type' => 'integer', 'minimum' => 1 ),
+					'source_type'       => array( 'type' => 'string', 'minLength' => 1 ),
+					'source_id'         => array( 'type' => 'string', 'minLength' => 1 ),
+					'return_url'        => array( 'type' => 'string', 'format' => 'uri' ),
+					'consent'           => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'profile_creation'  => array( 'type' => 'boolean' ),
+							'link_page'          => array( 'type' => 'boolean' ),
+							'disclosure_version' => array( 'type' => 'string' ),
+						),
+						'additionalProperties' => false,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'outcome'     => array( 'type' => 'string', 'enum' => array( 'account_claim_required', 'authentication_required', 'artist_consent_required', 'membership_request_required', 'managed_artist', 'artist_created' ) ),
+					'user'        => array( 'type' => 'object' ),
+					'artist'      => array( 'type' => 'object' ),
+					'membership'  => array( 'type' => 'object' ),
+					'claim'       => array( 'type' => 'object' ),
+					'link_page'   => array( 'type' => 'object' ),
+					'source'      => array( 'type' => 'object' ),
+					'return_url'  => array( 'type' => 'string' ),
+					'next_action' => array( 'type' => 'string' ),
+				),
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_onboard_external_artist',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array(
+					'readonly'    => false,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
+	wp_register_ability(
 		'extrachill/artist-invitation',
 		array(
 			'label'               => __( 'Artist Invitation', 'extrachill-artist-platform' ),

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -118,18 +118,69 @@ function extrachill_artist_platform_register_abilities() {
 				'additionalProperties' => false,
 			),
 			'output_schema'       => array(
-				'type'       => 'object',
-				'properties' => array(
+				'type'                 => 'object',
+				'required'             => array( 'outcome', 'user', 'artist', 'membership', 'claim', 'link_page', 'source', 'return_url', 'next_action' ),
+				'properties'           => array(
 					'outcome'     => array( 'type' => 'string', 'enum' => array( 'account_claim_required', 'authentication_required', 'artist_consent_required', 'membership_request_required', 'managed_artist', 'artist_created' ) ),
-					'user'        => array( 'type' => 'object' ),
-					'artist'      => array( 'type' => 'object' ),
-					'membership'  => array( 'type' => 'object' ),
-					'claim'       => array( 'type' => 'object' ),
-					'link_page'   => array( 'type' => 'object' ),
-					'source'      => array( 'type' => 'object' ),
+					'user'        => array(
+						'type'                 => 'object',
+						'required'             => array( 'id', 'state', 'created' ),
+						'properties'           => array(
+							'id'      => array( 'type' => 'integer', 'minimum' => 1 ),
+							'state'   => array( 'type' => 'string', 'enum' => array( 'unclaimed', 'created', 'existing' ) ),
+							'created' => array( 'type' => 'boolean' ),
+						),
+						'additionalProperties' => false,
+					),
+					'artist'      => array(
+						'type'                 => 'object',
+						'required'             => array( 'name', 'profile_id', 'term_id', 'state' ),
+						'properties'           => array(
+							'name'               => array( 'type' => 'string' ),
+							'profile_id'         => array( 'type' => array( 'integer', 'null' ) ),
+							'term_id'            => array( 'type' => array( 'integer', 'null' ) ),
+							'state'              => array( 'type' => 'string', 'enum' => array( 'existing_profile', 'existing_canonical_identity', 'new_eligible', 'eligible_after_claim_and_consent', 'eligible_after_authentication_and_consent', 'eligible_after_consent', 'created' ) ),
+							'disclosure_version' => array( 'type' => 'string' ),
+						),
+						'additionalProperties' => false,
+					),
+					'membership'  => array(
+						'type'                 => 'object',
+						'required'             => array( 'state' ),
+						'properties'           => array( 'state' => array( 'type' => 'string', 'enum' => array( 'managed', 'request_required', 'not_applicable' ) ) ),
+						'additionalProperties' => false,
+					),
+					'claim'       => array(
+						'type'                 => 'object',
+						'required'             => array( 'required', 'delivery' ),
+						'properties'           => array(
+							'required' => array( 'type' => 'boolean' ),
+							'delivery' => array( 'type' => 'string', 'enum' => array( 'not_required', 'previously_provisioned', 'sent', 'previously_sent', 'pending', 'busy', 'failed', 'sent_unconfirmed' ) ),
+						),
+						'additionalProperties' => false,
+					),
+					'link_page'   => array(
+						'type'                 => 'object',
+						'required'             => array( 'state', 'id' ),
+						'properties'           => array(
+							'state' => array( 'type' => 'string', 'enum' => array( 'unavailable', 'offered', 'existing', 'created' ) ),
+							'id'    => array( 'type' => array( 'integer', 'null' ) ),
+						),
+						'additionalProperties' => false,
+					),
+					'source'      => array(
+						'type'                 => 'object',
+						'required'             => array( 'type', 'id' ),
+						'properties'           => array(
+							'type' => array( 'type' => 'string' ),
+							'id'   => array( 'type' => 'string' ),
+						),
+						'additionalProperties' => false,
+					),
 					'return_url'  => array( 'type' => 'string' ),
-					'next_action' => array( 'type' => 'string' ),
+					'next_action' => array( 'type' => 'string', 'enum' => array( 'none', 'claim_account', 'request_membership', 'authenticate', 'confirm_profile_creation', 'manage_artist' ) ),
 				),
+				'additionalProperties' => false,
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_onboard_external_artist',
 			'permission_callback' => '__return_true',

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -183,7 +183,7 @@ function extrachill_artist_platform_register_abilities() {
 				'additionalProperties' => false,
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_onboard_external_artist',
-			'permission_callback' => '__return_true',
+			'permission_callback' => 'extrachill_artist_platform_ability_external_onboarding_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
 				'annotations'  => array(

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -157,6 +157,26 @@ function ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $main_blo
 }
 
 /**
+ * Store or clear the current request's canonical binding failure.
+ *
+ * @param WP_Error|null $failure Failure to store, or null to clear.
+ * @return void
+ */
+function ec_set_artist_binding_failure( $failure = null ) {
+	$GLOBALS['ec_artist_binding_failure'] = $failure instanceof WP_Error ? $failure : null;
+}
+
+/**
+ * Return the current request's canonical binding failure.
+ *
+ * @return WP_Error|null
+ */
+function ec_get_artist_binding_failure() {
+	$failure = $GLOBALS['ec_artist_binding_failure'] ?? null;
+	return $failure instanceof WP_Error ? $failure : null;
+}
+
+/**
  * Persist a validated one-to-one profile <-> term binding.
  *
  * One-sided stale references are replaced. A reciprocal binding owned by a
@@ -168,6 +188,7 @@ function ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $main_blo
  * @return bool Whether the requested binding is valid and persisted.
  */
 function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = null ) {
+	ec_set_artist_binding_failure();
 	$profile_id = (int) $profile_id;
 	$term_id    = (int) $term_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
@@ -225,6 +246,16 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 					break;
 				}
 			}
+			$restored_old_term = ec_artist_binding_read_term( $old_reciprocal_term_id, $main_blog_id );
+			if ( empty( $restored_old_term ) || $restored_old_term['profile_id'] !== $profile_id ) {
+				ec_set_artist_binding_failure(
+					new WP_Error(
+						'artist_binding_compensation_failed',
+						__( 'Canonical artist binding compensation failed. Manual reconciliation is required.', 'extrachill-artist-platform' ),
+						array( 'profile_id' => $profile_id, 'term_id' => $term_id, 'previous_term_id' => $old_reciprocal_term_id, 'retryable' => false )
+					)
+				);
+			}
 		}
 		return false;
 	}
@@ -254,6 +285,7 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 		} finally {
 			restore_current_blog();
 		}
+		ec_set_artist_binding_failure();
 		return true;
 	}
 
@@ -303,6 +335,27 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 		}
 	}
 
+	$final_profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
+	$final_term    = ec_artist_binding_read_term( $term_id, $main_blog_id );
+	$final_old_term = $old_reciprocal_term_id > 0 ? ec_artist_binding_read_term( $old_reciprocal_term_id, $main_blog_id ) : array();
+	$profile_restored = ! empty( $final_profile ) && $final_profile['term_id'] === $previous_term_id;
+	$term_restored    = ! empty( $final_term ) && $final_term['profile_id'] === $previous_profile_id;
+	$old_term_restored = 0 === $old_reciprocal_term_id || ( ! empty( $final_old_term ) && $final_old_term['profile_id'] === $profile_id );
+	if ( ! $profile_restored || ! $term_restored || ! $old_term_restored ) {
+		ec_set_artist_binding_failure(
+			new WP_Error(
+				'artist_binding_compensation_failed',
+				__( 'Canonical artist binding compensation failed. Manual reconciliation is required.', 'extrachill-artist-platform' ),
+				array(
+					'profile_id'       => $profile_id,
+					'term_id'          => $term_id,
+					'previous_term_id' => $previous_term_id,
+					'retryable'        => false,
+				)
+			)
+		);
+	}
+
 	return false;
 }
 
@@ -313,6 +366,7 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
  * @return int Main-blog artist term ID, or 0.
  */
 function ec_get_artist_term_id( $profile_id ) {
+	ec_set_artist_binding_failure();
 	$profile_id = (int) $profile_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
 	if ( $profile_id <= 0 || empty( $blog_ids ) ) {
@@ -327,6 +381,9 @@ function ec_get_artist_term_id( $profile_id ) {
 	if ( $profile['term_id'] > 0 ) {
 		if ( ec_reconcile_artist_profile_term_pair( $profile_id, $profile['term_id'], $blog_ids['main'] ) ) {
 			return $profile['term_id'];
+		}
+		if ( ec_get_artist_binding_failure() ) {
+			return 0;
 		}
 		ec_artist_binding_delete_profile_meta( $profile_id, $profile['term_id'], $blog_ids['artist'] );
 	}
@@ -346,7 +403,10 @@ function ec_get_artist_term_id( $profile_id ) {
 		restore_current_blog();
 	}
 
-	return $term_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ? $term_id : 0;
+	if ( $term_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ) {
+		return $term_id;
+	}
+	return 0;
 }
 
 /**
@@ -356,6 +416,7 @@ function ec_get_artist_term_id( $profile_id ) {
  * @return int Artist profile post ID, or 0.
  */
 function ec_get_artist_profile_id( $term_id ) {
+	ec_set_artist_binding_failure();
 	$term_id  = (int) $term_id;
 	$blog_ids = ec_artist_binding_blog_ids();
 	if ( $term_id <= 0 || empty( $blog_ids ) ) {
@@ -370,6 +431,9 @@ function ec_get_artist_profile_id( $term_id ) {
 	if ( $term['profile_id'] > 0 ) {
 		if ( ec_reconcile_artist_profile_term_pair( $term['profile_id'], $term_id, $blog_ids['main'] ) ) {
 			return $term['profile_id'];
+		}
+		if ( ec_get_artist_binding_failure() ) {
+			return 0;
 		}
 		ec_artist_binding_delete_term_meta( $term_id, $term['profile_id'], $blog_ids['main'] );
 	}
@@ -398,7 +462,10 @@ function ec_get_artist_profile_id( $term_id ) {
 		restore_current_blog();
 	}
 
-	return $profile_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ? $profile_id : 0;
+	if ( $profile_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ) {
+		return $profile_id;
+	}
+	return 0;
 }
 
 /**
@@ -419,6 +486,10 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 		return new WP_Error( 'invalid_artist_profile', __( 'The artist profile is unavailable.', 'extrachill-artist-platform' ) );
 	}
 	$existing_term_id = ec_get_artist_term_id( $profile_id );
+	$binding_failure  = ec_get_artist_binding_failure();
+	if ( $binding_failure ) {
+		return $binding_failure;
+	}
 	if ( $existing_term_id > 0 ) {
 		return $existing_term_id;
 	}
@@ -451,18 +522,26 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 	if ( ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $blog_ids['main'] ) ) {
 		return $new_term_id;
 	}
+	$binding_failure = ec_get_artist_binding_failure();
+	if ( $binding_failure ) {
+		return $binding_failure;
+	}
 
 	if ( $term_created ) {
 		$deleted = false;
 		$recoverable = false;
+		$delete_state_mismatch = false;
 		switch_to_blog( $blog_ids['main'] );
 		try {
 			$created_term = get_term( $new_term_id, 'artist' );
 			$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
 			if ( $created_term && ! is_wp_error( $created_term ) && 0 === (int) ( $created_term->count ?? 0 ) && 0 === $bound_profile_id ) {
 				$delete_result = wp_delete_term( $new_term_id, 'artist' );
-				$deleted       = ! is_wp_error( $delete_result ) && (bool) $delete_result;
-				if ( ! $deleted ) {
+				$delete_reported = ! is_wp_error( $delete_result ) && (bool) $delete_result;
+				$deleted_term    = get_term( $new_term_id, 'artist' );
+				$deleted         = $delete_reported && ( ! $deleted_term || is_wp_error( $deleted_term ) );
+				$delete_state_mismatch = $delete_reported && ! $deleted;
+				if ( ! $deleted && ! $delete_state_mismatch ) {
 					$created_term = get_term( $new_term_id, 'artist' );
 					$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
 					if ( $created_term && ! is_wp_error( $created_term ) && 0 === (int) ( $created_term->count ?? 0 ) && 0 === $bound_profile_id ) {
@@ -474,8 +553,11 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 		} finally {
 			restore_current_blog();
 		}
+		if ( $delete_state_mismatch ) {
+			return new WP_Error( 'artist_term_binding_rollback_failed', __( 'Canonical term deletion reported success without removing the term. Manual reconciliation is required.', 'extrachill-artist-platform' ), array( 'term_id' => $new_term_id, 'retryable' => false ) );
+		}
 		if ( ! $deleted && ! $recoverable ) {
-			return new WP_Error( 'artist_term_binding_rollback_failed', __( 'Canonical artist binding failed and its new empty term could not be removed.', 'extrachill-artist-platform' ), array( 'term_id' => $new_term_id ) );
+			return new WP_Error( 'artist_term_binding_rollback_failed', __( 'Canonical artist binding failed and its new empty term could not be removed.', 'extrachill-artist-platform' ), array( 'term_id' => $new_term_id, 'retryable' => false ) );
 		}
 	}
 

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -61,7 +61,7 @@ function ec_artist_binding_read_profile( $profile_id, $artist_blog_id ) {
  *
  * @param int $term_id      Artist term ID.
  * @param int $main_blog_id Main blog ID.
- * @return array{id:int,profile_id:int,slug:string}|array{}
+ * @return array{id:int,profile_id:int,slug:string,count:int}|array{}
  */
 function ec_artist_binding_read_term( $term_id, $main_blog_id ) {
 	$artist_term = array();
@@ -73,6 +73,7 @@ function ec_artist_binding_read_term( $term_id, $main_blog_id ) {
 				'id'         => (int) $term->term_id,
 				'profile_id' => (int) get_term_meta( $term_id, '_artist_profile_id', true ),
 				'slug'       => (string) $term->slug,
+				'count'      => (int) ( $term->count ?? 0 ),
 			);
 		}
 	} finally {
@@ -196,12 +197,39 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 		ec_artist_binding_delete_term_meta( $term_id, $term['profile_id'], $main_blog_id );
 	}
 
+	$old_reciprocal_term_id = 0;
 	if ( $profile['term_id'] > 0 && $profile['term_id'] !== $term_id ) {
 		$old_term = ec_artist_binding_read_term( $profile['term_id'], $main_blog_id );
 		if ( ! empty( $old_term ) && $old_term['profile_id'] === $profile_id ) {
+			$old_reciprocal_term_id = (int) $profile['term_id'];
 			ec_artist_binding_delete_term_meta( $profile['term_id'], $profile_id, $main_blog_id );
+			$old_term = ec_artist_binding_read_term( $profile['term_id'], $main_blog_id );
+			if ( ! empty( $old_term ) && $old_term['profile_id'] === $profile_id ) {
+				return false;
+			}
 		}
 	}
+	$profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
+	$term    = ec_artist_binding_read_term( $term_id, $main_blog_id );
+	if ( empty( $profile ) || empty( $term ) ) {
+		if ( $old_reciprocal_term_id > 0 ) {
+			for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+				switch_to_blog( $main_blog_id );
+				try {
+					update_term_meta( $old_reciprocal_term_id, '_artist_profile_id', $profile_id );
+				} finally {
+					restore_current_blog();
+				}
+				$old_term = ec_artist_binding_read_term( $old_reciprocal_term_id, $main_blog_id );
+				if ( ! empty( $old_term ) && $old_term['profile_id'] === $profile_id ) {
+					break;
+				}
+			}
+		}
+		return false;
+	}
+	$previous_term_id    = (int) $profile['term_id'];
+	$previous_profile_id = (int) $term['profile_id'];
 
 	switch_to_blog( $artist_blog_id );
 	try {
@@ -217,7 +245,65 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 		restore_current_blog();
 	}
 
-	return true;
+	$bound_profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
+	$bound_term    = ec_artist_binding_read_term( $term_id, $main_blog_id );
+	if ( ! empty( $bound_profile ) && ! empty( $bound_term ) && $bound_profile['term_id'] === $term_id && $bound_term['profile_id'] === $profile_id ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			delete_term_meta( $term_id, '_ec_artist_binding_recoverable' );
+		} finally {
+			restore_current_blog();
+		}
+		return true;
+	}
+
+	if ( ! empty( $bound_profile ) && $bound_profile['term_id'] === $term_id ) {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			switch_to_blog( $artist_blog_id );
+			try {
+				if ( $previous_term_id > 0 ) {
+					update_post_meta( $profile_id, '_artist_term_id', $previous_term_id );
+				} else {
+					delete_post_meta( $profile_id, '_artist_term_id', $term_id );
+				}
+			} finally {
+				restore_current_blog();
+			}
+			$rolled_profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
+			if ( ! empty( $rolled_profile ) && $rolled_profile['term_id'] === $previous_term_id ) {
+				break;
+			}
+		}
+	}
+	if ( ! empty( $bound_term ) && $bound_term['profile_id'] === $profile_id ) {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			switch_to_blog( $main_blog_id );
+			try {
+				if ( $previous_profile_id > 0 ) {
+					update_term_meta( $term_id, '_artist_profile_id', $previous_profile_id );
+				} else {
+					delete_term_meta( $term_id, '_artist_profile_id', $profile_id );
+				}
+			} finally {
+				restore_current_blog();
+			}
+			$rolled_term = ec_artist_binding_read_term( $term_id, $main_blog_id );
+			if ( ! empty( $rolled_term ) && $rolled_term['profile_id'] === $previous_profile_id ) {
+				break;
+			}
+		}
+	}
+	$rolled_profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
+	if ( $old_reciprocal_term_id > 0 && ! empty( $rolled_profile ) && $rolled_profile['term_id'] === $old_reciprocal_term_id ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			update_term_meta( $old_reciprocal_term_id, '_artist_profile_id', $profile_id );
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	return false;
 }
 
 /**
@@ -319,25 +405,30 @@ function ec_get_artist_profile_id( $term_id ) {
  * Ensure an artist profile is bound to a matching main-blog artist term.
  *
  * @param int $profile_id Artist profile post ID.
- * @return void
+ * @return int|WP_Error Bound artist term ID, or an actionable failure.
  */
 function ec_sync_artist_profile_term_binding( $profile_id ) {
 	$profile_id = (int) $profile_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
 	if ( $profile_id <= 0 || empty( $blog_ids ) ) {
-		return;
+		return new WP_Error( 'artist_identity_unavailable', __( 'Artist identity binding is unavailable.', 'extrachill-artist-platform' ) );
 	}
 
 	$profile = ec_artist_binding_read_profile( $profile_id, $blog_ids['artist'] );
-	if ( empty( $profile ) || ec_get_artist_term_id( $profile_id ) > 0 ) {
-		return;
+	if ( empty( $profile ) ) {
+		return new WP_Error( 'invalid_artist_profile', __( 'The artist profile is unavailable.', 'extrachill-artist-platform' ) );
+	}
+	$existing_term_id = ec_get_artist_term_id( $profile_id );
+	if ( $existing_term_id > 0 ) {
+		return $existing_term_id;
 	}
 
 	if ( '' === $profile['title'] || '' === $profile['slug'] ) {
-		return;
+		return new WP_Error( 'invalid_artist_identity', __( 'The artist profile needs a title and slug before binding.', 'extrachill-artist-platform' ) );
 	}
 
 	$new_term_id = 0;
+	$term_created = false;
 	switch_to_blog( $blog_ids['main'] );
 	try {
 		$existing = get_term_by( 'slug', $profile['slug'], 'artist' );
@@ -346,16 +437,49 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 		} else {
 			$inserted = wp_insert_term( $profile['title'], 'artist', array( 'slug' => $profile['slug'] ) );
 			if ( ! is_wp_error( $inserted ) && ! empty( $inserted['term_id'] ) ) {
-				$new_term_id = (int) $inserted['term_id'];
+				$new_term_id  = (int) $inserted['term_id'];
+				$term_created = true;
 			}
 		}
 	} finally {
 		restore_current_blog();
 	}
 
-	if ( $new_term_id > 0 ) {
-		ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $blog_ids['main'] );
+	if ( $new_term_id <= 0 ) {
+		return new WP_Error( 'artist_term_creation_failed', __( 'The canonical artist term could not be created.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
 	}
+	if ( ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $blog_ids['main'] ) ) {
+		return $new_term_id;
+	}
+
+	if ( $term_created ) {
+		$deleted = false;
+		$recoverable = false;
+		switch_to_blog( $blog_ids['main'] );
+		try {
+			$created_term = get_term( $new_term_id, 'artist' );
+			$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
+			if ( $created_term && ! is_wp_error( $created_term ) && 0 === (int) ( $created_term->count ?? 0 ) && 0 === $bound_profile_id ) {
+				$delete_result = wp_delete_term( $new_term_id, 'artist' );
+				$deleted       = ! is_wp_error( $delete_result ) && (bool) $delete_result;
+				if ( ! $deleted ) {
+					$created_term = get_term( $new_term_id, 'artist' );
+					$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
+					if ( $created_term && ! is_wp_error( $created_term ) && 0 === (int) ( $created_term->count ?? 0 ) && 0 === $bound_profile_id ) {
+						update_term_meta( $new_term_id, '_ec_artist_binding_recoverable', $profile['slug'] );
+						$recoverable = $profile['slug'] === (string) get_term_meta( $new_term_id, '_ec_artist_binding_recoverable', true );
+					}
+				}
+			}
+		} finally {
+			restore_current_blog();
+		}
+		if ( ! $deleted && ! $recoverable ) {
+			return new WP_Error( 'artist_term_binding_rollback_failed', __( 'Canonical artist binding failed and its new empty term could not be removed.', 'extrachill-artist-platform' ), array( 'term_id' => $new_term_id ) );
+		}
+	}
+
+	return new WP_Error( 'artist_term_binding_failed', __( 'The artist profile could not be bound to its canonical artist term.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
 }
 add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 1 );
 

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -50,6 +50,53 @@ function ec_get_reciprocal_link_page_id( $artist_id, $repair = true ) {
 }
 
 /**
+ * Roll back a link page created by the current operation.
+ *
+ * The page is deleted only after both metadata directions match the captured
+ * pre-operation state. Unsafe partial state is left intact for reconciliation.
+ *
+ * @param int $artist_id            Artist profile ID.
+ * @param int $new_link_page_id     Newly created link page ID.
+ * @param int $previous_link_page_id Previously reciprocal link page ID, or 0.
+ * @return true|WP_Error True when rollback completed, otherwise a manual repair error.
+ */
+function ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id = 0 ) {
+	delete_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+	if ( $previous_link_page_id ) {
+		update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
+	}
+	delete_post_meta( $new_link_page_id, '_associated_artist_profile_id', $artist_id );
+
+	$profile_link_id      = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+	$new_associated_id    = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
+	$previous_associated_id = $previous_link_page_id ? (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) : 0;
+	$metadata_restored    = $profile_link_id === (int) $previous_link_page_id
+		&& $new_associated_id !== (int) $artist_id
+		&& ( ! $previous_link_page_id || $previous_associated_id === (int) $artist_id );
+	if ( ! $metadata_restored ) {
+		return new WP_Error(
+			'link_page_association_compensation_failed',
+			'Link page association compensation failed. Manual reconciliation is required.',
+			array(
+				'artist_id'            => (int) $artist_id,
+				'link_page_id'         => (int) $new_link_page_id,
+				'previous_link_page_id' => (int) $previous_link_page_id,
+				'retryable'            => false,
+			)
+		);
+	}
+	if ( ! wp_delete_post( $new_link_page_id, true ) ) {
+		return new WP_Error(
+			'link_page_association_compensation_failed',
+			'Link page metadata was restored, but the new page could not be removed. Manual reconciliation is required.',
+			array( 'link_page_id' => (int) $new_link_page_id, 'retryable' => false )
+		);
+	}
+
+	return true;
+}
+
+/**
  * Create a link page for an artist profile (centralized creation logic)
  * 
  * @param int  $artist_id The artist profile ID to create a link page for
@@ -109,18 +156,9 @@ function ec_create_link_page( $artist_id, $force = false ) {
 	$profile_link_id      = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
 	$associated_artist_id = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
 	if ( (int) $new_link_page_id !== $profile_link_id || $artist_id !== $associated_artist_id ) {
-		delete_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
-		$previous_restored = true;
-		if ( $force && $previous_link_page_id ) {
-			update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
-			$previous_restored = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true ) === $previous_link_page_id;
-		}
-		if ( ! wp_delete_post( $new_link_page_id, true ) || ! $previous_restored ) {
-			return new WP_Error(
-				'link_page_association_rollback_failed',
-				'Link page association and rollback both failed. Manual reconciliation is required.',
-				array( 'link_page_id' => (int) $new_link_page_id )
-			);
+		$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $force ? $previous_link_page_id : 0 );
+		if ( is_wp_error( $rollback ) ) {
+			return $rollback;
 		}
 		return new WP_Error(
 			'link_page_association_failed',
@@ -131,15 +169,9 @@ function ec_create_link_page( $artist_id, $force = false ) {
 	if ( $force && $previous_link_page_id && $previous_link_page_id !== (int) $new_link_page_id ) {
 		delete_post_meta( $previous_link_page_id, '_associated_artist_profile_id', $artist_id );
 		if ( $artist_id === (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) ) {
-			delete_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
-			update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
-			$previous_restored = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true ) === $previous_link_page_id;
-			if ( ! wp_delete_post( $new_link_page_id, true ) || ! $previous_restored ) {
-				return new WP_Error(
-					'link_page_association_rollback_failed',
-					'Link page replacement cleanup and rollback both failed. Manual reconciliation is required.',
-					array( 'link_page_id' => (int) $new_link_page_id )
-				);
+			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+			if ( is_wp_error( $rollback ) ) {
+				return $rollback;
 			}
 			return new WP_Error(
 				'link_page_previous_detach_failed',
@@ -170,7 +202,12 @@ function ec_create_link_page( $artist_id, $force = false ) {
 }
 
 /**
- * Set up default data for a newly created link page
+ * Snapshot optional default styles for a newly created link page.
+ *
+ * This write is an optimization, not a provisioning invariant. The canonical
+ * read path merges ec_get_link_page_defaults_for( 'styles' ) whenever stored
+ * custom styles are absent, so a published page remains complete and valid if
+ * this best-effort snapshot cannot be persisted.
  *
  * @param int $link_page_id The link page ID
  * @param int $artist_id    The associated artist profile ID

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -9,6 +9,47 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Resolve and optionally repair the reciprocal artist/link-page association.
+ *
+ * @param int  $artist_id Artist profile ID.
+ * @param bool $repair    Whether a valid inverse-only association may be repaired.
+ * @return int|WP_Error Reciprocal link page ID, 0, or a repair failure.
+ */
+function ec_get_reciprocal_link_page_id( $artist_id, $repair = true ) {
+	$artist_id = absint( $artist_id );
+	if ( ! $artist_id || 'artist_profile' !== get_post_type( $artist_id ) ) {
+		return 0;
+	}
+
+	$profile_link_id = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+	if ( $profile_link_id ) {
+		$associated_artist_id = (int) get_post_meta( $profile_link_id, '_associated_artist_profile_id', true );
+		if ( 'artist_link_page' === get_post_type( $profile_link_id ) && $artist_id === $associated_artist_id ) {
+			return $profile_link_id;
+		}
+		delete_post_meta( $artist_id, '_extrch_link_page_id', $profile_link_id );
+	}
+
+	$link_page_id = function_exists( 'ec_get_link_page_id' ) ? (int) ec_get_link_page_id( $artist_id ) : 0;
+	if ( ! $link_page_id || 'artist_link_page' !== get_post_type( $link_page_id ) || $artist_id !== (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) ) {
+		return 0;
+	}
+	if ( ! $repair ) {
+		return 0;
+	}
+
+	update_post_meta( $artist_id, '_extrch_link_page_id', $link_page_id );
+	if ( (int) get_post_meta( $artist_id, '_extrch_link_page_id', true ) !== $link_page_id ) {
+		return new WP_Error(
+			'link_page_association_repair_failed',
+			'An existing link page could not be associated with its artist profile.',
+			array( 'link_page_id' => $link_page_id, 'retryable' => true )
+		);
+	}
+	return $link_page_id;
+}
+
+/**
  * Create a link page for an artist profile (centralized creation logic)
  * 
  * @param int  $artist_id The artist profile ID to create a link page for
@@ -16,63 +57,99 @@ defined( 'ABSPATH' ) || exit;
  * @return int|WP_Error   Link page ID on success, WP_Error on failure
  */
 function ec_create_link_page( $artist_id, $force = false ) {
-    // Validate artist profile
-    if ( ! $artist_id || get_post_type( $artist_id ) !== 'artist_profile' ) {
-        return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for link page creation' );
-    }
+	if ( ! $artist_id || 'artist_profile' !== get_post_type( $artist_id ) ) {
+		return new WP_Error( 'invalid_artist_profile', 'Invalid artist profile ID for link page creation' );
+	}
 
-    // Check if link page already exists (unless forced)
-    $existing_link_page_id = apply_filters( 'ec_get_link_page_id', 0, $artist_id );
-    if ( $existing_link_page_id && ! $force ) {
-        // Link page already exists - return existing ID
-        if ( get_post_type( $existing_link_page_id ) === 'artist_link_page' ) {
-            return $existing_link_page_id;
-        }
-    }
+	$existing_link_page_id = ec_get_reciprocal_link_page_id( $artist_id );
+	if ( is_wp_error( $existing_link_page_id ) ) {
+		return $existing_link_page_id;
+	}
+	$previous_link_page_id = (int) $existing_link_page_id;
+	if ( $existing_link_page_id && ! $force ) {
+		$associated_artist_id = (int) get_post_meta( $existing_link_page_id, '_associated_artist_profile_id', true );
+		if ( 'artist_link_page' === get_post_type( $existing_link_page_id ) && $artist_id === $associated_artist_id ) {
+			return $existing_link_page_id;
+		}
+		delete_post_meta( $artist_id, '_extrch_link_page_id', $existing_link_page_id );
+	}
 
-    // Get latest artist profile data
-    $artist_post = get_post( $artist_id );
-    if ( ! $artist_post ) {
-        return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
-    }
+	$artist_post = get_post( $artist_id );
+	if ( ! $artist_post ) {
+		return new WP_Error( 'artist_not_found', 'Artist profile post not found' );
+	}
 
-    // Prepare link page data
-    $link_page_title = $artist_post->post_title;
-    $artist_profile_slug = $artist_post->post_name;
+	$link_page_title    = $artist_post->post_title;
+	$artist_profile_slug = $artist_post->post_name;
+	if ( empty( $link_page_title ) || empty( $artist_profile_slug ) ) {
+		return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug for link page creation' );
+	}
 
-    // Ensure title and slug are not empty
-    if ( empty( $link_page_title ) || empty( $artist_profile_slug ) ) {
-        return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug for link page creation' );
-    }
+	$new_link_page_id = wp_insert_post(
+		array(
+			'post_type'   => 'artist_link_page',
+			'post_title'  => $link_page_title,
+			'post_name'   => $artist_profile_slug,
+			'post_status' => 'publish',
+			'meta_input'  => array(
+				'_associated_artist_profile_id' => $artist_id,
+			),
+		),
+		true
+	);
 
-    // Create link page
-    $link_page_args = array(
-        'post_type'   => 'artist_link_page',
-        'post_title'  => $link_page_title,
-        'post_name'   => $artist_profile_slug,
-        'post_status' => 'publish',
-        'meta_input'  => array(
-            '_associated_artist_profile_id' => $artist_id,
-        ),
-    );
+	if ( is_wp_error( $new_link_page_id ) ) {
+		return $new_link_page_id;
+	}
+	if ( ! $new_link_page_id ) {
+		return new WP_Error( 'creation_failed', 'Failed to create link page' );
+	}
 
+	update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+	$profile_link_id      = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+	$associated_artist_id = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
+	if ( (int) $new_link_page_id !== $profile_link_id || $artist_id !== $associated_artist_id ) {
+		delete_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+		$previous_restored = true;
+		if ( $force && $previous_link_page_id ) {
+			update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
+			$previous_restored = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true ) === $previous_link_page_id;
+		}
+		if ( ! wp_delete_post( $new_link_page_id, true ) || ! $previous_restored ) {
+			return new WP_Error(
+				'link_page_association_rollback_failed',
+				'Link page association and rollback both failed. Manual reconciliation is required.',
+				array( 'link_page_id' => (int) $new_link_page_id )
+			);
+		}
+		return new WP_Error(
+			'link_page_association_failed',
+			'Link page association could not be persisted. No link page was created.',
+			array( 'retryable' => true )
+		);
+	}
+	if ( $force && $previous_link_page_id && $previous_link_page_id !== (int) $new_link_page_id ) {
+		delete_post_meta( $previous_link_page_id, '_associated_artist_profile_id', $artist_id );
+		if ( $artist_id === (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) ) {
+			delete_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+			update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
+			$previous_restored = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true ) === $previous_link_page_id;
+			if ( ! wp_delete_post( $new_link_page_id, true ) || ! $previous_restored ) {
+				return new WP_Error(
+					'link_page_association_rollback_failed',
+					'Link page replacement cleanup and rollback both failed. Manual reconciliation is required.',
+					array( 'link_page_id' => (int) $new_link_page_id )
+				);
+			}
+			return new WP_Error(
+				'link_page_previous_detach_failed',
+				'The previous link page could not be detached. The original association was restored.',
+				array( 'retryable' => true )
+			);
+		}
+	}
 
-    // Create the link page
-    $new_link_page_id = wp_insert_post( $link_page_args );
-
-    if ( is_wp_error( $new_link_page_id ) ) {
-        return $new_link_page_id;
-    }
-
-    if ( ! $new_link_page_id ) {
-        return new WP_Error( 'creation_failed', 'Failed to create link page' );
-    }
-
-    // Update artist profile with link page ID
-    update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
-
-    // Apply default settings
-    ec_setup_default_link_page_data( $new_link_page_id, $artist_id );
+	ec_setup_default_link_page_data( $new_link_page_id, $artist_id );
 
     /**
      * Fires after a link page has been created successfully.
@@ -89,7 +166,7 @@ function ec_create_link_page( $artist_id, $force = false ) {
      */
     do_action( 'ec_link_page_created', $new_link_page_id, $artist_id, $force );
 
-    return $new_link_page_id;
+	return $new_link_page_id;
 }
 
 /**

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -90,6 +90,7 @@ final class AbilityAuthorizationTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'artist_creation_rollback_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
 		$this->assertArrayHasKey( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
 	}
 

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -119,6 +119,30 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
 
+	public function test_failed_rebinding_restores_the_previous_reciprocal_pair(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'old-name', 12 );
+		$this->addTerm( 102, 'new-name' );
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertSame( 101, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+		$this->assertArrayNotHasKey( 102, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
+	public function test_rebinding_stops_when_old_inverse_cannot_be_removed(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'old-name', 12 );
+		$this->addTerm( 102, 'new-name' );
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 1;
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertSame( 101, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+		$this->assertArrayNotHasKey( 102, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
 	public function test_deleting_a_colliding_main_blog_post_does_not_unbind_the_profile(): void {
 		$this->addProfile( 12, 'the-band', 101 );
 		$this->addTerm( 101, 'the-band', 12 );

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -70,7 +70,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addProfile( 12, 'the-band', 999 );
 
 		$this->assertSame( 0, ec_get_artist_term_id( 12 ) );
-		$this->assertArrayNotHasKey( '_artist_term_id', $GLOBALS['ec_test']['blogs'][4]['post_meta'][12] );
+		$this->assertArrayNotHasKey( '_artist_term_id', $GLOBALS['ec_test']['blogs'][4]['post_meta'][12] ?? array() );
 
 		$this->addTerm( 101, 'missing-profile', 999 );
 		$this->assertSame( 0, ec_get_artist_profile_id( 101 ) );
@@ -141,6 +141,60 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertSame( 101, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
 		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 		$this->assertArrayNotHasKey( 102, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
+	public function test_profile_side_compensation_exhaustion_is_reported_for_manual_repair(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 102, 'the-band' );
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys']['_artist_term_id'] = 5;
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertSame( 'artist_binding_compensation_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertFalse( ec_get_artist_binding_failure()->get_error_data()['retryable'] );
+		$this->assertSame( 102, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertArrayNotHasKey( 102, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
+	public function test_term_side_compensation_exhaustion_is_reported_for_manual_repair(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 102, 'the-band' );
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_artist_term_id'] = 1;
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 5;
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertSame( 'artist_binding_compensation_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertFalse( ec_get_artist_binding_failure()->get_error_data()['retryable'] );
+		$this->assertArrayNotHasKey( '_artist_term_id', $GLOBALS['ec_test']['blogs'][4]['post_meta'][12] ?? array() );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
+	}
+
+	public function test_existing_pair_compensation_exhaustion_is_reported_for_manual_repair(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'old-name', 12 );
+		$this->addTerm( 102, 'new-name' );
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_post_meta_update_on_calls'] = array( 2, 3, 4 );
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertSame( 'artist_binding_compensation_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertFalse( ec_get_artist_binding_failure()->get_error_data()['retryable'] );
+		$this->assertSame( 102, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+	}
+
+	public function test_sync_propagates_resolver_compensation_failure_without_cleanup(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 102, 'the-band' );
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_artist_term_id'] = 1;
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 5;
+
+		$result = ec_sync_artist_profile_term_binding( 12 );
+
+		$this->assertSame( 'artist_binding_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertArrayNotHasKey( '_artist_term_id', $GLOBALS['ec_test']['blogs'][4]['post_meta'][12] ?? array() );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
 	}
 
 	public function test_deleting_a_colliding_main_blog_post_does_not_unbind_the_profile(): void {

--- a/tests/ExternalArtistOnboardingTest.php
+++ b/tests/ExternalArtistOnboardingTest.php
@@ -1,0 +1,391 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ExternalArtistOnboardingTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'blogs'           => array(
+				1 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+				4 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+			),
+			'users'           => array(),
+			'user_meta'       => array(),
+			'email_users'     => array(),
+		);
+
+		wp_register_ability(
+			'extrachill/create-user',
+			array(
+				'execute_callback'    => function ( $input ) {
+					$email = strtolower( $input['email'] );
+					if ( email_exists( $email ) ) {
+						return new WP_Error( 'existing_user_email', 'Email already exists.' );
+					}
+					$user_id = count( $GLOBALS['ec_test']['users'] ) + 1;
+					$GLOBALS['ec_test']['users'][ $user_id ] = (object) array(
+						'ID'           => $user_id,
+						'user_login'   => $input['username'],
+						'user_email'   => $email,
+						'display_name' => $input['username'],
+					);
+					$GLOBALS['ec_test']['email_users'][ $email ] = $user_id;
+					if ( ! empty( $input['unclaimed'] ) ) {
+						update_user_meta( $user_id, 'ec_unclaimed', 1 );
+					}
+					return $user_id;
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array(),
+			)
+		);
+		extrachill_artist_platform_register_abilities();
+		wp_register_ability(
+			'extrachill/get-artist-data',
+			array(
+				'execute_callback'    => function ( $input ) {
+					return array( 'id' => (int) $input['artist_id'], 'name' => get_the_title( $input['artist_id'] ) );
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array(),
+			)
+		);
+	}
+
+	private function input( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'submitter_email' => 'artist@example.com',
+				'artist_name'     => 'Test Artist',
+				'source_type'     => 'external_form',
+				'source_id'       => 'lead-123',
+				'return_url'      => 'https://caller.example/complete',
+			),
+			$overrides
+		);
+	}
+
+	private function addUser( $user_id, $email, $unclaimed = false ): void {
+		$GLOBALS['ec_test']['users'][ $user_id ] = (object) array(
+			'ID'           => $user_id,
+			'user_login'   => 'user-' . $user_id,
+			'user_email'   => $email,
+			'display_name' => 'User ' . $user_id,
+		);
+		$GLOBALS['ec_test']['email_users'][ strtolower( $email ) ] = $user_id;
+		if ( $unclaimed ) {
+			$GLOBALS['ec_test']['user_meta'][ $user_id ]['ec_unclaimed'] = 1;
+		}
+	}
+
+	private function addProfile( $profile_id, $name = 'Test Artist' ): void {
+		$GLOBALS['ec_test']['blogs'][4]['posts'][ $profile_id ] = (object) array(
+			'ID'          => $profile_id,
+			'post_type'   => 'artist_profile',
+			'post_status' => 'publish',
+			'post_title'  => $name,
+			'post_name'   => sanitize_title( $name ),
+			'post_author' => 99,
+		);
+	}
+
+	private function addTerm( $term_id, $name = 'Test Artist' ): void {
+		$GLOBALS['ec_test']['blogs'][1]['terms'][ $term_id ] = (object) array(
+			'term_id'  => $term_id,
+			'taxonomy' => 'artist',
+			'slug'     => sanitize_title( $name ),
+		);
+	}
+
+	public function test_new_submitter_gets_one_unclaimed_account_and_claim_email_across_retries(): void {
+		$first  = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$second = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'account_claim_required', $first['outcome'] );
+		$this->assertTrue( $first['user']['created'] );
+		$this->assertSame( 'sent', $first['claim']['delivery'] );
+		$this->assertSame( 'eligible_after_claim_and_consent', $first['artist']['state'] );
+		$this->assertSame( 'account_claim_required', $second['outcome'] );
+		$this->assertFalse( $second['user']['created'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['users'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['claim_deliveries'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_existing_claimed_user_must_authenticate_then_consent(): void {
+		$this->addUser( 7, 'artist@example.com' );
+
+		$anonymous = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'authentication_required', $anonymous['outcome'] );
+
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$authenticated = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'artist_consent_required', $authenticated['outcome'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_authenticated_consent_creates_artist_membership_binding_and_link_page_once(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$input = $this->input(
+			array(
+				'consent' => array(
+					'profile_creation'  => true,
+					'link_page'          => true,
+					'disclosure_version' => 'artist-offer-v1',
+				),
+			)
+		);
+
+		$first = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'artist_created', $first['outcome'] );
+		$this->assertSame( 'managed', $first['membership']['state'] );
+		$this->assertSame( 'created', $first['link_page']['state'] );
+		$this->assertNotNull( $first['artist']['term_id'] );
+		$sources = get_post_meta( $first['artist']['profile_id'], '_ec_external_onboarding_sources', true );
+		$this->assertSame( 'external_form', reset( $sources )['type'] );
+		$this->assertSame( 'lead-123', reset( $sources )['id'] );
+		$this->assertSame( array( 'artist-offer-v1' ), reset( $sources )['disclosure_versions'] );
+
+		$profile_id = $first['artist']['profile_id'];
+		$GLOBALS['ec_test']['managed_artists'][7] = array( $profile_id );
+		$second = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'managed_artist', $second['outcome'] );
+		$this->assertSame( 'existing', $second['link_page']['state'] );
+		$this->assertSame( $first['link_page']['id'], $second['link_page']['id'] );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+
+		$without_consent = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'managed_artist', $without_consent['outcome'] );
+		$sources = get_post_meta( $profile_id, '_ec_external_onboarding_sources', true );
+		$this->assertTrue( reset( $sources )['profile_creation'] );
+		$this->assertTrue( reset( $sources )['link_page'] );
+		$this->assertSame( array( 'artist-offer-v1' ), reset( $sources )['disclosure_versions'] );
+	}
+
+	public function test_existing_managed_artist_reuses_link_page(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['current_user_id']     = 7;
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 20 );
+		$GLOBALS['ec_test']['blogs'][4]['posts'][30] = (object) array(
+			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'managed_artist', $result['outcome'] );
+		$this->assertSame( array( 'state' => 'existing', 'id' => 30 ), $result['link_page'] );
+	}
+
+	public function test_existing_unowned_artist_requires_membership_request_without_grant_or_invite(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'consent' => array( 'profile_creation' => true, 'link_page' => true, 'disclosure_version' => 'artist-offer-v1' ) ) )
+		);
+
+		$this->assertSame( 'membership_request_required', $result['outcome'] );
+		$this->assertSame( 'request_required', $result['membership']['state'] );
+		$this->assertEmpty( get_post_meta( 20, '_pending_invitations', true ) );
+		$this->assertEmpty( get_user_meta( 7, '_artist_profile_ids', true ) );
+	}
+
+	public function test_existing_unclaimed_account_cannot_create_or_join_artist(): void {
+		$this->addUser( 7, 'artist@example.com', true );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'consent' => array( 'profile_creation' => true, 'link_page' => true, 'disclosure_version' => 'artist-offer-v1' ) ) )
+		);
+
+		$this->assertSame( 'account_claim_required', $result['outcome'] );
+		$this->assertSame( 'claim_account', $result['next_action'] );
+		$this->assertEmpty( get_user_meta( 7, '_artist_profile_ids', true ) );
+	}
+
+	public function test_duplicate_canonical_artist_name_never_creates_profile(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addTerm( 50 );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ) ) )
+		);
+
+		$this->assertSame( 'membership_request_required', $result['outcome'] );
+		$this->assertSame( 50, $result['artist']['term_id'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_conflicting_user_and_artist_identities_fail_closed(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20, 'One Artist' );
+		$this->addProfile( 21, 'Two Artist' );
+		$this->addTerm( 50, 'One Artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_artist_term_id'] = 50;
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][50]['_artist_profile_id'] = 20;
+
+		$user_conflict = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'submitter_user_id' => 7, 'submitter_email' => 'other@example.com' ) )
+		);
+		$this->assertSame( 'conflicting_submitter_identity', $user_conflict->get_error_code() );
+
+		$artist_conflict = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'artist_profile_id' => 21, 'artist_term_id' => 50 ) )
+		);
+		$this->assertSame( 'conflicting_artist_identity', $artist_conflict->get_error_code() );
+	}
+
+	public function test_ability_is_internal_and_declared_idempotent(): void {
+		$meta = wp_get_ability( 'extrachill/onboard-external-artist' )->get_meta();
+
+		$this->assertFalse( $meta['show_in_rest'] );
+		$this->assertTrue( $meta['annotations']['idempotent'] );
+	}
+
+	public function test_anonymous_existing_owner_cannot_provision_link_page(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 20 );
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input(
+				array(
+					'consent' => array( 'link_page' => true, 'disclosure_version' => 'artist-offer-v1' ),
+				)
+			)
+		);
+
+		$this->assertSame( 'authentication_required', $result['outcome'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+	}
+
+	public function test_invalid_artist_identity_does_not_create_account(): void {
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'artist_profile_id' => 999 ) )
+		);
+
+		$this->assertSame( 'invalid_artist_identity', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['users'] );
+		$this->assertArrayNotHasKey( 'claim_deliveries', $GLOBALS['ec_test'] );
+	}
+
+	public function test_failed_claim_delivery_is_retried_until_sent(): void {
+		$GLOBALS['ec_test']['fail_claim_delivery'] = true;
+		$first = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'failed', $first['claim']['delivery'] );
+
+		$GLOBALS['ec_test']['fail_claim_delivery'] = false;
+		$second = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$third  = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'sent', $second['claim']['delivery'] );
+		$this->assertSame( 'previously_sent', $third['claim']['delivery'] );
+		$this->assertCount( 2, $GLOBALS['ec_test']['claim_deliveries'] );
+	}
+
+	public function test_explicit_identity_must_match_submitted_name(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20, 'Different Artist' );
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'artist_profile_id' => 20 ) )
+		);
+
+		$this->assertSame( 'conflicting_artist_identity', $result->get_error_code() );
+	}
+
+	public function test_mutating_consent_requires_disclosure_version(): void {
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'consent' => array( 'profile_creation' => true ) ) )
+		);
+
+		$this->assertSame( 'missing_consent_disclosure', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['users'] );
+	}
+
+	public function test_post_lock_identity_resolution_prevents_concurrent_duplicate_profile(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['after_external_artist_lock'] = function () {
+			$this->addProfile( 20 );
+		};
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input(
+				array(
+					'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+				)
+			)
+		);
+
+		$this->assertSame( 'membership_request_required', $result['outcome'] );
+		$this->assertSame( 20, $result['artist']['profile_id'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_provenance_failure_rolls_back_new_profile_before_link_creation(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id']     = 7;
+		$GLOBALS['ec_test']['fail_post_meta_update'] = true;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input(
+				array(
+					'consent' => array(
+						'profile_creation'  => true,
+						'link_page'          => true,
+						'disclosure_version' => 'artist-offer-v1',
+					),
+				)
+			)
+		);
+
+		$this->assertSame( 'artist_onboarding_source_failed', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_user_meta( 7, '_artist_profile_ids', true ) );
+	}
+
+	public function test_artist_name_requires_a_stable_slug(): void {
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'artist_name' => '!!!' ) )
+		);
+
+		$this->assertSame( 'invalid_artist_name', $result->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['users'] );
+	}
+
+	public function test_stale_claim_delivery_reservation_is_recovered(): void {
+		$this->addUser( 7, 'artist@example.com', true );
+		$GLOBALS['ec_test']['user_meta'][7]['_ec_artist_onboarding_claim_delivery'] = array(
+			'state'      => 'pending',
+			'started_at' => time() - ( 16 * MINUTE_IN_SECONDS ),
+		);
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'sent', $result['claim']['delivery'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['claim_deliveries'] );
+	}
+
+	public function test_indirect_identity_mismatch_fails_closed(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20, 'Different Artist' );
+		$this->addTerm( 50 );
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][50]['_artist_profile_id'] = 20;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist(
+			$this->input( array( 'artist_term_id' => 50 ) )
+		);
+
+		$this->assertSame( 'conflicting_artist_identity', $result->get_error_code() );
+	}
+}

--- a/tests/ExternalArtistOnboardingTest.php
+++ b/tests/ExternalArtistOnboardingTest.php
@@ -99,6 +99,29 @@ final class ExternalArtistOnboardingTest extends TestCase {
 		);
 	}
 
+	private function assertRequiredSchemaShape( array $schema, array $value ): void {
+		foreach ( $schema['required'] ?? array() as $required ) {
+			$this->assertArrayHasKey( $required, $value );
+		}
+		if ( false === ( $schema['additionalProperties'] ?? true ) ) {
+			$this->assertSame( array(), array_diff( array_keys( $value ), array_keys( $schema['properties'] ?? array() ) ) );
+		}
+		foreach ( $schema['properties'] ?? array() as $key => $property_schema ) {
+			if ( ! array_key_exists( $key, $value ) ) {
+				continue;
+			}
+			$types       = (array) ( $property_schema['type'] ?? array() );
+			$actual_type = is_int( $value[ $key ] ) ? 'integer' : ( is_bool( $value[ $key ] ) ? 'boolean' : ( is_array( $value[ $key ] ) ? 'object' : ( is_null( $value[ $key ] ) ? 'null' : gettype( $value[ $key ] ) ) ) );
+			$this->assertContains( $actual_type, $types, $key . ' has the wrong schema type.' );
+			if ( isset( $property_schema['enum'] ) ) {
+				$this->assertContains( $value[ $key ], $property_schema['enum'], $key . ' is outside the schema enum.' );
+			}
+			if ( is_array( $value[ $key ] ) && 'object' === $actual_type ) {
+				$this->assertRequiredSchemaShape( $property_schema, $value[ $key ] );
+			}
+		}
+	}
+
 	public function test_new_submitter_gets_one_unclaimed_account_and_claim_email_across_retries(): void {
 		$first  = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
 		$second = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
@@ -174,6 +197,7 @@ final class ExternalArtistOnboardingTest extends TestCase {
 			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
 		);
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
 
 		$result = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
 
@@ -387,5 +411,203 @@ final class ExternalArtistOnboardingTest extends TestCase {
 		);
 
 		$this->assertSame( 'conflicting_artist_identity', $result->get_error_code() );
+	}
+
+	public function test_link_page_association_failure_rolls_back_and_retry_creates_one_page(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 20 );
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_extrch_link_page_id'] = 1;
+		$input = $this->input(
+			array(
+				'consent' => array( 'link_page' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$failed = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'link_page_association_failed', $failed->get_error_code() );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+
+		$retried = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'managed_artist', $retried['outcome'] );
+		$this->assertSame( 'created', $retried['link_page']['state'] );
+		$link_pages = array_filter(
+			$GLOBALS['ec_test']['blogs'][4]['posts'],
+			static function ( $post ) {
+				return 'artist_link_page' === $post->post_type;
+			}
+		);
+		$this->assertCount( 1, $link_pages );
+		$this->assertSame( 20, (int) get_post_meta( $retried['link_page']['id'], '_associated_artist_profile_id', true ) );
+	}
+
+	public function test_link_page_missing_inverse_association_is_rolled_back(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['fail_meta_input_keys']['_associated_artist_profile_id'] = 1;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_association_failed', $result->get_error_code() );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+	}
+
+	public function test_binding_failure_removes_new_empty_term_and_retry_succeeds(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$input = $this->input(
+			array(
+				'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$failed = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'artist_term_binding_failed', $failed->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][1]['terms'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_user_meta( 7, '_artist_profile_ids', true ) );
+
+		$retried = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'artist_created', $retried['outcome'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][1]['terms'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertNotNull( $retried['artist']['term_id'] );
+	}
+
+	public function test_active_claim_send_is_suppressed_and_expired_send_is_reissued(): void {
+		$this->addUser( 7, 'artist@example.com', true );
+		$GLOBALS['ec_test']['user_meta'][7]['_ec_artist_onboarding_claim_delivery'] = array(
+			'state'   => 'sent',
+			'sent_at' => time(),
+		);
+
+		$active = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'previously_sent', $active['claim']['delivery'] );
+		$this->assertArrayNotHasKey( 'claim_deliveries', $GLOBALS['ec_test'] );
+
+		$GLOBALS['ec_test']['user_meta'][7]['_ec_artist_onboarding_claim_delivery']['sent_at'] = time() - DAY_IN_SECONDS - 1;
+		$expired = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+		$this->assertSame( 'sent', $expired['claim']['delivery'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['claim_deliveries'] );
+	}
+
+	public function test_registered_output_contract_requires_nested_response_shape(): void {
+		$ability = wp_get_ability( 'extrachill/onboard-external-artist' );
+		$schema  = $ability->get_output_schema();
+		$result  = $ability->execute( $this->input() );
+
+		$this->assertSame(
+			array( 'outcome', 'user', 'artist', 'membership', 'claim', 'link_page', 'source', 'return_url', 'next_action' ),
+			$schema['required']
+		);
+		$this->assertRequiredSchemaShape( $schema, $result );
+		$this->assertSame( array( 'id', 'state', 'created' ), $schema['properties']['user']['required'] );
+		$this->assertSame( array( 'name', 'profile_id', 'term_id', 'state' ), $schema['properties']['artist']['required'] );
+	}
+
+	public function test_inverse_only_link_page_association_is_repaired_and_reused(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 20 );
+		$GLOBALS['ec_test']['blogs'][4]['posts'][30] = (object) array(
+			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'managed_artist', $result['outcome'] );
+		$this->assertSame( array( 'state' => 'existing', 'id' => 30 ), $result['link_page'] );
+		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_failed_term_delete_leaves_recoverable_term_for_successful_retry(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_term_delete'] = true;
+		$input = $this->input(
+			array(
+				'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$failed = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'artist_term_binding_failed', $failed->get_error_code() );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][1]['terms'] );
+		$this->assertSame( 'test-artist', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1]['_ec_artist_binding_recoverable'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+
+		$GLOBALS['ec_test']['fail_term_delete'] = false;
+		$retried = extrachill_artist_platform_ability_onboard_external_artist( $input );
+		$this->assertSame( 'artist_created', $retried['outcome'] );
+		$this->assertSame( 1, $retried['artist']['term_id'] );
+		$this->assertArrayNotHasKey( '_ec_artist_binding_recoverable', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][1]['terms'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_legacy_claim_marker_is_reissued_instead_of_suppressed_forever(): void {
+		$this->addUser( 7, 'artist@example.com', true );
+		$GLOBALS['ec_test']['user_meta'][7]['_ec_artist_onboarding_claim_delivery'] = 1;
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $this->input() );
+
+		$this->assertSame( 'sent', $result['claim']['delivery'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['claim_deliveries'] );
+	}
+
+	public function test_inverse_only_repair_failure_does_not_create_duplicate_link_page(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['blogs'][4]['posts'][30] = (object) array(
+			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_extrch_link_page_id'] = 1;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_association_repair_failed', $result->get_error_code() );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+	}
+
+	public function test_forced_link_replacement_failure_restores_previous_association(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['blogs'][4]['posts'][30] = (object) array(
+			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['fail_meta_input_keys']['_associated_artist_profile_id'] = 1;
+
+		$result = ec_create_link_page( 20, true );
+
+		$this->assertSame( 'link_page_association_failed', $result->get_error_code() );
+		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 20, (int) get_post_meta( 30, '_associated_artist_profile_id', true ) );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_forced_link_replacement_rolls_back_when_previous_page_cannot_detach(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['blogs'][4]['posts'][30] = (object) array(
+			'ID' => 30, 'post_type' => 'artist_link_page', 'post_status' => 'publish', 'post_title' => 'Test Artist', 'post_name' => 'test-artist',
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys']['_associated_artist_profile_id'] = 1;
+
+		$result = ec_create_link_page( 20, true );
+
+		$this->assertSame( 'link_page_previous_detach_failed', $result->get_error_code() );
+		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 20, (int) get_post_meta( 30, '_associated_artist_profile_id', true ) );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
 	}
 }

--- a/tests/ExternalArtistOnboardingTest.php
+++ b/tests/ExternalArtistOnboardingTest.php
@@ -497,6 +497,7 @@ final class ExternalArtistOnboardingTest extends TestCase {
 	public function test_registered_output_contract_requires_nested_response_shape(): void {
 		$ability = wp_get_ability( 'extrachill/onboard-external-artist' );
 		$schema  = $ability->get_output_schema();
+		$GLOBALS['ec_test']['allow_external_artist_onboarding'] = true;
 		$result  = $ability->execute( $this->input() );
 
 		$this->assertSame(
@@ -506,6 +507,18 @@ final class ExternalArtistOnboardingTest extends TestCase {
 		$this->assertRequiredSchemaShape( $schema, $result );
 		$this->assertSame( array( 'id', 'state', 'created' ), $schema['properties']['user']['required'] );
 		$this->assertSame( array( 'name', 'profile_id', 'term_id', 'state' ), $schema['properties']['artist']['required'] );
+	}
+
+	public function test_external_onboarding_ability_requires_explicit_internal_caller_opt_in(): void {
+		$ability = wp_get_ability( 'extrachill/onboard-external-artist' );
+
+		$denied = $ability->execute( $this->input() );
+		$this->assertSame( 'ability_permission_denied', $denied->get_error_code() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['users'] );
+
+		$GLOBALS['ec_test']['allow_external_artist_onboarding'] = true;
+		$allowed = $ability->execute( $this->input() );
+		$this->assertSame( 'account_claim_required', $allowed['outcome'] );
 	}
 
 	public function test_inverse_only_link_page_association_is_repaired_and_reused(): void {
@@ -609,5 +622,127 @@ final class ExternalArtistOnboardingTest extends TestCase {
 		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
 		$this->assertSame( 20, (int) get_post_meta( 30, '_associated_artist_profile_id', true ) );
 		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+	}
+
+	public function test_persistent_profile_pointer_rollback_failure_keeps_new_page_for_manual_repair(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['fail_meta_input_keys']['_associated_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys']['_extrch_link_page_id'] = 5;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_association_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$new_link_id = (int) get_post_meta( 20, '_extrch_link_page_id', true );
+		$this->assertGreaterThan( 0, $new_link_id );
+		$this->assertSame( 'artist_link_page', get_post_type( $new_link_id ) );
+		$this->assertEmpty( get_post_meta( $new_link_id, '_associated_artist_profile_id', true ) );
+	}
+
+	public function test_persistent_page_inverse_rollback_failure_keeps_page_for_manual_repair(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_extrch_link_page_id'] = 1;
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys']['_associated_artist_profile_id'] = 5;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_association_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertCount( 2, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertSame( 20, (int) get_post_meta( 21, '_associated_artist_profile_id', true ) );
+	}
+
+	public function test_page_delete_failure_after_safe_metadata_compensation_requires_manual_repair(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['fail_meta_input_keys']['_associated_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_post_delete'] = true;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_association_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 'artist_link_page', get_post_type( 21 ) );
+	}
+
+	public function test_link_default_snapshot_is_optional_because_reads_merge_runtime_defaults(): void {
+		$this->addProfile( 20 );
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_link_page_custom_css_vars'] = 5;
+
+		$link_page_id = ec_create_link_page( 20 );
+		$this->assertIsInt( $link_page_id );
+		$this->assertEmpty( get_post_meta( $link_page_id, '_link_page_custom_css_vars', true ) );
+
+		$data = ec_get_link_page_data( 20, $link_page_id );
+		$this->assertSame( '#fff', $data['css_vars']['--link-page-card-bg-color'] );
+		$this->assertSame( '#000', $data['css_vars']['--link-page-link-text-color'] );
+	}
+
+	public function test_manual_binding_compensation_failure_preserves_profile_for_reconciliation(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['fail_post_meta_update_keys']['_artist_term_id'] = 1;
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 5;
+		$input = $this->input(
+			array(
+				'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $input );
+
+		$this->assertSame( 'artist_binding_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertNotEmpty( get_user_meta( 7, '_artist_profile_ids', true ) );
+		$this->assertSame( 1, $GLOBALS['ec_test']['blogs'][1]['term_meta'][1]['_artist_profile_id'] );
+	}
+
+	public function test_term_delete_success_without_final_deletion_is_manual_failure(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['report_term_delete_success_without_delete'] = true;
+		$input = $this->input(
+			array(
+				'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $input );
+
+		$this->assertSame( 'artist_term_binding_rollback_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertCount( 1, $GLOBALS['ec_test']['blogs'][1]['terms'] );
+	}
+
+	public function test_persistent_term_reference_after_profile_delete_is_manual_failure(): void {
+		$this->addUser( 7, 'artist@example.com' );
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+		$GLOBALS['ec_test']['fail_term_meta_update_keys']['_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 10;
+		$GLOBALS['ec_test']['before_post_delete'] = function ( $profile_id ) {
+			$GLOBALS['ec_test']['blogs'][1]['terms'][99] = (object) array(
+				'term_id'  => 99,
+				'taxonomy' => 'artist',
+				'slug'     => 'stale-reference',
+				'count'    => 0,
+			);
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][99]['_artist_profile_id'] = $profile_id;
+		};
+		$input = $this->input(
+			array(
+				'consent' => array( 'profile_creation' => true, 'disclosure_version' => 'artist-offer-v1' ),
+			)
+		);
+
+		$result = extrachill_artist_platform_ability_onboard_external_artist( $input );
+
+		$this->assertSame( 'artist_onboarding_rollback_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertSame( 1, $GLOBALS['ec_test']['blogs'][1]['term_meta'][99]['_artist_profile_id'] );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,8 @@
 
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'OBJECT', 'OBJECT' );
+define( 'MINUTE_IN_SECONDS', 60 );
+define( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED', 'artist_profile_created' );
 
 function plugin_dir_path( $file ) {
 	return trailingslashit( dirname( $file ) );
@@ -42,6 +44,11 @@ class EcTestWpdb {
 		if ( str_contains( $query, 'GET_LOCK' ) ) {
 			$GLOBALS['ec_test']['db_lock_get_calls'][ $name ] = ( $GLOBALS['ec_test']['db_lock_get_calls'][ $name ] ?? 0 ) + 1;
 			$GLOBALS['ec_test']['db_locks'][ $name ] = ( $GLOBALS['ec_test']['db_locks'][ $name ] ?? 0 ) + 1;
+			if ( isset( $GLOBALS['ec_test']['after_external_artist_lock'] ) ) {
+				$callback = $GLOBALS['ec_test']['after_external_artist_lock'];
+				unset( $GLOBALS['ec_test']['after_external_artist_lock'] );
+				$callback();
+			}
 			return '1';
 		}
 		if ( isset( $GLOBALS['ec_test']['db_locks'][ $name ] ) ) {
@@ -138,6 +145,13 @@ class EcTestRegisteredAbility {
 		return call_user_func( $this->args['permission_callback'], $input );
 	}
 
+	public function execute( $input ) {
+		if ( ! $this->check_permissions( $input ) ) {
+			return new WP_Error( 'ability_permission_denied', 'Ability permission denied.' );
+		}
+		return call_user_func( $this->args['execute_callback'], $input );
+	}
+
 	public function get_meta() {
 		return $this->args['meta'];
 	}
@@ -214,12 +228,30 @@ function sanitize_key( $value ) {
 	return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $value ) );
 }
 
+function sanitize_title( $value ) {
+	$value = strtolower( trim( $value ) );
+	return trim( preg_replace( '/[^a-z0-9]+/', '-', $value ), '-' );
+}
+
+function esc_url_raw( $value ) {
+	return filter_var( $value, FILTER_VALIDATE_URL ) ? $value : '';
+}
+
 function is_email( $value ) {
 	return false !== filter_var( $value, FILTER_VALIDATE_EMAIL );
 }
 
 function email_exists( $email ) {
 	return $GLOBALS['ec_test']['email_users'][ strtolower( $email ) ] ?? false;
+}
+
+function ec_generate_username_from_email( $email ) {
+	return sanitize_title( strstr( $email, '@', true ) ?: 'user' );
+}
+
+function retrieve_password( $login ) {
+	$GLOBALS['ec_test']['claim_deliveries'][] = $login;
+	return empty( $GLOBALS['ec_test']['fail_claim_delivery'] ) ? true : new WP_Error( 'claim_delivery_failed', 'Claim delivery failed.' );
 }
 
 function wp_generate_password( $length ) {
@@ -247,7 +279,7 @@ function get_post_meta( $post_id, $key = '', $single = false ) {
 		return $meta;
 	}
 	$value = $meta[ $key ] ?? ( $single ? '' : array() );
-	if ( $single && in_array( $key, array( '_artist_member_ids', '_pending_invitations' ), true ) ) {
+	if ( $single && in_array( $key, array( '_artist_member_ids', '_pending_invitations', '_ec_external_onboarding_sources' ), true ) ) {
 		return $value;
 	}
 	return $single && is_array( $value ) ? ( $value[0] ?? '' ) : $value;
@@ -389,7 +421,15 @@ function wp_insert_post( $post_data, $return_error = false ) {
 	}
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$post_id = empty( $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'] ) ? 1 : max( array_keys( $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'] ) ) + 1;
+	if ( empty( $post_data['post_name'] ) && ! empty( $post_data['post_title'] ) ) {
+		$post_data['post_name'] = sanitize_title( $post_data['post_title'] );
+	}
 	$GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ] = (object) array_merge( array( 'ID' => $post_id ), $post_data );
+	if ( ! empty( $post_data['meta_input'] ) ) {
+		foreach ( $post_data['meta_input'] as $key => $value ) {
+			$GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] = $value;
+		}
+	}
 	return $post_id;
 }
 
@@ -583,7 +623,14 @@ function get_super_admins() {
 	return array( 'admin' );
 }
 
-function get_user_by() {
+function get_user_by( $field = '', $value = '' ) {
+	if ( 'email' === $field ) {
+		$user_id = email_exists( $value );
+		return $user_id ? get_userdata( $user_id ) : false;
+	}
+	if ( 'id' === $field ) {
+		return get_userdata( $value );
+	}
 	return (object) array( 'ID' => 1 );
 }
 
@@ -622,11 +669,60 @@ function get_userdata( $user_id ) {
 	if ( ! empty( $GLOBALS['ec_test']['missing_user'] ) || ! $user_id ) {
 		return false;
 	}
+	if ( isset( $GLOBALS['ec_test']['users'] ) && ! isset( $GLOBALS['ec_test']['users'][ $user_id ] ) ) {
+		return false;
+	}
+	if ( isset( $GLOBALS['ec_test']['users'][ $user_id ] ) ) {
+		return $GLOBALS['ec_test']['users'][ $user_id ];
+	}
 	return (object) array(
 		'ID'           => $user_id,
 		'user_login'   => 'user-' . $user_id,
 		'user_email'   => $GLOBALS['ec_test']['user_emails'][ $user_id ] ?? 'user-' . $user_id . '@example.com',
 		'display_name' => 'User ' . $user_id,
+	);
+}
+
+function apply_filters( $hook_name, $value, ...$args ) {
+	if ( 'ec_get_artist_id' === $hook_name && is_array( $value ) ) {
+		return (int) ( $value['artist_id'] ?? 0 );
+	}
+	if ( 'ec_get_link_page_id' === $hook_name ) {
+		if ( isset( $GLOBALS['ec_test']['link_page_id'] ) ) {
+			return (int) $GLOBALS['ec_test']['link_page_id'];
+		}
+		$artist_id = empty( $args ) ? (int) $value : (int) end( $args );
+		return ec_get_link_page_id( $artist_id );
+	}
+	return $value;
+}
+
+function do_action() {
+	return true;
+}
+
+function ec_artist_platform_emit_funnel_event() {
+	return true;
+}
+
+function ec_get_link_page_id( $artist_id ) {
+	return (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+}
+
+function ec_get_link_page_defaults_for() {
+	return array(
+		'--link-page-card-bg-color'        => '#fff',
+		'--link-page-link-text-color'       => '#000',
+		'--link-page-title-font-family'     => 'sans-serif',
+		'--link-page-body-font-family'      => 'sans-serif',
+		'--link-page-background-type'       => 'color',
+		'--link-page-background-color'      => '#fff',
+		'--link-page-button-hover-bg-color' => '#000',
+		'--link-page-button-border-color'   => '#000',
+		'--link-page-button-bg-color'       => '#fff',
+		'--link-page-muted-text-color'      => '#555',
+		'--link-page-input-bg'              => '#fff',
+		'--link-page-button-radius'         => '4px',
 	);
 }
 
@@ -667,7 +763,9 @@ require_once dirname( __DIR__ ) . '/inc/artist-profiles/frontend/shows-section.p
 require_once dirname( __DIR__ ) . '/inc/abilities/registry.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/update-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/create-artist.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/onboard-external-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-invitation.php';
+require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-social-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-export-subscribers.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,7 @@
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'OBJECT', 'OBJECT' );
 define( 'MINUTE_IN_SECONDS', 60 );
+define( 'DAY_IN_SECONDS', 86400 );
 define( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED', 'artist_profile_created' );
 
 function plugin_dir_path( $file ) {
@@ -154,6 +155,14 @@ class EcTestRegisteredAbility {
 
 	public function get_meta() {
 		return $this->args['meta'];
+	}
+
+	public function get_input_schema() {
+		return $this->args['input_schema'] ?? array();
+	}
+
+	public function get_output_schema() {
+		return $this->args['output_schema'] ?? array();
 	}
 }
 
@@ -336,6 +345,10 @@ function add_post_meta( $post_id, $key, $value, $unique = false ) {
 function update_post_meta( $post_id, $key, $value, $previous = '' ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$GLOBALS['ec_test']['post_meta_update_calls'] = ( $GLOBALS['ec_test']['post_meta_update_calls'] ?? 0 ) + 1;
+	if ( ! empty( $GLOBALS['ec_test']['fail_post_meta_update_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_post_meta_update_keys'][ $key ];
+		return false;
+	}
 	if ( in_array( $GLOBALS['ec_test']['post_meta_update_calls'], $GLOBALS['ec_test']['fail_post_meta_update_on_calls'] ?? array(), true ) ) {
 		return false;
 	}
@@ -427,6 +440,10 @@ function wp_insert_post( $post_data, $return_error = false ) {
 	$GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ] = (object) array_merge( array( 'ID' => $post_id ), $post_data );
 	if ( ! empty( $post_data['meta_input'] ) ) {
 		foreach ( $post_data['meta_input'] as $key => $value ) {
+			if ( ! empty( $GLOBALS['ec_test']['fail_meta_input_keys'][ $key ] ) ) {
+				--$GLOBALS['ec_test']['fail_meta_input_keys'][ $key ];
+				continue;
+			}
 			$GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] = $value;
 		}
 	}
@@ -446,6 +463,10 @@ function wp_delete_post( $post_id, $force_delete = false ) {
 
 function delete_post_meta( $post_id, $key, $value = '' ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	if ( ! empty( $GLOBALS['ec_test']['fail_post_meta_delete_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_post_meta_delete_keys'][ $key ];
+		return false;
+	}
 	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] ?? null;
 	if ( '' === $value || (string) $current === (string) $value ) {
 		unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] );
@@ -518,12 +539,20 @@ function get_term_meta( $term_id, $key, $single = false ) {
 
 function update_term_meta( $term_id, $key, $value ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	if ( ! empty( $GLOBALS['ec_test']['fail_term_meta_update_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_term_meta_update_keys'][ $key ];
+		return false;
+	}
 	$GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] = $value;
 	return true;
 }
 
 function delete_term_meta( $term_id, $key, $value = '' ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	if ( ! empty( $GLOBALS['ec_test']['fail_term_meta_delete_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_term_meta_delete_keys'][ $key ];
+		return false;
+	}
 	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] ?? null;
 	if ( is_array( $current ) && '' !== $value ) {
 		$remaining = array_values(
@@ -563,6 +592,9 @@ function get_posts( $args ) {
 		if ( isset( $args['post_status'] ) && 'any' !== $args['post_status'] && $post->post_status !== $args['post_status'] ) {
 			continue;
 		}
+		if ( isset( $args['meta_key'] ) && (string) get_post_meta( $post_id, $args['meta_key'], true ) !== (string) ( $args['meta_value'] ?? '' ) ) {
+			continue;
+		}
 		$ids[] = (int) $post_id;
 	}
 	return $ids;
@@ -575,8 +607,20 @@ function wp_insert_term( $title, $taxonomy, $args = array() ) {
 		'term_id'  => $term_id,
 		'taxonomy' => $taxonomy,
 		'slug'     => $args['slug'] ?? $title,
+		'count'    => 0,
 	);
 	return array( 'term_id' => $term_id );
+}
+
+function wp_delete_term( $term_id, $taxonomy ) {
+	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	$term    = $GLOBALS['ec_test']['blogs'][ $blog_id ]['terms'][ $term_id ] ?? null;
+	if ( ! $term || $term->taxonomy !== $taxonomy || ! empty( $GLOBALS['ec_test']['fail_term_delete'] ) ) {
+		return false;
+	}
+	unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['terms'][ $term_id ], $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ] );
+	$GLOBALS['ec_test']['deleted_terms'][] = $term_id;
+	return true;
 }
 
 function get_option( $key, $default = false ) {
@@ -706,7 +750,22 @@ function ec_artist_platform_emit_funnel_event() {
 }
 
 function ec_get_link_page_id( $artist_id ) {
-	return (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+	if ( 'artist_link_page' === get_post_type( $artist_id ) ) {
+		return (int) $artist_id;
+	}
+	if ( 'artist_profile' !== get_post_type( $artist_id ) ) {
+		return 0;
+	}
+	$link_pages = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'meta_key'       => '_associated_artist_profile_id',
+			'meta_value'     => (string) $artist_id,
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+		)
+	);
+	return empty( $link_pages ) ? 0 : (int) $link_pages[0];
 }
 
 function ec_get_link_page_defaults_for() {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -456,6 +456,14 @@ function wp_delete_post( $post_id, $force_delete = false ) {
 	}
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$post    = $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ] ?? null;
+	if ( isset( $GLOBALS['ec_test']['before_post_delete'] ) ) {
+		$callback = $GLOBALS['ec_test']['before_post_delete'];
+		unset( $GLOBALS['ec_test']['before_post_delete'] );
+		$callback( $post_id, $post );
+	}
+	if ( $post && 'artist_profile' === $post->post_type && function_exists( 'ec_delete_artist_profile_term_binding' ) ) {
+		ec_delete_artist_profile_term_binding( $post_id );
+	}
 	unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ], $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ] );
 	$GLOBALS['ec_test']['deleted_posts'][] = $post_id;
 	return $post;
@@ -618,6 +626,9 @@ function wp_delete_term( $term_id, $taxonomy ) {
 	if ( ! $term || $term->taxonomy !== $taxonomy || ! empty( $GLOBALS['ec_test']['fail_term_delete'] ) ) {
 		return false;
 	}
+	if ( ! empty( $GLOBALS['ec_test']['report_term_delete_success_without_delete'] ) ) {
+		return true;
+	}
 	unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['terms'][ $term_id ], $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ] );
 	$GLOBALS['ec_test']['deleted_terms'][] = $term_id;
 	return true;
@@ -728,6 +739,9 @@ function get_userdata( $user_id ) {
 }
 
 function apply_filters( $hook_name, $value, ...$args ) {
+	if ( 'extrachill_allow_external_artist_onboarding' === $hook_name ) {
+		return ! empty( $GLOBALS['ec_test']['allow_external_artist_onboarding'] );
+	}
 	if ( 'ec_get_artist_id' === $hook_name && is_array( $value ) ) {
 		return (int) ( $value['artist_id'] ?? 0 );
 	}


### PR DESCRIPTION
## Summary

- Add the internal `extrachill/onboard-external-artist` ability for generic external-product artist leads.
- Resolve account and canonical artist identity before consent-gated profile and `.link` provisioning.
- Return explicit claim, authentication, consent, membership-request, managed-artist, and artist-created outcomes without exposing claim tokens.

Closes #150.

## Existing Primitives Reused

- `extrachill/create-user` creates locked subscriber accounts with `ec_unclaimed=1`.
- `ec_generate_username_from_email()` supplies the users-owned collision-safe username.
- WordPress `retrieve_password()` and the existing branded password-reset hooks own claim-token creation and delivery; no token enters the ability response or logs.
- `extrachill/create-artist` owns profile creation and reciprocal membership creation.
- `ec_artist_binding_read_profile()`, `ec_artist_binding_read_term()`, `ec_reconcile_artist_profile_term_pair()`, `ec_sync_artist_profile_term_binding()`, and `ec_get_artist_term_id()` own canonical profile/term identity.
- `ec_can_manage_artist()` owns management authorization.
- `ec_create_link_page()` owns idempotent link-page creation and reuse.
- `ec_remove_artist_membership()` plus `wp_delete_post()` provide rollback when required provenance cannot be stored.

The users-owned claim completion path currently does not clear `ec_unclaimed` after a successful password set. That owner-layer gap is tracked in Extra-Chill/extrachill-users#235; this PR does not weaken or duplicate that security boundary.

## Ability Contract

Ability: `extrachill/onboard-external-artist`

Exposure: internal only (`show_in_rest=false`), non-destructive, idempotent.

Inputs:

- `submitter_user_id` or `submitter_email`
- `artist_name`
- Optional `artist_term_id` and `artist_profile_id`
- Generic `source_type` and `source_id`
- Optional `return_url`
- Optional `consent.profile_creation`, `consent.link_page`, and required `consent.disclosure_version` whenever either consent is asserted

Outputs:

- `outcome`
- `user` with resolved ID, state, and creation status
- `artist` with name, canonical profile/term IDs, and lifecycle state
- `membership.state`
- `claim.required` and token-free delivery status
- `link_page.state` and ID
- Echoed generic `source` and `return_url`
- `next_action`

Outcome states:

- `account_claim_required`
- `authentication_required`
- `artist_consent_required`
- `membership_request_required`
- `managed_artist`
- `artist_created`

## Consent And Ownership

- Email possession never grants existing-artist management.
- Unclaimed accounts cannot create profiles, join artists, or provision link pages.
- Existing owners must authenticate as the resolved user before any artist/source/link mutation.
- Existing unowned profiles or canonical terms return `membership_request_required`; the ability never self-invites or bypasses the established invitation/approval path.
- New public profiles require authenticated identity plus explicit profile-creation consent and a disclosure version.
- New public link pages require established artist management plus explicit link-page consent and a disclosure version.
- Claim delivery uses a leased pending/sent marker and returns only delivery state, never reset keys or URLs containing tokens.

## Identity And Duplicate Prevention

- Explicit profile/term IDs must exist, agree with each other, and match the normalized submitted artist name.
- Name lookup checks both the main-site artist taxonomy and Artist Platform profile slug before creation.
- Existing canonical terms and profiles are reused; term-only identities are never claimed by a new email contact.
- Pre-authentication identity resolution is read-only.
- Artist creation and link provisioning run under an artist-name advisory lock, with identity re-resolved after lock acquisition to close concurrent retry races.
- A canonical reciprocal profile/term binding is required before link-page success.

## Idempotency And Attribution

- Existing users are resolved by email; account-creation races re-resolve the winning account.
- Claim delivery is serialized per user, retries failed sends, leases interrupted pending work, and does not resend after recorded success.
- Generic source/consent provenance is stored on the managed profile under a deterministic source key.
- Provenance is monotonic: weaker retries cannot erase earlier profile/link consent or disclosure versions.
- Provenance must persist before canonical binding and link provisioning continue; newly created profiles roll back if it cannot be stored.
- Repeated requests reuse users, profiles, memberships, canonical bindings, source entries, and link pages.

## Tests

- New unclaimed user creation, retry dedupe, claim send, failed-send retry, and stale lease recovery
- Existing claimed user authentication and consent gates
- Existing managed artist and link-page reuse
- Existing unowned artist membership-request path
- Existing unclaimed account restrictions
- Duplicate canonical artist-name prevention
- Conflicting user, explicit artist, and indirect identity rejection
- Concurrent post-lock identity re-resolution
- Source provenance persistence, monotonic consent, and rollback on persistence failure
- Stable artist-slug validation
- Internal/idempotent ability metadata

Commands run:

- `vendor/bin/phpunit --filter ExternalArtistOnboardingTest` (19 tests, 67 assertions)
- `vendor/bin/phpunit` (110 tests, 692 assertions)
- `php -l inc/abilities/handlers/onboard-external-artist.php`
- `php -l inc/abilities/registry.php`
- `php -l tests/ExternalArtistOnboardingTest.php`
- `php -l tests/bootstrap.php`
- `git diff --check`
- `homeboy review --changed-only audit` (completed with repository-wide heuristic warnings, including pre-existing findings)

The repository-local PHPCS script cannot run because `composer.json` does not install the configured WordPress standard. Homeboy lint also fails before analyzing files because its WordPress extension Composer autoloader is corrupted; no code lint finding was produced.

## Layer Purity

Confirmed: no booking, venue, settlement, product-vendor, or transport-specific concepts entered the generic Artist Platform contract or implementation.

## Merge Block

This PR remains explicitly blocked on Extra-Chill/extrachill-users#236. Do not merge until the users-owned `extrachill/create-user` contract verifies that `ec_unclaimed=1` persisted. Artist Platform does not work around that ownership boundary.