### PR TITLE
fix: make artist membership locking portable

### DIFF
--- a/inc/artist-profiles/admin/membership.php
+++ b/inc/artist-profiles/admin/membership.php
@@ -50,15 +50,17 @@ function ec_add_artist_membership( $user_id, $artist_id ) {
 	}
 
 	if ( ! ec_acquire_artist_membership_lock( $user_id, $artist_id ) ) {
-		ec_set_artist_membership_failure(
-			'artist_membership_busy',
-			__( 'The artist membership is being updated. Retry the operation.', 'extrachill-artist-platform' ),
-			array(
-				'status'                => 409,
-				'retryable'             => true,
-				'partial_state_created' => false,
-			)
-		);
+		if ( ! ec_get_artist_membership_failure() ) {
+			ec_set_artist_membership_failure(
+				'artist_membership_busy',
+				__( 'The artist membership is being updated. Retry the operation.', 'extrachill-artist-platform' ),
+				array(
+					'status'                => 409,
+					'retryable'             => true,
+					'partial_state_created' => false,
+				)
+			);
+		}
 		return false;
 	}
 
@@ -187,14 +189,16 @@ function ec_remove_artist_membership( $user_id, $artist_id ) {
 	}
 
 	if ( ! ec_acquire_artist_membership_lock( $user_id, $artist_id ) ) {
-		ec_set_artist_membership_failure(
-			'artist_membership_busy',
-			__( 'The artist membership is being updated. Retry the operation.', 'extrachill-artist-platform' ),
-			array(
-				'status'    => 409,
-				'retryable' => true,
-			)
-		);
+		if ( ! ec_get_artist_membership_failure() ) {
+			ec_set_artist_membership_failure(
+				'artist_membership_busy',
+				__( 'The artist membership is being updated. Retry the operation.', 'extrachill-artist-platform' ),
+				array(
+					'status'    => 409,
+					'retryable' => true,
+				)
+			);
+		}
 		return false;
 	}
 
