### PR TITLE
feat: add artist local support availability

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -76,6 +76,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/page-title.php';
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-term-binding.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/local-support/availability.php';
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/user-linking.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/admin/relationship-admin-page.php';

--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -40,6 +40,7 @@ require_once __DIR__ . '/handlers/artist-list-subscribers.php';
 require_once __DIR__ . '/handlers/artist-export-subscribers.php';
 require_once __DIR__ . '/handlers/artist-get-analytics.php';
 require_once __DIR__ . '/handlers/get-artist-platform-stats.php';
+require_once __DIR__ . '/handlers/artist-local-support.php';
 
 // Admin artist-relationships ability handlers.
 require_once __DIR__ . '/handlers/admin-list-artist-relationships.php';

--- a/inc/abilities/handlers/artist-local-support.php
+++ b/inc/abilities/handlers/artist-local-support.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Local support availability ability handlers.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/** Get local support availability for an exactly managed artist. */
+function extrachill_artist_platform_ability_get_local_support_availability( $input ) {
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', __( 'You are not allowed to manage this artist.', 'extrachill-artist-platform' ) );
+	}
+
+	return extrachill_artist_platform_get_local_support_availability( absint( $input['id'] ?? 0 ) );
+}
+
+/** Update local support availability for an exactly managed artist. */
+function extrachill_artist_platform_ability_update_local_support_availability( $input ) {
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', __( 'You are not allowed to manage this artist.', 'extrachill-artist-platform' ) );
+	}
+
+	return extrachill_artist_platform_update_local_support_availability(
+		absint( $input['id'] ?? 0 ),
+		! empty( $input['available'] ),
+		array_key_exists( 'scene_slug', $input ) ? (string) $input['scene_slug'] : null,
+		get_current_user_id()
+	);
+}
+
+/** Query privacy-safe candidates through the private producer contract. */
+function extrachill_artist_platform_ability_query_local_support_candidates( $input ) {
+	return extrachill_artist_platform_resolve_local_support_candidates(
+		$input['producer'] ?? '',
+		$input['scene_slug'] ?? '',
+		$input['genre'] ?? '',
+		$input['exclude_artist_ids'] ?? array()
+	);
+}

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -75,6 +75,25 @@ function extrachill_artist_platform_ability_create_permission( $input ) {
 }
 
 /**
+ * Permission callback for the private local-support producer query.
+ *
+ * @param array $input Ability input.
+ * @return bool
+ */
+function extrachill_artist_platform_ability_local_support_producer_permission( $input ) {
+	if ( current_user_can( 'manage_network_options' ) ) {
+		return true;
+	}
+
+	$producer = sanitize_key( $input['producer'] ?? '' );
+	$scene    = extrachill_artist_platform_resolve_local_support_scene( $input['scene_slug'] ?? '' );
+
+	return '' !== $producer
+		&& ! is_wp_error( $scene )
+		&& (bool) apply_filters( 'extrachill_artist_platform_local_support_producer_authorized', false, $producer, $scene );
+}
+
+/**
  * ID meta key map for link page entities.
  *
  * Maps entity type to the post meta counter key stored on the link page.

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -657,6 +657,126 @@ function extrachill_artist_platform_register_abilities() {
 	);
 
 	wp_register_ability(
+		'extrachill/artist-get-local-support-availability',
+		array(
+			'label'               => __( 'Get artist local support availability', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns local support availability for an exactly managed artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id' ),
+				'properties'           => array( 'id' => array( 'type' => 'integer', 'minimum' => 1 ) ),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'required'             => array( 'artist_id', 'available', 'scene' ),
+				'properties'           => array(
+					'artist_id' => array( 'type' => 'integer' ),
+					'available' => array( 'type' => 'boolean' ),
+					'scene'     => array( 'type' => array( 'object', 'null' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_get_local_support_availability',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-update-local-support-availability',
+		array(
+			'label'               => __( 'Update artist local support availability', 'extrachill-artist-platform' ),
+			'description'         => __( 'Enables or disables local support matching for an exactly managed artist.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'id', 'available' ),
+				'properties'           => array(
+					'id'         => array( 'type' => 'integer', 'minimum' => 1 ),
+					'available'  => array( 'type' => 'boolean' ),
+					'scene_slug' => array( 'type' => 'string' ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'required'             => array( 'artist_id', 'available', 'scene' ),
+				'properties'           => array(
+					'artist_id' => array( 'type' => 'integer' ),
+					'available' => array( 'type' => 'boolean' ),
+					'scene'     => array( 'type' => array( 'object', 'null' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_update_local_support_availability',
+			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+			),
+		)
+	);
+
+	wp_register_ability(
+		'extrachill/artist-query-local-support-candidates',
+		array(
+			'label'               => __( 'Query local support candidates', 'extrachill-artist-platform' ),
+			'description'         => __( 'Returns privacy-safe local support candidates for an authorized producer.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artists',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'producer', 'scene_slug' ),
+				'properties'           => array(
+					'producer'           => array( 'type' => 'string' ),
+					'scene_slug'         => array( 'type' => 'string' ),
+					'genre'              => array( 'type' => 'string' ),
+					'exclude_artist_ids' => array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'required'             => array( 'location', 'candidates' ),
+				'properties'           => array(
+					'location'   => array( 'type' => 'object' ),
+					'candidates' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type'                 => 'object',
+							'required'             => array( 'artist_profile_id', 'artist_term_id', 'name', 'slug', 'permalink', 'genre', 'local_city', 'profile_image_url', 'header_image_url', 'manager_user_ids' ),
+							'properties'           => array(
+								'artist_profile_id' => array( 'type' => 'integer' ),
+								'artist_term_id'    => array( 'type' => 'integer' ),
+								'name'              => array( 'type' => 'string' ),
+								'slug'              => array( 'type' => 'string' ),
+								'permalink'         => array( 'type' => 'string', 'format' => 'uri' ),
+								'genre'             => array( 'type' => array( 'string', 'null' ) ),
+								'local_city'        => array( 'type' => array( 'string', 'null' ) ),
+								'profile_image_url' => array( 'type' => array( 'string', 'null' ) ),
+								'header_image_url'  => array( 'type' => array( 'string', 'null' ) ),
+								'manager_user_ids'  => array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+							),
+							'additionalProperties' => false,
+						),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_query_local_support_candidates',
+			'permission_callback' => 'extrachill_artist_platform_ability_local_support_producer_permission',
+			'meta'                => array(
+				'show_in_rest' => false,
+				'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+			),
+		)
+	);
+
+	wp_register_ability(
 		'extrachill/artist-update-links',
 		array(
 			'label'               => __( 'Update artist link page', 'extrachill-artist-platform' ),

--- a/inc/local-support/availability.php
+++ b/inc/local-support/availability.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Artist-controlled local support availability.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META = '_local_support_available';
+const EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META     = '_local_support_scene';
+
+/**
+ * Resolve a canonical Events location through the Users-owned contract.
+ *
+ * @param string $slug Location slug.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_resolve_local_support_scene( $slug ) {
+	if ( ! function_exists( 'extrachill_users_resolve_local_scene' ) ) {
+		return new WP_Error( 'local_scene_dependency_missing', __( 'Canonical Local Scene resolution is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	return extrachill_users_resolve_local_scene( sanitize_title( $slug ) );
+}
+
+/**
+ * Read one artist's local support preference.
+ *
+ * @param int $artist_id Artist profile ID.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_get_local_support_availability( $artist_id ) {
+	$artist_id     = absint( $artist_id );
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'artist' ) ) : 0;
+	if ( ! $artist_id || ! $artist_blog_id ) {
+		return new WP_Error( 'invalid_artist', __( 'A valid artist profile is required.', 'extrachill-artist-platform' ) );
+	}
+
+	$did_switch = get_current_blog_id() !== $artist_blog_id;
+	if ( $did_switch ) {
+		switch_to_blog( $artist_blog_id );
+	}
+
+	try {
+		if ( 'artist_profile' !== get_post_type( $artist_id ) ) {
+			return new WP_Error( 'invalid_artist', __( 'A valid artist profile is required.', 'extrachill-artist-platform' ) );
+		}
+
+		$available  = '1' === (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META, true );
+		$scene_slug = (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META, true );
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+
+	$scene = null;
+	if ( '' !== $scene_slug ) {
+		$scene = extrachill_artist_platform_resolve_local_support_scene( $scene_slug );
+		if ( is_wp_error( $scene ) ) {
+			return $scene;
+		}
+	}
+
+	return array(
+		'artist_id' => $artist_id,
+		'available' => $available,
+		'scene'     => $scene,
+	);
+}
+
+/**
+ * Persist one artist's local support preference after exact manager authorization.
+ *
+ * @param int         $artist_id Artist profile ID.
+ * @param bool        $available Whether the artist is available.
+ * @param string|null $scene_slug Optional canonical location override.
+ * @param int         $actor_id Acting manager user ID.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_update_local_support_availability( $artist_id, $available, $scene_slug, $actor_id ) {
+	$artist_id = absint( $artist_id );
+	$actor_id  = absint( $actor_id );
+	if ( ! $artist_id || ! $actor_id || ! function_exists( 'ec_can_manage_artist' ) || ! ec_can_manage_artist( $actor_id, $artist_id ) ) {
+		return new WP_Error( 'artist_access_denied', __( 'You are not allowed to manage this artist.', 'extrachill-artist-platform' ) );
+	}
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'artist' ) ) : 0;
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'dependency_missing', __( 'The artist site is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	$did_switch = get_current_blog_id() !== $artist_blog_id;
+	if ( $did_switch ) {
+		switch_to_blog( $artist_blog_id );
+	}
+
+	try {
+		if ( 'artist_profile' !== get_post_type( $artist_id ) ) {
+			return new WP_Error( 'invalid_artist', __( 'A valid artist profile is required.', 'extrachill-artist-platform' ) );
+		}
+
+		if ( ! $available ) {
+			delete_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META );
+			if ( '' !== (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META, true ) ) {
+				return new WP_Error( 'local_support_save_failed', __( 'Local support availability could not be disabled.', 'extrachill-artist-platform' ) );
+			}
+			delete_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META );
+			return array(
+				'artist_id' => $artist_id,
+				'available' => false,
+				'scene'     => null,
+			);
+		}
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+
+	if ( null !== $scene_slug && '' !== trim( (string) $scene_slug ) ) {
+		$scene = extrachill_artist_platform_resolve_local_support_scene( $scene_slug );
+	} elseif ( function_exists( 'extrachill_users_get_local_scene' ) ) {
+		$scene = extrachill_users_get_local_scene( $actor_id );
+	} else {
+		$scene = new WP_Error( 'local_scene_dependency_missing', __( 'Canonical Local Scene resolution is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	if ( is_wp_error( $scene ) ) {
+		return $scene;
+	}
+	if ( ! is_array( $scene ) || empty( $scene['slug'] ) ) {
+		return new WP_Error( 'local_support_scene_required', __( 'Choose a canonical Local Scene before enabling local support availability.', 'extrachill-artist-platform' ) );
+	}
+
+	$scene_slug = sanitize_title( $scene['slug'] );
+	$did_switch = get_current_blog_id() !== $artist_blog_id;
+	if ( $did_switch ) {
+		switch_to_blog( $artist_blog_id );
+	}
+
+	try {
+		update_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META, $scene_slug );
+		if ( $scene_slug !== (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META, true ) ) {
+			return new WP_Error( 'local_support_save_failed', __( 'The matching scene could not be saved.', 'extrachill-artist-platform' ) );
+		}
+
+		update_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META, '1' );
+		if ( '1' !== (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META, true ) ) {
+			return new WP_Error( 'local_support_save_failed', __( 'Local support availability could not be saved.', 'extrachill-artist-platform' ) );
+		}
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+
+	return array(
+		'artist_id' => $artist_id,
+		'available' => true,
+		'scene'     => $scene,
+	);
+}
+
+/**
+ * Return reciprocal, existing artist managers as notification recipient IDs.
+ *
+ * @param int $artist_id Artist profile ID in the current artist-blog context.
+ * @return int[]
+ */
+function extrachill_artist_platform_get_local_support_manager_ids( $artist_id ) {
+	$member_ids = get_post_meta( $artist_id, '_artist_member_ids', true );
+	if ( ! is_array( $member_ids ) ) {
+		return array();
+	}
+
+	$manager_ids = array();
+	foreach ( array_unique( array_map( 'absint', $member_ids ) ) as $user_id ) {
+		$artist_ids = get_user_meta( $user_id, '_artist_profile_ids', true );
+		if ( $user_id && get_userdata( $user_id ) && is_array( $artist_ids ) && in_array( (int) $artist_id, array_map( 'absint', $artist_ids ), true ) ) {
+			$manager_ids[] = $user_id;
+		}
+	}
+
+	return $manager_ids;
+}
+
+/**
+ * Resolve privacy-safe candidates for an authorized producer.
+ *
+ * @param string $producer Producer identifier authorized by its owning plugin.
+ * @param string $scene_slug Canonical Events location slug.
+ * @param string $genre Optional exact, case-insensitive genre.
+ * @param int[]  $exclude_artist_ids Artist profile IDs already attached to an event.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_resolve_local_support_candidates( $producer, $scene_slug, $genre = '', $exclude_artist_ids = array() ) {
+	$producer = sanitize_key( $producer );
+	$scene    = extrachill_artist_platform_resolve_local_support_scene( $scene_slug );
+	if ( is_wp_error( $scene ) ) {
+		return $scene;
+	}
+	if ( '' === $producer || ! apply_filters( 'extrachill_artist_platform_local_support_producer_authorized', false, $producer, $scene ) ) {
+		return new WP_Error( 'local_support_producer_forbidden', __( 'This producer is not authorized to resolve local support candidates.', 'extrachill-artist-platform' ) );
+	}
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'artist' ) ) : 0;
+	if ( ! $artist_blog_id ) {
+		return new WP_Error( 'dependency_missing', __( 'The artist site is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	$genre              = trim( sanitize_text_field( $genre ) );
+	$exclude_artist_ids = array_unique( array_filter( array_map( 'absint', (array) $exclude_artist_ids ) ) );
+	$did_switch         = get_current_blog_id() !== $artist_blog_id;
+	if ( $did_switch ) {
+		switch_to_blog( $artist_blog_id );
+	}
+
+	try {
+		$artist_ids = get_posts(
+			array(
+				'post_type'      => 'artist_profile',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_key'       => EXTRACHILL_ARTIST_LOCAL_SUPPORT_AVAILABLE_META,
+				'meta_value'     => '1',
+			)
+		);
+		$candidates = array();
+		foreach ( $artist_ids as $artist_id ) {
+			$artist_id = absint( $artist_id );
+			if ( in_array( $artist_id, $exclude_artist_ids, true ) || (string) $scene['slug'] !== (string) get_post_meta( $artist_id, EXTRACHILL_ARTIST_LOCAL_SUPPORT_SCENE_META, true ) ) {
+				continue;
+			}
+
+			$artist_genre = (string) get_post_meta( $artist_id, '_genre', true );
+			if ( '' !== $genre && 0 !== strcasecmp( $genre, trim( $artist_genre ) ) ) {
+				continue;
+			}
+
+			$manager_ids = extrachill_artist_platform_get_local_support_manager_ids( $artist_id );
+			$term_id     = function_exists( 'ec_get_artist_term_id' ) ? absint( ec_get_artist_term_id( $artist_id ) ) : 0;
+			if ( ! $term_id || empty( $manager_ids ) ) {
+				continue;
+			}
+
+			$profile_image_id = get_post_thumbnail_id( $artist_id );
+			$header_image_id  = absint( get_post_meta( $artist_id, '_artist_profile_header_image_id', true ) );
+			$candidates[]     = array(
+				'artist_profile_id' => $artist_id,
+				'artist_term_id'    => $term_id,
+				'name'              => get_the_title( $artist_id ),
+				'slug'              => get_post_field( 'post_name', $artist_id ),
+				'permalink'         => get_permalink( $artist_id ),
+				'genre'             => '' !== $artist_genre ? $artist_genre : null,
+				'local_city'        => get_post_meta( $artist_id, '_local_city', true ) ?: null,
+				'profile_image_url' => $profile_image_id ? wp_get_attachment_image_url( $profile_image_id, 'medium' ) : null,
+				'header_image_url'  => $header_image_id ? wp_get_attachment_image_url( $header_image_id, 'large' ) : null,
+				'manager_user_ids'  => $manager_ids,
+			);
+		}
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+
+	return array(
+		'location'   => $scene,
+		'candidates' => $candidates,
+	);
+}

--- a/src/blocks/artist-manager/components/LocalSupportTab.js
+++ b/src/blocks/artist-manager/components/LocalSupportTab.js
@@ -1,0 +1,192 @@
+import { useEffect, useState } from '@wordpress/element';
+import {
+	ActionRow,
+	FieldGroup,
+	InlineStatus,
+	Panel,
+} from '@extrachill/components';
+import {
+	getLocalSupportAvailability,
+	searchEventLocations,
+	updateLocalSupportAvailability,
+} from '../../shared/api/client';
+
+const useDebounce = ( value, delay ) => {
+	const [ debouncedValue, setDebouncedValue ] = useState( value );
+
+	useEffect( () => {
+		const handler = setTimeout( () => setDebouncedValue( value ), delay );
+		return () => clearTimeout( handler );
+	}, [ value, delay ] );
+
+	return debouncedValue;
+};
+
+const LocalSupportTab = ( { artistId } ) => {
+	const [ available, setAvailable ] = useState( false );
+	const [ scene, setScene ] = useState( null );
+	const [ search, setSearch ] = useState( '' );
+	const [ locations, setLocations ] = useState( [] );
+	const [ loading, setLoading ] = useState( false );
+	const [ saving, setSaving ] = useState( false );
+	const [ status, setStatus ] = useState( '' );
+	const [ error, setError ] = useState( '' );
+	const debouncedSearch = useDebounce( search, 300 );
+
+	useEffect( () => {
+		const load = async () => {
+			setLoading( true );
+			try {
+				const data = await getLocalSupportAvailability( artistId );
+				setAvailable( Boolean( data?.available ) );
+				setScene( data?.scene || null );
+				setSearch( data?.scene?.name || '' );
+				setError( '' );
+			} catch ( err ) {
+				setError(
+					err?.message || 'Could not load local support settings.'
+				);
+			} finally {
+				setLoading( false );
+			}
+		};
+
+		if ( artistId ) {
+			load();
+		}
+	}, [ artistId ] );
+
+	useEffect( () => {
+		const run = async () => {
+			if (
+				debouncedSearch.trim().length < 2 ||
+				debouncedSearch === scene?.name
+			) {
+				setLocations( [] );
+				return;
+			}
+			try {
+				const data = await searchEventLocations(
+					debouncedSearch.trim()
+				);
+				setLocations(
+					Array.isArray( data?.locations ) ? data.locations : []
+				);
+			} catch ( err ) {
+				setLocations( [] );
+			}
+		};
+
+		run();
+	}, [ debouncedSearch, scene ] );
+
+	const save = async () => {
+		setSaving( true );
+		setStatus( '' );
+		setError( '' );
+		try {
+			const data = await updateLocalSupportAvailability(
+				artistId,
+				available,
+				scene?.slug || ''
+			);
+			setAvailable( Boolean( data?.available ) );
+			setScene( data?.scene || null );
+			setSearch( data?.scene?.name || '' );
+			setLocations( [] );
+			setStatus( 'Local support settings saved.' );
+		} catch ( err ) {
+			setError(
+				err?.message || 'Could not save local support settings.'
+			);
+		} finally {
+			setSaving( false );
+		}
+	};
+
+	return (
+		<Panel>
+			{ loading && (
+				<InlineStatus tone="info">
+					Loading local support settings…
+				</InlineStatus>
+			) }
+			{ error && <InlineStatus tone="error">{ error }</InlineStatus> }
+			{ status && <InlineStatus tone="success">{ status }</InlineStatus> }
+			<p>
+				Opt in to be considered for event-specific local opening slots
+				in your selected Local Scene. Managers may receive matching
+				recommendations and notifications.
+			</p>
+			<label
+				className="ec-am__check-row"
+				htmlFor="ec-am-local-support-available"
+			>
+				<input
+					id="ec-am-local-support-available"
+					type="checkbox"
+					checked={ available }
+					onChange={ ( event ) =>
+						setAvailable( event.target.checked )
+					}
+				/>
+				<span>Available for local support opportunities</span>
+			</label>
+			{ available && (
+				<FieldGroup label="Matching Local Scene">
+					<div className="ec-am__location-picker">
+						<input
+							className="ec-am__location-input"
+							type="search"
+							value={ search }
+							onChange={ ( event ) => {
+								setSearch( event.target.value );
+								setScene( null );
+							} }
+							placeholder="Search canonical event locations"
+						/>
+						{ locations.length > 0 && (
+							<div className="ec-am__location-results">
+								{ locations.map( ( location ) => (
+									<button
+										type="button"
+										key={ location.slug }
+										onClick={ () => {
+											setScene( location );
+											setSearch( location.name );
+											setLocations( [] );
+										} }
+									>
+										{ location.hierarchy?.label ||
+											location.name }
+									</button>
+								) ) }
+							</div>
+						) }
+					</div>
+					<p className="ec-am__help">
+						Leave the scene unselected to use your account&apos;s
+						canonical Local Scene when saving.
+					</p>
+				</FieldGroup>
+			) }
+			<p className="ec-am__privacy-note">
+				Your contact information is never included in candidate results.
+				Events may share contact information only after explicit,
+				request-scoped consent.
+			</p>
+			<ActionRow align="end">
+				<button
+					type="button"
+					className="button-1 button-medium"
+					onClick={ save }
+					disabled={ loading || saving }
+				>
+					{ saving ? 'Saving…' : 'Save Local Support Settings' }
+				</button>
+			</ActionRow>
+		</Panel>
+	);
+};
+
+export default LocalSupportTab;

--- a/src/blocks/artist-manager/style.scss
+++ b/src/blocks/artist-manager/style.scss
@@ -153,7 +153,51 @@
   color: var(--muted-text);
 }
 
+.ec-am__check-row {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing-sm);
+	font-weight: 600;
+}
+
+.ec-am__location-picker {
+	position: relative;
+
+	.ec-am__location-input {
+		width: 100%;
+	}
+}
+
+.ec-am__location-results {
+	position: absolute;
+	z-index: 10;
+	display: grid;
+	width: 100%;
+	max-height: 240px;
+	overflow-y: auto;
+	border: 1px solid var(--border-color);
+	background: var(--background-color);
+	box-shadow: var(--card-shadow);
+
+	button {
+		padding: var(--spacing-sm) var(--spacing-md);
+		border: 0;
+		border-bottom: 1px solid var(--border-color);
+		background: transparent;
+		color: var(--text-color);
+		text-align: left;
+		cursor: pointer;
+	}
+}
+
+.ec-am__help,
+.ec-am__privacy-note {
+	color: var(--muted-text);
+	font-size: var(--font-size-sm);
+}
+
 @media (max-width: 480px) {
+
 	.ec-am__inline {
 		flex-direction: column;
 	}

--- a/src/blocks/artist-manager/view.js
+++ b/src/blocks/artist-manager/view.js
@@ -28,6 +28,7 @@ import {
 	deleteMedia,
 } from '../shared/api/client';
 import ArtistSwitcher from '../shared/components/ArtistSwitcher';
+import LocalSupportTab from './components/LocalSupportTab';
 
 const isValidEmail = (email) => {
 	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -527,6 +528,7 @@ const App = () => {
 		{ id: 'info', label: 'Info' },
 		{ id: 'managers', label: 'Profile Managers' },
 		{ id: 'subscribers', label: 'Subscribers' },
+		{ id: 'local-support', label: 'Local Support' },
 	];
 
 	const loadArtist = async (id) => {
@@ -619,6 +621,10 @@ const App = () => {
 				return selectedId ? <ManagersTab artistId={ selectedId } /> : null;
 			case 'subscribers':
 				return selectedId ? <SubscribersTab artistId={ selectedId } /> : null;
+			case 'local-support':
+				return selectedId ? (
+					<LocalSupportTab artistId={ selectedId } />
+				) : null;
 			default:
 				return null;
 		}

--- a/src/blocks/shared/api/client.js
+++ b/src/blocks/shared/api/client.js
@@ -31,6 +31,55 @@ export const createArtist = ( data ) => client.artists.create( data );
 export const updateArtist = ( artistId, data ) =>
 	client.artists.update( artistId, data );
 
+const abilityPath = ( name ) =>
+	`/wp-abilities/v1/abilities/${ name
+		.split( '/' )
+		.map( encodeURIComponent )
+		.join( '/' ) }/run`;
+
+export const getLocalSupportAvailability = ( artistId ) => {
+	const query = new URLSearchParams();
+	query.set( 'input[id]', String( artistId ) );
+	return apiFetch( {
+		path: `${ abilityPath(
+			'extrachill/artist-get-local-support-availability'
+		) }?${ query.toString() }`,
+		method: 'GET',
+	} );
+};
+
+export const updateLocalSupportAvailability = (
+	artistId,
+	available,
+	sceneSlug
+) =>
+	apiFetch( {
+		path: abilityPath(
+			'extrachill/artist-update-local-support-availability'
+		),
+		method: 'POST',
+		data: {
+			input: {
+				id: artistId,
+				available,
+				...( sceneSlug ? { scene_slug: sceneSlug } : {} ),
+			},
+		},
+	} );
+
+export const searchEventLocations = ( search ) => {
+	const query = new URLSearchParams();
+	query.set( 'input[mode]', 'search' );
+	query.set( 'input[search]', search );
+	query.set( 'input[limit]', '10' );
+	return apiFetch( {
+		path: `${ abilityPath(
+			'extrachill/user-event-locations'
+		) }?${ query.toString() }`,
+		method: 'GET',
+	} );
+};
+
 // ─── Link page ──────────────────────────────────────────────────────────────
 
 export const getLinks = ( artistId ) => client.artists.getLinks( artistId );
@@ -202,6 +251,9 @@ export default {
 	getArtist,
 	createArtist,
 	updateArtist,
+	getLocalSupportAvailability,
+	updateLocalSupportAvailability,
+	searchEventLocations,
 	getLinks,
 	updateLinks,
 	getSocials,

--- a/tests/LocalSupportAvailabilityTest.php
+++ b/tests/LocalSupportAvailabilityTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class LocalSupportAvailabilityTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'current_user_id' => 7,
+			'managed_artists' => array( 7 => array( 42, 43, 44, 45 ) ),
+			'canonical_locations' => array(
+				'charleston' => array( 'term_id' => 10, 'name' => 'Charleston', 'slug' => 'charleston' ),
+				'austin'     => array( 'term_id' => 11, 'name' => 'Austin', 'slug' => 'austin' ),
+			),
+			'local_scenes' => array(
+				7 => array( 'term_id' => 10, 'name' => 'Charleston', 'slug' => 'charleston' ),
+			),
+			'blogs' => array(
+				1 => array(
+					'terms' => array(
+						142 => (object) array( 'term_id' => 142, 'taxonomy' => 'artist', 'slug' => 'test-band' ),
+						143 => (object) array( 'term_id' => 143, 'taxonomy' => 'artist', 'slug' => 'excluded-band' ),
+						144 => (object) array( 'term_id' => 144, 'taxonomy' => 'artist', 'slug' => 'austin-band' ),
+						145 => (object) array( 'term_id' => 145, 'taxonomy' => 'artist', 'slug' => 'opted-out-band' ),
+					),
+					'term_meta' => array(
+						142 => array( '_artist_profile_id' => 42 ),
+						143 => array( '_artist_profile_id' => 43 ),
+						144 => array( '_artist_profile_id' => 44 ),
+						145 => array( '_artist_profile_id' => 45 ),
+					),
+				),
+				4 => array(
+					'posts' => array(
+						42 => $this->artist( 42, 'Test Band', 'test-band' ),
+						43 => $this->artist( 43, 'Excluded Band', 'excluded-band' ),
+						44 => $this->artist( 44, 'Austin Band', 'austin-band' ),
+						45 => $this->artist( 45, 'Opted Out Band', 'opted-out-band' ),
+					),
+					'post_meta' => array(
+						42 => $this->artist_meta( 142, 'charleston', 'Rock', array( 7, 8, 9 ) ),
+						43 => $this->artist_meta( 143, 'charleston', 'Rock', array( 7 ) ),
+						44 => $this->artist_meta( 144, 'austin', 'Rock', array( 7 ) ),
+						45 => array_merge( $this->artist_meta( 145, 'charleston', 'Rock', array( 7 ) ), array( '_local_support_available' => '' ) ),
+					),
+				),
+			),
+			'user_meta' => array(
+				7 => array( '_artist_profile_ids' => array( 42, 43, 44, 45 ) ),
+				8 => array( '_artist_profile_ids' => array() ),
+			),
+			'users' => array(
+				7 => (object) array( 'ID' => 7, 'user_login' => 'manager', 'user_email' => 'manager@example.com', 'display_name' => 'Manager' ),
+				8 => (object) array( 'ID' => 8, 'user_login' => 'stale', 'user_email' => 'stale@example.com', 'display_name' => 'Stale' ),
+			),
+		);
+		extrachill_artist_platform_register_abilities();
+	}
+
+	private function artist( int $id, string $name, string $slug ): object {
+		return (object) array(
+			'ID'           => $id,
+			'post_type'    => 'artist_profile',
+			'post_status'  => 'publish',
+			'post_title'   => $name,
+			'post_name'    => $slug,
+			'post_content' => 'Public artist bio.',
+		);
+	}
+
+	private function artist_meta( int $term_id, string $scene, string $genre, array $member_ids ): array {
+		return array(
+			'_artist_term_id'         => $term_id,
+			'_artist_member_ids'      => $member_ids,
+			'_local_support_available' => '1',
+			'_local_support_scene'     => $scene,
+			'_genre'                   => $genre,
+			'_local_city'              => 'Display City',
+		);
+	}
+
+	public function test_manager_abilities_enforce_the_exact_artist_on_permission_and_execution_paths(): void {
+		$get    = wp_get_ability( 'extrachill/artist-get-local-support-availability' );
+		$update = wp_get_ability( 'extrachill/artist-update-local-support-availability' );
+
+		$this->assertTrue( $get->check_permissions( array( 'id' => 42 ) ) );
+		$this->assertTrue( $update->check_permissions( array( 'id' => 42, 'available' => true ) ) );
+
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 43 );
+		$this->assertFalse( $get->check_permissions( array( 'id' => 42 ) ) );
+		$this->assertFalse( $update->check_permissions( array( 'id' => 42, 'available' => false ) ) );
+		$this->assertSame( 'artist_access_denied', extrachill_artist_platform_ability_get_local_support_availability( array( 'id' => 42 ) )->get_error_code() );
+		$this->assertSame( 'artist_access_denied', extrachill_artist_platform_ability_update_local_support_availability( array( 'id' => 42, 'available' => false ) )->get_error_code() );
+	}
+
+	public function test_opt_in_defaults_to_manager_local_scene_and_validates_overrides(): void {
+		delete_post_meta( 42, '_local_support_available' );
+		delete_post_meta( 42, '_local_support_scene' );
+
+		$result = extrachill_artist_platform_ability_update_local_support_availability(
+			array( 'id' => 42, 'available' => true )
+		);
+		$this->assertTrue( $result['available'] );
+		$this->assertSame( 'charleston', $result['scene']['slug'] );
+		$this->assertSame( 'charleston', get_post_meta( 42, '_local_support_scene', true ) );
+
+		$invalid = extrachill_artist_platform_ability_update_local_support_availability(
+			array( 'id' => 42, 'available' => true, 'scene_slug' => 'made-up-city' )
+		);
+		$this->assertInstanceOf( WP_Error::class, $invalid );
+		$this->assertSame( 'location_not_found', $invalid->get_error_code() );
+		$this->assertSame( 'charleston', get_post_meta( 42, '_local_support_scene', true ) );
+
+		$override = extrachill_artist_platform_ability_update_local_support_availability(
+			array( 'id' => 42, 'available' => true, 'scene_slug' => 'austin' )
+		);
+		$this->assertSame( 'austin', $override['scene']['slug'] );
+	}
+
+	public function test_opt_out_immediately_removes_artist_from_candidate_resolution(): void {
+		$GLOBALS['ec_test']['authorized_local_support_producers'] = array( 'extrachill-events-local-support' );
+
+		$before = extrachill_artist_platform_resolve_local_support_candidates( 'extrachill-events-local-support', 'charleston' );
+		$this->assertSame( array( 42, 43 ), array_column( $before['candidates'], 'artist_profile_id' ) );
+
+		extrachill_artist_platform_ability_update_local_support_availability( array( 'id' => 42, 'available' => false ) );
+		$after = extrachill_artist_platform_resolve_local_support_candidates( 'extrachill-events-local-support', 'charleston' );
+		$this->assertSame( array( 43 ), array_column( $after['candidates'], 'artist_profile_id' ) );
+	}
+
+	public function test_private_candidate_contract_filters_and_discloses_only_valid_manager_ids(): void {
+		$ability = wp_get_ability( 'extrachill/artist-query-local-support-candidates' );
+		$input   = array(
+			'producer'           => 'extrachill-events-local-support',
+			'scene_slug'         => 'charleston',
+			'genre'              => 'rock',
+			'exclude_artist_ids' => array( 43 ),
+		);
+
+		$this->assertFalse( $ability->check_permissions( $input ) );
+		$this->assertSame( 'local_support_producer_forbidden', extrachill_artist_platform_ability_query_local_support_candidates( $input )->get_error_code() );
+
+		$GLOBALS['ec_test']['authorized_local_support_producers'] = array( 'extrachill-events-local-support' );
+		$this->assertTrue( $ability->check_permissions( $input ) );
+		$result = $ability->execute( $input );
+
+		$this->assertCount( 1, $result['candidates'] );
+		$candidate = $result['candidates'][0];
+		$this->assertSame( 42, $candidate['artist_profile_id'] );
+		$this->assertSame( 142, $candidate['artist_term_id'] );
+		$this->assertSame( array( 7 ), $candidate['manager_user_ids'] );
+		$this->assertSame( 'Display City', $candidate['local_city'] );
+		$this->assertArrayNotHasKey( 'email', $candidate );
+		$this->assertArrayNotHasKey( 'phone', $candidate );
+		$this->assertArrayNotHasKey( 'subscribers', $candidate );
+		$this->assertStringNotContainsString( 'manager@example.com', json_encode( $result ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -783,6 +783,10 @@ function wp_get_attachment_url( $attachment_id ) {
 	return 'https://artist.example/media/' . $attachment_id . '.jpg';
 }
 
+function wp_get_attachment_image_url( $attachment_id, $size = 'thumbnail' ) {
+	return wp_get_attachment_url( $attachment_id );
+}
+
 function get_the_post_thumbnail_url( $post_id, $size ) {
 	$attachment_id = get_post_thumbnail_id( $post_id );
 	return $attachment_id ? wp_get_attachment_url( $attachment_id ) : false;
@@ -829,7 +833,20 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		$artist_id = empty( $args ) ? (int) $value : (int) end( $args );
 		return ec_get_link_page_id( $artist_id );
 	}
+	if ( 'extrachill_artist_platform_local_support_producer_authorized' === $hook_name ) {
+		$producer = (string) ( $args[0] ?? '' );
+		return in_array( $producer, $GLOBALS['ec_test']['authorized_local_support_producers'] ?? array(), true );
+	}
 	return $value;
+}
+
+function extrachill_users_get_local_scene( $user_id ) {
+	return $GLOBALS['ec_test']['local_scenes'][ (int) $user_id ] ?? null;
+}
+
+function extrachill_users_resolve_local_scene( $slug ) {
+	$slug = sanitize_title( $slug );
+	return $GLOBALS['ec_test']['canonical_locations'][ $slug ] ?? new WP_Error( 'location_not_found', 'No canonical location matched that slug.' );
 }
 
 function do_action() {
@@ -907,6 +924,7 @@ require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/permissions.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-platform-post-types.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
+require_once dirname( __DIR__ ) . '/inc/local-support/availability.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-term-binding.php';
 require_once dirname( __DIR__ ) . '/inc/artist-profiles/frontend/shows-section.php';
@@ -919,5 +937,6 @@ require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-social-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-export-subscribers.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-local-support.php';
 require_once dirname( __DIR__ ) . '/inc/core/actions/save.php';
 require_once dirname( __DIR__ ) . '/inc/core/platform-artist-provisioning.php';


### PR DESCRIPTION
## Summary
- add artist-scoped local-support opt-in with exact manager authorization and an Artist Manager settings surface
- reuse Extra Chill Users' canonical Local Scene resolution for manager defaults and validated Events location overrides
- expose a private, producer-authorized candidate contract with location/genre filters, event exclusions, bound artist terms, public card fields, and reciprocal manager user IDs

## Architecture and privacy
- Availability is stored on the canonical artist profile; `_local_city` remains display-only and is never used as a matching key.
- The existing `extrachill_users_get_local_scene()` and `extrachill_users_resolve_local_scene()` contract is reused. This PR adds no scene taxonomy, vocabulary, resolver, or generic substrate.
- Candidate enumeration is not exposed through REST and fails closed behind a producer authorization filter.
- Results contain public artist-card fields and validated manager user IDs only. Account email, invitation email, phone, subscriber data, and other private contact data are not returned.
- Event requests, notifications, shortlist state, and request-scoped contact consent remain outside Artist Platform.

## Tests
- `composer test` (149 tests, 926 assertions)
- `npm run test:js` (2 suites, 5 tests)
- `npm run build`
- `npm run lint:js -- src/blocks/shared/api/client.js src/blocks/artist-manager/components/LocalSupportTab.js`
- `git diff --check`
- changed PHP files validated with `php -l`

## Existing gate debt
- Repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by pre-existing failures tracked in #159.
- `composer lint:php` remains blocked by the missing WordPress coding-standard dependency tracked in #141.

Closes #158