### PR TITLE
Resolve artist email consent from canonical subscriptions

### DIFF
--- a/inc/abilities/handlers/artist-export-subscribers.php
+++ b/inc/abilities/handlers/artist-export-subscribers.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-export-subscribers
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  * }
  * @return array|WP_Error
  */
-function extrachill_artist_platform_ability_artist_export_subscribers( array $input ): array|WP_Error {
+function extrachill_artist_platform_ability_artist_export_subscribers( array $input ) {
 	$artist_id        = isset( $input['id'] ) ? (int) $input['id'] : 0;
 	$include_exported = ! empty( $input['include_exported'] );
 
@@ -46,12 +47,15 @@ function extrachill_artist_platform_ability_artist_export_subscribers( array $in
 		'limit'    => -1,
 		'exported' => $exported_filter,
 	) );
+	if ( is_wp_error( $subscribers ) ) {
+		return $subscribers;
+	}
 
-	$subscriber_ids_to_mark = array();
+	$subscriber_ids_to_mark = extrachill_artist_subscriber_ids_to_mark_exported( $subscribers, $include_exported );
 	$export_data            = array();
 
 	foreach ( $subscribers as $subscriber ) {
-		$is_exported = isset( $subscriber->exported ) && $subscriber->exported == 1;
+		$is_exported = isset( $subscriber->exported ) && 1 === (int) $subscriber->exported;
 
 		$export_data[] = array(
 			'email'         => $subscriber->subscriber_email,
@@ -60,9 +64,6 @@ function extrachill_artist_platform_ability_artist_export_subscribers( array $in
 			'exported'      => $is_exported,
 		);
 
-		if ( ! $is_exported && ! $include_exported ) {
-			$subscriber_ids_to_mark[] = $subscriber->subscriber_id;
-		}
 	}
 
 	// Mark newly exported subscribers.

--- a/inc/abilities/handlers/artist-list-subscribers.php
+++ b/inc/abilities/handlers/artist-list-subscribers.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-list-subscribers
  *
@@ -8,6 +7,8 @@ declare(strict_types=1);
  * @package ExtraChillArtistPlatform
  * @since   1.9.0
  */
+
+declare(strict_types=1);
 
 defined( 'ABSPATH' ) || exit;
 
@@ -21,13 +22,17 @@ defined( 'ABSPATH' ) || exit;
  * }
  * @return array|WP_Error
  */
-function extrachill_artist_platform_ability_artist_list_subscribers( array $input ): array|WP_Error {
+function extrachill_artist_platform_ability_artist_list_subscribers( array $input ) {
 	$artist_id = isset( $input['id'] ) ? (int) $input['id'] : 0;
 	$page      = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
 	$per_page  = isset( $input['per_page'] ) ? max( 1, min( 100, (int) $input['per_page'] ) ) : 20;
 
 	if ( ! $artist_id ) {
 		return new WP_Error( 'missing_id', 'id is required.' );
+	}
+
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
 	}
 
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
@@ -38,17 +43,13 @@ function extrachill_artist_platform_ability_artist_list_subscribers( array $inpu
 		return new WP_Error( 'dependency_missing', 'Subscriber functions not available.' );
 	}
 
+	$all_subscribers = extrachill_artist_get_artist_subscribers( $artist_id );
+	if ( is_wp_error( $all_subscribers ) ) {
+		return $all_subscribers;
+	}
 	$offset      = ( $page - 1 ) * $per_page;
-	$subscribers = extrachill_artist_get_artist_subscribers( $artist_id, array(
-		'limit'  => $per_page,
-		'offset' => $offset,
-	) );
-
-	global $wpdb;
-	$table = $wpdb->prefix . 'artist_subscribers';
-	$total = (int) $wpdb->get_var(
-		$wpdb->prepare( "SELECT COUNT(*) FROM {$table} WHERE artist_profile_id = %d", $artist_id )
-	);
+	$subscribers = array_slice( $all_subscribers, $offset, $per_page );
+	$total       = count( $all_subscribers );
 
 	return array(
 		'subscribers' => $subscribers,

--- a/inc/artist-profiles/subscribe-data-functions.php
+++ b/inc/artist-profiles/subscribe-data-functions.php
@@ -1,72 +1,233 @@
 <?php
 /**
- * Artist Profile Subscriber Data Functions
- * 
- * Backend functions for fetching and managing artist profile subscriber data.
- * Handles subscriber management and CSV exports for artist profiles.
+ * Artist profile subscriber data functions.
+ *
+ * @package ExtraChillArtistPlatform
  */
 
 defined( 'ABSPATH' ) || exit;
 
+const EXTRACHILL_ARTIST_EMAIL_SHARING_PRODUCER = 'artist-platform-subscriber-list-export';
+
 /**
- * Fetches subscriber data for a given artist profile ID.
+ * Register the product-owned artist email-sharing purpose identity.
  *
- * @param int $artist_id The ID of the artist profile.
- * @param array $args Optional arguments for querying.
- * @return array List of subscriber objects or empty array.
+ * @param array $entities Entity subscription descriptors.
+ * @return array
+ */
+function extrachill_artist_register_email_sharing_identity( array $entities ): array {
+	$entities['artist-email-sharing'] = array(
+		'taxonomy'                           => 'artist',
+		'uses_notification_email_preference' => false,
+	);
+
+	return $entities;
+}
+add_filter( 'extrachill_users_entity_subscription_entities', 'extrachill_artist_register_email_sharing_identity' );
+
+/**
+ * Authorize only this product's private list/export recipient resolution.
+ *
+ * @param bool   $authorized Existing authorization result.
+ * @param string $producer Producer identifier.
+ * @param array  $entity Canonical entity identity.
+ * @param string $delivery Delivery channel.
+ * @return bool
+ */
+function extrachill_artist_authorize_email_sharing_producer( $authorized, $producer, $entity, $delivery ): bool {
+	return (bool) $authorized || (
+		EXTRACHILL_ARTIST_EMAIL_SHARING_PRODUCER === $producer
+		&& 'artist-email-sharing' === ( $entity['entity_type'] ?? '' )
+		&& 'artist' === ( $entity['taxonomy'] ?? '' )
+		&& 'email' === $delivery
+	);
+}
+add_filter( 'extrachill_users_entity_subscription_producer_authorized', 'extrachill_artist_authorize_email_sharing_producer', 10, 4 );
+
+/**
+ * Resolve an artist profile to its canonical artist term slug.
+ *
+ * @param int $artist_id Artist profile post ID.
+ * @return string|WP_Error
+ */
+function extrachill_artist_email_sharing_slug( $artist_id ) {
+	$term_id      = function_exists( 'ec_get_artist_term_id' ) ? absint( ec_get_artist_term_id( $artist_id ) ) : 0;
+	$main_blog_id = function_exists( 'ec_get_blog_id' ) ? absint( ec_get_blog_id( 'main' ) ) : 0;
+	if ( ! $term_id || ! $main_blog_id ) {
+		return new WP_Error( 'artist_email_sharing_identity_unavailable', __( 'The canonical artist identity is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	switch_to_blog( $main_blog_id );
+	try {
+		$term = get_term( $term_id, 'artist' );
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( ! $term instanceof WP_Term ) {
+		return new WP_Error( 'artist_email_sharing_identity_unavailable', __( 'The canonical artist identity is unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	return $term->slug;
+}
+
+/**
+ * Resolve current account emails for canonical artist email-sharing consent.
+ *
+ * @param int $artist_id Artist profile post ID.
+ * @return array|WP_Error
+ */
+function extrachill_artist_get_canonical_email_subscribers( $artist_id ) {
+	$slug = extrachill_artist_email_sharing_slug( $artist_id );
+	if ( is_wp_error( $slug ) ) {
+		return $slug;
+	}
+
+	$recipient_ids = extrachill_users_entity_subscription_recipients(
+		EXTRACHILL_ARTIST_EMAIL_SHARING_PRODUCER,
+		'artist-email-sharing',
+		'artist',
+		$slug,
+		'email'
+	);
+	if ( is_wp_error( $recipient_ids ) ) {
+		return $recipient_ids;
+	}
+
+	$subscribers = array();
+	foreach ( $recipient_ids as $user_id ) {
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			continue;
+		}
+		$email = sanitize_email( $user->user_email );
+		if ( ! is_email( $email ) ) {
+			continue;
+		}
+
+		$subscribers[] = (object) array(
+			'subscriber_id'    => 0,
+			'user_id'          => absint( $user_id ),
+			'subscriber_email' => $email,
+			'username'         => $user->user_login,
+			'source'           => 'entity_subscription',
+			'subscribed_at'    => '',
+			'exported'         => 0,
+		);
+	}
+
+	return $subscribers;
+}
+
+/**
+ * Merge product-owned and account-derived subscribers by normalized email.
+ *
+ * Product-owned rows take precedence so their export bookkeeping remains
+ * attached when the same address also has canonical account consent.
+ *
+ * @param array $direct Direct subscriber rows.
+ * @param array $canonical Canonical account-derived rows.
+ * @return array
+ */
+function extrachill_artist_merge_subscriber_sources( array $direct, array $canonical ): array {
+	$merged = array();
+	foreach ( array_merge( $direct, $canonical ) as $subscriber ) {
+		$email = strtolower( sanitize_email( $subscriber->subscriber_email ?? '' ) );
+		if ( ! is_email( $email ) || isset( $merged[ $email ] ) ) {
+			continue;
+		}
+		$subscriber->subscriber_email = $email;
+		$merged[ $email ]             = $subscriber;
+	}
+
+	return array_values( $merged );
+}
+
+/**
+ * Select only unexported product-owned rows for export bookkeeping.
+ *
+ * @param array $subscribers Subscriber rows included in an export.
+ * @param bool  $include_exported Whether previously exported rows were requested.
+ * @return int[]
+ */
+function extrachill_artist_subscriber_ids_to_mark_exported( array $subscribers, bool $include_exported ): array {
+	if ( $include_exported ) {
+		return array();
+	}
+
+	$ids = array();
+	foreach ( $subscribers as $subscriber ) {
+		if ( empty( $subscriber->exported ) && ! empty( $subscriber->subscriber_id ) ) {
+			$ids[] = absint( $subscriber->subscriber_id );
+		}
+	}
+
+	return $ids;
+}
+
+/**
+ * Fetch mixed-source subscriber data for an artist profile.
+ *
+ * Legacy account-derived rows remain readable only before the canonical Users
+ * resolver is available. Once available, it is authoritative for revocation
+ * and current account email resolution.
+ *
+ * @param int   $artist_id Artist profile post ID.
+ * @param array $args Query arguments.
+ * @return array|WP_Error
  */
 function extrachill_artist_get_artist_subscribers( $artist_id, $args = array() ) {
-    global $wpdb;
-    $table_name = $wpdb->prefix . 'artist_subscribers';
-    $artist_id = absint( $artist_id );
+	global $wpdb;
 
-    if ( empty( $artist_id ) ) {
-        return array();
-    }
+	$artist_id = absint( $artist_id );
+	if ( ! $artist_id ) {
+		return array();
+	}
 
-    // Default arguments
-    $defaults = array(
-        'orderby' => 'subscribed_at',
-        'order' => 'DESC',
-        'limit' => -1, // -1 for no limit, fetch all
-        'offset' => 0,
-        'exported' => null, // null means include all, 0 for not exported, 1 for exported
-    );
-    $args = wp_parse_args( $args, $defaults );
+	$args = wp_parse_args(
+		$args,
+		array(
+			'orderby'  => 'subscribed_at',
+			'order'    => 'DESC',
+			'limit'    => -1,
+			'offset'   => 0,
+			'exported' => null,
+		)
+	);
 
-    $sql = "SELECT * FROM $table_name WHERE artist_profile_id = %d";
-    $sql_args = array( $artist_id );
+	$table_name        = $wpdb->prefix . 'artist_subscribers';
+	$canonical_enabled = function_exists( 'extrachill_users_entity_subscription_recipients' );
+	$sql               = "SELECT * FROM {$table_name} WHERE artist_profile_id = %d";
+	$sql_args          = array( $artist_id );
+	if ( $canonical_enabled ) {
+		$sql       .= ' AND source <> %s';
+		$sql_args[] = 'platform_follow_consent';
+	}
+	if ( null !== $args['exported'] ) {
+		$sql       .= ' AND exported = %d';
+		$sql_args[] = absint( $args['exported'] );
+	}
 
-    // Filter by exported status if specified
-    if ( $args['exported'] !== null ) {
-        $sql .= " AND exported = %d";
-        $sql_args[] = absint( $args['exported'] );
-    }
+	$orderby = sanitize_key( $args['orderby'] );
+	if ( in_array( $orderby, array( 'subscriber_id', 'artist_profile_id', 'subscriber_email', 'username', 'subscribed_at', 'exported' ), true ) ) {
+		$sql .= ' ORDER BY ' . $orderby . ( 'ASC' === strtoupper( $args['order'] ) ? ' ASC' : ' DESC' );
+	}
 
-    // Add order by clause
-    $orderby = sanitize_sql_orderby( $args['orderby'] ); // Sanitize orderby input
-    $order = ( strtoupper( $args['order'] ) === 'ASC' ) ? 'ASC' : 'DESC';
-    if ( $orderby ) {
-         // Ensure ordering by a valid column to prevent SQL errors
-         $valid_orderby = array('subscriber_id', 'artist_profile_id', 'subscriber_email', 'username', 'subscribed_at', 'exported');
-         if ( in_array( $orderby, $valid_orderby ) ) {
-            $sql .= " ORDER BY " . $orderby . " " . $order;
-         }
-    }
+	$direct = $wpdb->get_results( $wpdb->prepare( $sql, $sql_args ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is assembled from fixed clauses and an allowlisted order column.
+	if ( ! is_array( $direct ) ) {
+		return new WP_Error( 'artist_subscribers_read_failed', __( 'Subscriber data could not be loaded.', 'extrachill-artist-platform' ) );
+	}
 
-    // Add limit and offset
-    if ( $args['limit'] > 0 ) {
-        $sql .= " LIMIT %d";
-        $sql_args[] = absint( $args['limit'] );
-        if ( $args['offset'] >= 0 ) {
-            $sql .= " OFFSET %d";
-            $sql_args[] = absint( $args['offset'] );
-        }
-    }
+	$subscribers = $direct;
+	if ( $canonical_enabled ) {
+		$canonical = extrachill_artist_get_canonical_email_subscribers( $artist_id );
+		if ( is_wp_error( $canonical ) ) {
+			return $canonical;
+		}
+		$subscribers = extrachill_artist_merge_subscriber_sources( $direct, $canonical );
+	}
 
-    // Prepare and execute the query
-    $query = $wpdb->prepare( $sql, $sql_args );
-    $subscribers = $wpdb->get_results( $query );
-
-    return is_array( $subscribers ) ? $subscribers : array();
+	$offset = max( 0, absint( $args['offset'] ) );
+	$limit  = (int) $args['limit'];
+	return $limit > 0 ? array_slice( $subscribers, $offset, $limit ) : array_slice( $subscribers, $offset );
 }

--- a/tests/ArtistSubscriberConsentTest.php
+++ b/tests/ArtistSubscriberConsentTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistSubscriberConsentTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+		);
+	}
+
+	public function test_registers_exact_descriptor_and_authorization_boundary(): void {
+		$entities = extrachill_artist_register_email_sharing_identity( array() );
+
+		$this->assertSame(
+			array(
+				'taxonomy'                           => 'artist',
+				'uses_notification_email_preference' => false,
+			),
+			$entities['artist-email-sharing']
+		);
+		$this->assertTrue(
+			extrachill_artist_authorize_email_sharing_producer(
+				false,
+				'artist-platform-subscriber-list-export',
+				array( 'entity_type' => 'artist-email-sharing', 'taxonomy' => 'artist', 'slug' => 'susto' ),
+				'email'
+			)
+		);
+		$this->assertFalse( extrachill_artist_authorize_email_sharing_producer( false, 'other-producer', array( 'entity_type' => 'artist-email-sharing', 'taxonomy' => 'artist' ), 'email' ) );
+		$this->assertFalse( extrachill_artist_authorize_email_sharing_producer( false, 'artist-platform-subscriber-list-export', array( 'entity_type' => 'artist', 'taxonomy' => 'artist' ), 'email' ) );
+		$this->assertFalse( extrachill_artist_authorize_email_sharing_producer( false, 'artist-platform-subscriber-list-export', array( 'entity_type' => 'artist-email-sharing', 'taxonomy' => 'artist' ), 'notification' ) );
+	}
+
+	public function test_mixed_sources_deduplicate_and_preserve_direct_row(): void {
+		$direct = (object) array(
+			'subscriber_id'    => 17,
+			'subscriber_email' => ' Listener@Example.com ',
+			'source'           => 'artist_subscribe_form',
+			'exported'         => 0,
+		);
+		$canonical = (object) array(
+			'subscriber_id'    => 0,
+			'subscriber_email' => 'listener@example.com',
+			'source'           => 'entity_subscription',
+			'exported'         => 0,
+		);
+
+		$merged = extrachill_artist_merge_subscriber_sources( array( $direct ), array( $canonical ) );
+
+		$this->assertCount( 1, $merged );
+		$this->assertSame( 17, $merged[0]->subscriber_id );
+		$this->assertSame( 'listener@example.com', $merged[0]->subscriber_email );
+	}
+
+	public function test_current_account_email_and_revocation_are_resolved_each_time(): void {
+		$this->bind_artist( 42, 9, 'futurebirds' );
+		$GLOBALS['ec_test']['users'][7] = (object) array(
+			'ID'         => 7,
+			'user_login' => 'listener',
+			'user_email' => 'first@example.com',
+		);
+		$GLOBALS['ec_test']['entity_subscription_recipients']['futurebirds'] = array( 7 );
+
+		$first = extrachill_artist_get_canonical_email_subscribers( 42 );
+		$GLOBALS['ec_test']['users'][7]->user_email = 'current@example.com';
+		$changed = extrachill_artist_get_canonical_email_subscribers( 42 );
+		$GLOBALS['ec_test']['entity_subscription_recipients']['futurebirds'] = array();
+		$revoked = extrachill_artist_get_canonical_email_subscribers( 42 );
+
+		$this->assertSame( 'first@example.com', $first[0]->subscriber_email );
+		$this->assertSame( 'current@example.com', $changed[0]->subscriber_email );
+		$this->assertSame( array(), $revoked );
+		$this->assertSame( 'artist-email-sharing', $GLOBALS['ec_test']['recipient_resolution_calls'][0]['entity_type'] );
+	}
+
+	public function test_anonymous_direct_rows_remain_independent(): void {
+		$direct = (object) array(
+			'subscriber_id'    => 23,
+			'user_id'          => null,
+			'subscriber_email' => 'anonymous@example.com',
+			'source'           => 'artist_subscribe_form',
+			'exported'         => 0,
+		);
+
+		$this->assertSame( array( $direct ), extrachill_artist_merge_subscriber_sources( array( $direct ), array() ) );
+	}
+
+	public function test_list_handler_rejects_unauthorized_artist_before_reading(): void {
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		$result = extrachill_artist_platform_ability_artist_list_subscribers( array( 'id' => 42 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'artist_access_denied', $result->get_error_code() );
+	}
+
+	public function test_canonical_rows_have_no_local_export_bookkeeping_id(): void {
+		$this->bind_artist( 42, 9, 'susto' );
+		$GLOBALS['ec_test']['entity_subscription_recipients']['susto'] = array( 7 );
+
+		$subscribers = extrachill_artist_get_canonical_email_subscribers( 42 );
+		$direct      = (object) array( 'subscriber_id' => 31, 'exported' => 0 );
+
+		$this->assertSame( 0, $subscribers[0]->subscriber_id );
+		$this->assertSame( 'entity_subscription', $subscribers[0]->source );
+		$this->assertSame( array( 31 ), extrachill_artist_subscriber_ids_to_mark_exported( array( $direct, $subscribers[0] ), false ) );
+		$this->assertSame( array(), extrachill_artist_subscriber_ids_to_mark_exported( array( $direct, $subscribers[0] ), true ) );
+	}
+
+	private function bind_artist( int $profile_id, int $term_id, string $slug ): void {
+		$GLOBALS['ec_test']['blogs'][4]['posts'][ $profile_id ] = (object) array(
+			'ID'          => $profile_id,
+			'post_type'   => 'artist_profile',
+			'post_status' => 'publish',
+			'post_name'   => $slug,
+			'post_title'  => ucfirst( $slug ),
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][ $profile_id ]['_artist_term_id'] = $term_id;
+		$term           = new WP_Term();
+		$term->term_id  = $term_id;
+		$term->taxonomy = 'artist';
+		$term->slug     = $slug;
+		$term->name     = ucfirst( $slug );
+		$GLOBALS['ec_test']['blogs'][1]['terms'][ $term_id ] = $term;
+		$GLOBALS['ec_test']['blogs'][1]['term_meta'][ $term_id ]['_artist_profile_id'] = $profile_id;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -34,6 +34,9 @@ class WP_Error {
 	}
 }
 
+class WP_Term {
+}
+
 class EcTestWpdb {
 	public $last_error = '';
 	public $options    = 'wp_options';
@@ -819,6 +822,11 @@ function get_userdata( $user_id ) {
 	);
 }
 
+function extrachill_users_entity_subscription_recipients( $producer, $entity_type, $taxonomy, $slug, $delivery ) {
+	$GLOBALS['ec_test']['recipient_resolution_calls'][] = compact( 'producer', 'entity_type', 'taxonomy', 'slug', 'delivery' );
+	return $GLOBALS['ec_test']['entity_subscription_recipients'][ $slug ] ?? array();
+}
+
 function apply_filters( $hook_name, $value, ...$args ) {
 	if ( 'extrachill_allow_external_artist_onboarding' === $hook_name ) {
 		return ! empty( $GLOBALS['ec_test']['allow_external_artist_onboarding'] );
@@ -927,6 +935,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/local-support/availability.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-term-binding.php';
+require_once dirname( __DIR__ ) . '/inc/artist-profiles/subscribe-data-functions.php';
 require_once dirname( __DIR__ ) . '/inc/artist-profiles/frontend/shows-section.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/registry.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/update-artist.php';
@@ -937,6 +946,7 @@ require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-social-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-export-subscribers.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-list-subscribers.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-local-support.php';
 require_once dirname( __DIR__ ) . '/inc/core/actions/save.php';
 require_once dirname( __DIR__ ) . '/inc/core/platform-artist-provisioning.php';


### PR DESCRIPTION
## Summary
- register the exact `artist-email-sharing/artist/<canonical-term-slug>` descriptor with notification-email preference bypassed for explicit sharing consent
- authorize only the private `artist-platform-subscriber-list-export` producer for that purpose, taxonomy, and email delivery boundary
- resolve current consenting user IDs through Users, resolve current account emails locally, then merge them with direct `artist_subscribers` rows by normalized email
- exclude legacy `platform_follow_consent` rows once the canonical Users resolver is available, while retaining bounded pre-contract compatibility reads until Users is deployed
- preserve direct/anonymous signup rows and local export bookkeeping without assigning canonical consent a local subscriber/export identity

## Behavior
- revocation and account email changes are reflected on every list/export read
- direct product-owned rows win mixed-source deduplication so their export state remains attached
- canonical account consent is never persisted or marked exported in Artist Platform
- `artist/artist/<slug>` update subscriptions remain a separate purpose and do not imply email-sharing consent
- list and export retain artist ownership checks, and recipient enumeration remains private behind the exact producer contract
- this PR does not run or apply the Users-owned legacy migration

## Verification
- `vendor/bin/phpunit`: 155 tests, 945 assertions passed
- Homeboy changed-file lint: PHPCS passed; PHPStan level 7 passed
- Homeboy PR audit: passed with no introduced findings
- `npm run build`: passed
- repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by pre-existing frontend debt (2,026 JS errors and 1,566 CSS errors); this PHP-only change introduces no frontend files
- Homeboy changed-test selection ran the six focused tests successfully but its aggregate adapter reported the other 149 unselected tests as failures; the direct full PHPUnit result above is clean

Closes #157