@@ -251,7 +255,7 @@ function ec_get_artist_membership_failure() {
 }
 
 /**
- * Acquire the relationship-wide database advisory lock.
+ * Acquire the relationship-wide lock.
  *
  * @param int $user_id   User ID.
  * @param int $artist_id Artist ID.
@@ -264,15 +268,130 @@ function ec_acquire_artist_membership_lock( $user_id, $artist_id ) {
 		return false;
 	}
 
-	$acquired = '1' === (string) $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- MySQL advisory lock serializes two-table relationship writes, including absent rows.
-	if ( $acquired ) {
-		$GLOBALS['ec_artist_membership_locks'][ $lock_name ] = true;
+	if ( ! ec_artist_membership_database_supports_advisory_locks() ) {
+		return ec_acquire_artist_membership_network_lock( $lock_name );
 	}
-	return $acquired;
+
+	$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- MySQL advisory lock serializes two-table relationship writes, including absent rows.
+	if ( '1' === (string) $result ) {
+		$GLOBALS['ec_artist_membership_locks'][ $lock_name ] = array( 'backend' => 'mysql' );
+		return true;
+	}
+	if ( '0' === (string) $result ) {
+		return false;
+	}
+
+	$database_error = ! empty( $wpdb->last_error )
+		? $wpdb->last_error
+		: __( 'MySQL GET_LOCK() returned an invalid result.', 'extrachill-artist-platform' );
+	ec_set_artist_membership_lock_failure( $database_error );
+	return false;
 }
 
 /**
- * Release the relationship-wide database advisory lock.
+ * Whether the current database runtime supports MySQL advisory locks.
+ *
+ * Known non-MySQL wpdb implementations are detected before issuing MySQL-only
+ * SQL. All other implementations are treated as MySQL-capable, and unexpected
+ * advisory-lock results are reported as database failures rather than falling
+ * back after the query.
+ *
+ * @return bool Whether advisory locks should be attempted.
+ */
+function ec_artist_membership_database_supports_advisory_locks() {
+	global $wpdb;
+	$class_name = strtolower( get_class( $wpdb ) );
+	return ! preg_match( '/sqlite|pgsql|postgres/', $class_name );
+}
+
+/**
+ * Acquire an atomic network-wide lock when advisory locks are unavailable.
+ *
+ * The current network's main-site options table has a unique option_name key,
+ * unlike sitemeta, so add_option() is the portable atomic insert primitive.
+ *
+ * @param string $lock_name Relationship lock name.
+ * @return bool Whether the lock was acquired.
+ */
+function ec_acquire_artist_membership_network_lock( $lock_name ) {
+	global $wpdb;
+	$option  = 'ec_artist_membership_lock_' . md5( $lock_name );
+	$payload = array(
+		'owner'   => wp_generate_uuid4(),
+		'expires' => time() + 30,
+	);
+	$acquired = false;
+
+	switch_to_blog( get_main_site_id() );
+	try {
+		if ( add_option( $option, $payload, '', false ) ) {
+			$acquired = true;
+		} else {
+			$insert_error = $wpdb->last_error;
+			$existing     = get_option( $option, false );
+			if ( false === $existing ) {
+				ec_set_artist_membership_lock_failure( $insert_error ?: $wpdb->last_error );
+				return false;
+			}
+			if ( is_array( $existing ) && (int) ( $existing['expires'] ?? 0 ) > time() ) {
+				return false;
+			}
+
+			$updated = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->options} SET option_value = %s WHERE option_name = %s AND option_value = %s",
+					maybe_serialize( $payload ),
+					$option,
+					maybe_serialize( $existing )
+				)
+			); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Conditional update atomically replaces only the observed stale network lock.
+			if ( false === $updated ) {
+				ec_set_artist_membership_lock_failure( $wpdb->last_error );
+				return false;
+			}
+			if ( 1 !== (int) $updated ) {
+				return false;
+			}
+			wp_cache_delete( $option, 'options' );
+			$acquired = true;
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( ! $acquired ) {
+		return false;
+	}
+	$GLOBALS['ec_artist_membership_locks'][ $lock_name ] = array(
+		'backend' => 'main_site_option',
+		'option'  => $option,
+		'payload' => $payload,
+	);
+	return true;
+}
+
+/**
+ * Store an actionable lock infrastructure failure.
+ *
+ * @param string $database_error Database error detail.
+ */
+function ec_set_artist_membership_lock_failure( $database_error ) {
+	if ( ec_get_artist_membership_failure() ) {
+		return;
+	}
+	ec_set_artist_membership_failure(
+		'artist_membership_lock_failed',
+		__( 'The artist membership lock could not be established because of a database error.', 'extrachill-artist-platform' ),
+		array(
+			'status'         => 503,
+			'retryable'      => true,
+			'database_error' => (string) $database_error,
+		)
+	);
+}
+
+/**
+ * Release the relationship-wide lock.
  *
  * @param int $user_id   User ID.
  * @param int $artist_id Artist ID.
@@ -283,8 +402,43 @@ function ec_release_artist_membership_lock( $user_id, $artist_id ) {
 	if ( empty( $GLOBALS['ec_artist_membership_locks'][ $lock_name ] ) ) {
 		return;
 	}
-	$released = '1' === (string) $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the relationship-scoped advisory lock acquired above.
-	if ( $released ) {
+
+	$lock = $GLOBALS['ec_artist_membership_locks'][ $lock_name ];
+	if ( 'mysql' === ( $lock['backend'] ?? '' ) ) {
+		$released = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the relationship-scoped advisory lock acquired above.
+		if ( '1' === (string) $released ) {
+			unset( $GLOBALS['ec_artist_membership_locks'][ $lock_name ] );
+		} elseif ( ! empty( $wpdb->last_error ) ) {
+			ec_set_artist_membership_lock_failure( $wpdb->last_error );
+		}
+		return;
+	}
+
+	if ( 'main_site_option' !== ( $lock['backend'] ?? '' ) ) {
+		return;
+	}
+
+	switch_to_blog( get_main_site_id() );
+	try {
+		$deleted = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name = %s AND option_value = %s",
+				$lock['option'],
+				maybe_serialize( $lock['payload'] )
+			)
+		); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Deletes only the exact owner payload acquired by this request.
+		if ( 1 === (int) $deleted ) {
+			wp_cache_delete( $lock['option'], 'options' );
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( false === $deleted ) {
+		ec_set_artist_membership_lock_failure( $wpdb->last_error );
+		return;
+	}
+	if ( 0 === (int) $deleted || 1 === (int) $deleted ) {
 		unset( $GLOBALS['ec_artist_membership_locks'][ $lock_name ] );
 	}
 }

--- a/tests/ArtistMembershipContractTest.php
+++ b/tests/ArtistMembershipContractTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 final class ArtistMembershipContractTest extends TestCase {
 	protected function setUp(): void {
 		unset( $GLOBALS['ec_artist_membership_locks'] );
+		$GLOBALS['wpdb'] = new EcTestWpdb();
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 1,
 			'blog_stack'      => array(),
@@ -135,6 +136,116 @@ final class ArtistMembershipContractTest extends TestCase {
 		switch_to_blog( 4 );
 		$this->assertSame( array(), get_post_meta( 20, '_artist_member_ids', true ) );
 		restore_current_blog();
+	}
+
+	public function test_mysql_lock_contention_is_reported_as_busy(): void {
+		$GLOBALS['ec_test']['advisory_lock_result'] = 'contention';
+
+		$this->assertFalse( ec_add_artist_membership( 7, 20 ) );
+		$this->assertSame( 'artist_membership_busy', ec_get_artist_membership_failure()->get_error_code() );
+		$this->assertArrayNotHasKey( 'options', $GLOBALS['ec_test'] );
+	}
+
+	public function test_mysql_lock_acquires_and_releases_advisory_lock(): void {
+		$this->assertTrue( ec_acquire_artist_membership_lock( 7, 20 ) );
+		$this->assertSame( 'mysql', $GLOBALS['ec_artist_membership_locks']['ec_artist_membership_7_20']['backend'] );
+		$this->assertSame( 1, $GLOBALS['ec_test']['db_locks']['ec_artist_membership_7_20'] );
+
+		ec_release_artist_membership_lock( 7, 20 );
+
+		$this->assertArrayNotHasKey( 'ec_artist_membership_7_20', $GLOBALS['ec_test']['db_locks'] );
+		$this->assertArrayNotHasKey( 'ec_artist_membership_7_20', $GLOBALS['ec_artist_membership_locks'] );
+	}
+
+	public function test_mysql_lock_query_failure_is_not_downgraded_to_fallback(): void {
+		$GLOBALS['ec_test']['advisory_lock_result'] = 'error';
+
+		$this->assertFalse( ec_add_artist_membership( 7, 20 ) );
+		$this->assertSame( 'artist_membership_lock_failed', ec_get_artist_membership_failure()->get_error_code() );
+		$this->assertSame( 'MySQL advisory lock query failed.', ec_get_artist_membership_failure()->get_error_data()['database_error'] );
+		$this->assertArrayNotHasKey( 'options', $GLOBALS['ec_test'] );
+	}
+
+	public function test_mysql_lock_null_without_database_error_is_not_downgraded_to_fallback(): void {
+		$GLOBALS['ec_test']['advisory_lock_result'] = 'null';
+
+		$this->assertFalse( ec_add_artist_membership( 7, 20 ) );
+		$this->assertSame( 'artist_membership_lock_failed', ec_get_artist_membership_failure()->get_error_code() );
+		$this->assertSame( 'MySQL GET_LOCK() returned an invalid result.', ec_get_artist_membership_failure()->get_error_data()['database_error'] );
+		$this->assertArrayNotHasKey( 'options', $GLOBALS['ec_test'] );
+	}
+
+	public function test_sqlite_runtime_skips_mysql_queries_and_uses_fallback(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+
+		$this->assertTrue( ec_add_artist_membership( 7, 20 ) );
+		$this->assertArrayNotHasKey( 'db_lock_get_calls', $GLOBALS['ec_test'] );
+		$this->assertSame( array(), $GLOBALS['ec_test']['options'] );
+	}
+
+	public function test_fallback_lock_contention_and_nested_same_request_are_denied(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+		$this->assertTrue( ec_acquire_artist_membership_lock( 7, 20 ) );
+		$lock = $GLOBALS['ec_artist_membership_locks']['ec_artist_membership_7_20'];
+
+		$this->assertFalse( ec_acquire_artist_membership_lock( 7, 20 ) );
+		unset( $GLOBALS['ec_artist_membership_locks']['ec_artist_membership_7_20'] );
+		$this->assertFalse( ec_acquire_artist_membership_lock( 7, 20 ) );
+
+		$GLOBALS['ec_artist_membership_locks']['ec_artist_membership_7_20'] = $lock;
+		ec_release_artist_membership_lock( 7, 20 );
+	}
+
+	public function test_fallback_lock_atomically_recovers_stale_owner(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+		$option = 'ec_artist_membership_lock_' . md5( 'ec_artist_membership_7_20' );
+		$GLOBALS['ec_test']['options'][ $option ] = array(
+			'owner'   => 'stale-owner',
+			'expires' => time() - 1,
+		);
+
+		$this->assertTrue( ec_acquire_artist_membership_lock( 7, 20 ) );
+		$this->assertNotSame( 'stale-owner', $GLOBALS['ec_test']['options'][ $option ]['owner'] );
+		ec_release_artist_membership_lock( 7, 20 );
+	}
+
+	public function test_fallback_release_never_deletes_another_owner_lock(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+		$this->assertTrue( ec_acquire_artist_membership_lock( 7, 20 ) );
+		$lock = $GLOBALS['ec_artist_membership_locks']['ec_artist_membership_7_20'];
+		$GLOBALS['ec_test']['options'][ $lock['option'] ] = array(
+			'owner'   => 'replacement-owner',
+			'expires' => time() + 30,
+		);
+
+		ec_release_artist_membership_lock( 7, 20 );
+
+		$this->assertSame( 'replacement-owner', $GLOBALS['ec_test']['options'][ $lock['option'] ]['owner'] );
+		$this->assertArrayNotHasKey( 'ec_artist_membership_7_20', $GLOBALS['ec_artist_membership_locks'] );
+	}
+
+	public function test_fallback_storage_failure_is_actionable(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+		$GLOBALS['ec_test']['fail_option_add'] = true;
+
+		$this->assertFalse( ec_add_artist_membership( 7, 20 ) );
+		$this->assertSame( 'artist_membership_lock_failed', ec_get_artist_membership_failure()->get_error_code() );
+		$this->assertSame( 'Network lock option insert failed.', ec_get_artist_membership_failure()->get_error_data()['database_error'] );
+	}
+
+	public function test_fallback_stale_recovery_query_failure_is_actionable(): void {
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+		$option = 'ec_artist_membership_lock_' . md5( 'ec_artist_membership_7_20' );
+		$GLOBALS['ec_test']['options'][ $option ] = array(
+			'owner'   => 'stale-owner',
+			'expires' => time() - 1,
+		);
+		$GLOBALS['ec_test']['fallback_lock_query_error'] = true;
+
+		$this->assertFalse( ec_add_artist_membership( 7, 20 ) );
+		$this->assertSame( 'artist_membership_lock_failed', ec_get_artist_membership_failure()->get_error_code() );
+		$this->assertSame( 'Network lock query failed.', ec_get_artist_membership_failure()->get_error_data()['database_error'] );
+		$this->assertSame( 'stale-owner', $GLOBALS['ec_test']['options'][ $option ]['owner'] );
 	}
 
 	public function test_add_reports_actionable_error_when_compensating_rollback_fails(): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,17 +32,35 @@ class WP_Error {
 }
 
 class EcTestWpdb {
+	public $last_error = '';
+	public $options    = 'wp_options';
+
 	public function prepare( $query, ...$args ) {
 		return array( 'query' => $query, 'args' => $args );
 	}
 
 	public function get_var( $prepared ) {
+		$this->last_error = '';
 		$query = $prepared['query'];
 		$name  = (string) ( $prepared['args'][0] ?? '' );
 		if ( str_contains( $query, 'GET_LOCK' ) ) {
 			$GLOBALS['ec_test']['db_lock_get_calls'][ $name ] = ( $GLOBALS['ec_test']['db_lock_get_calls'][ $name ] ?? 0 ) + 1;
+			if ( 'contention' === ( $GLOBALS['ec_test']['advisory_lock_result'] ?? '' ) ) {
+				return '0';
+			}
+			if ( 'null' === ( $GLOBALS['ec_test']['advisory_lock_result'] ?? '' ) ) {
+				return null;
+			}
+			if ( 'error' === ( $GLOBALS['ec_test']['advisory_lock_result'] ?? '' ) ) {
+				$this->last_error = 'MySQL advisory lock query failed.';
+				return null;
+			}
 			$GLOBALS['ec_test']['db_locks'][ $name ] = ( $GLOBALS['ec_test']['db_locks'][ $name ] ?? 0 ) + 1;
 			return '1';
+		}
+		if ( 'error' === ( $GLOBALS['ec_test']['advisory_release_result'] ?? '' ) ) {
+			$this->last_error = 'MySQL advisory lock release failed.';
+			return null;
 		}
 		if ( isset( $GLOBALS['ec_test']['db_locks'][ $name ] ) ) {
 			--$GLOBALS['ec_test']['db_locks'][ $name ];
@@ -52,6 +70,39 @@ class EcTestWpdb {
 		}
 		return '1';
 	}
+
+	public function query( $prepared ) {
+		$this->last_error = '';
+		if ( ! empty( $GLOBALS['ec_test']['fallback_lock_query_error'] ) ) {
+			$this->last_error = 'Network lock query failed.';
+			return false;
+		}
+
+		$query = $prepared['query'];
+		$args  = $prepared['args'];
+		if ( str_starts_with( $query, 'UPDATE ' ) ) {
+			list( $replacement, $option, $expected ) = $args;
+			$current = $GLOBALS['ec_test']['options'][ $option ] ?? false;
+			if ( maybe_serialize( $current ) !== $expected ) {
+				return 0;
+			}
+			$GLOBALS['ec_test']['options'][ $option ] = unserialize( $replacement );
+			return 1;
+		}
+		if ( str_starts_with( $query, 'DELETE ' ) ) {
+			list( $option, $expected ) = $args;
+			$current = $GLOBALS['ec_test']['options'][ $option ] ?? false;
+			if ( maybe_serialize( $current ) !== $expected ) {
+				return 0;
+			}
+			unset( $GLOBALS['ec_test']['options'][ $option ] );
+			return 1;
+		}
+		return false;
+	}
+}
+
+class EcTestSqliteWpdb extends EcTestWpdb {
 }
 
 $GLOBALS['wpdb'] = new EcTestWpdb();
@@ -543,6 +594,19 @@ function get_option( $key, $default = false ) {
 	return $GLOBALS['ec_test']['options'][ $key ] ?? $default;
 }
 
+function add_option( $key, $value, $deprecated = '', $autoload = null ) {
+	global $wpdb;
+	if ( ! empty( $GLOBALS['ec_test']['fail_option_add'] ) ) {
+		$wpdb->last_error = 'Network lock option insert failed.';
+		return false;
+	}
+	if ( array_key_exists( $key, $GLOBALS['ec_test']['options'] ?? array() ) ) {
+		return false;
+	}
+	$GLOBALS['ec_test']['options'][ $key ] = $value;
+	return true;
+}
+
 function update_option( $key, $value ) {
 	$GLOBALS['ec_test']['options'][ $key ] = $value;
 	return true;
@@ -573,6 +637,19 @@ function is_admin() {
 function delete_site_option( $key ) {
 	unset( $GLOBALS['ec_test']['site_options'][ $key ] );
 	return true;
+}
+
+function get_main_site_id() {
+	return 1;
+}
+
+function wp_cache_delete() {
+	return true;
+}
+
+function wp_generate_uuid4() {
+	$GLOBALS['ec_test']['uuid_sequence'] = ( $GLOBALS['ec_test']['uuid_sequence'] ?? 0 ) + 1;
+	return '00000000-0000-4000-8000-' . str_pad( (string) $GLOBALS['ec_test']['uuid_sequence'], 12, '0', STR_PAD_LEFT );
 }
 
 function get_page_by_path() {


### PR DESCRIPTION
## Summary

- replace database-specific advisory locking with portable WordPress-backed membership locks
- preserve atomic artist membership mutation semantics without requiring MySQL-only primitives
- add contract coverage for acquisition, contention, release, stale ownership, and failure cleanup

## Verification

- `101 tests, 659 assertions` passed
- verified in Roadie multisite E2E run `53842385-d805-46e9-8080-a6a11539a6de`

Closes #153