### PR TITLE
fix: enforce artist ability object authorization

### DIFF
--- a/inc/abilities/handlers/artist-get-analytics.php
+++ b/inc/abilities/handlers/artist-get-analytics.php
@@ -28,6 +28,10 @@ function extrachill_artist_platform_ability_artist_get_analytics( array $input )
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( ! function_exists( 'ec_get_link_page_for_artist' ) ) {
 		return new WP_Error( 'dependency_missing', 'Artist platform not active.' );
 	}

--- a/inc/abilities/handlers/artist-get-links.php
+++ b/inc/abilities/handlers/artist-get-links.php
@@ -24,6 +24,10 @@ function extrachill_artist_platform_ability_artist_get_links( array $input ): ar
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( ! function_exists( 'ec_get_link_page_data' ) ) {
 		return new WP_Error( 'dependency_missing', 'Link page data function not available.' );
 	}

--- a/inc/abilities/handlers/artist-get-permissions.php
+++ b/inc/abilities/handlers/artist-get-permissions.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  */
 function extrachill_artist_platform_ability_artist_get_permissions( array $input ): array|WP_Error {
 	$artist_id       = isset( $input['id'] ) ? (int) $input['id'] : 0;
-	$current_user_id = get_current_user_id();
+	$current_user_id = extrachill_artist_platform_ability_acting_user_id();
 	$can_edit        = false;
 	$manage_url      = '';
 
@@ -27,7 +27,13 @@ function extrachill_artist_platform_ability_artist_get_permissions( array $input
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
-	if ( $artist_id && $current_user_id && function_exists( 'ec_can_manage_artist' ) && ec_can_manage_artist( $current_user_id, $artist_id ) ) {
+	if ( $artist_id && $current_user_id && function_exists( 'ec_user_can' ) && ec_user_can(
+		'manage_artist',
+		array(
+			'artist_id' => $artist_id,
+			'user_id'   => $current_user_id,
+		)
+	) ) {
 		$can_edit   = true;
 		$manage_url = home_url( '/manage-link-page/' );
 	}

--- a/inc/abilities/handlers/artist-get-roster.php
+++ b/inc/abilities/handlers/artist-get-roster.php
@@ -24,6 +24,10 @@ function extrachill_artist_platform_ability_artist_get_roster( array $input ): a
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Invalid artist specified.' );
 	}

--- a/inc/abilities/handlers/artist-list-socials.php
+++ b/inc/abilities/handlers/artist-list-socials.php
@@ -24,6 +24,10 @@ function extrachill_artist_platform_ability_artist_list_socials( array $input ):
 		return new WP_Error( 'missing_id', 'id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}

--- a/inc/abilities/handlers/artist-local-support.php
+++ b/inc/abilities/handlers/artist-local-support.php
@@ -26,7 +26,7 @@ function extrachill_artist_platform_ability_update_local_support_availability( $
 		absint( $input['id'] ?? 0 ),
 		! empty( $input['available'] ),
 		array_key_exists( 'scene_slug', $input ) ? (string) $input['scene_slug'] : null,
-		get_current_user_id()
+		extrachill_artist_platform_ability_acting_user_id()
 	);
 }
 

--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -32,7 +32,7 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	$bio        = isset( $input['bio'] ) ? wp_kses_post( wp_unslash( $input['bio'] ) ) : '';
 	$local_city = isset( $input['local_city'] ) ? sanitize_text_field( wp_unslash( $input['local_city'] ) ) : '';
 	$genre      = isset( $input['genre'] ) ? sanitize_text_field( wp_unslash( $input['genre'] ) ) : '';
-	$user_id    = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : get_current_user_id();
+	$user_id    = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : extrachill_artist_platform_ability_acting_user_id();
 
 	if ( ! extrachill_artist_platform_ability_create_permission( $input ) ) {
 		return new WP_Error( 'artist_access_denied', 'You are not allowed to create an artist for this user.' );
@@ -136,9 +136,8 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 
 	restore_current_blog();
 
-	$get_ability = wp_get_ability( 'extrachill/get-artist-data' );
-	if ( $get_ability ) {
-		return $get_ability->execute( array( 'artist_id' => $artist_id ) );
+	if ( function_exists( 'extrachill_artist_platform_read_artist_data' ) ) {
+		return extrachill_artist_platform_read_artist_data( $artist_id );
 	}
 
 	return array(

--- a/inc/abilities/handlers/get-artist-data.php
+++ b/inc/abilities/handlers/get-artist-data.php
@@ -21,6 +21,20 @@ function extrachill_artist_platform_ability_get_artist_data( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
+	return extrachill_artist_platform_read_artist_data( $artist_id );
+}
+
+/**
+ * Read artist data after the caller has authorized the operation.
+ *
+ * @param int $artist_id Artist profile post ID.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_read_artist_data( $artist_id ) {
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 	$did_switch     = false;
 
@@ -31,7 +45,7 @@ function extrachill_artist_platform_ability_get_artist_data( $input ) {
 
 	$artist = get_post( $artist_id );
 
-	if ( ! $artist || $artist->post_type !== 'artist_profile' ) {
+	if ( ! $artist || 'artist_profile' !== $artist->post_type || 'publish' !== $artist->post_status ) {
 		if ( $did_switch ) {
 			restore_current_blog();
 		}
@@ -61,8 +75,8 @@ function extrachill_artist_platform_ability_get_artist_data( $input ) {
 		'name'              => $artist->post_title,
 		'slug'              => $artist->post_name,
 		'bio'               => $artist->post_content,
-		'local_city'        => $local_city !== '' ? $local_city : null,
-		'genre'             => $genre !== '' ? $genre : null,
+		'local_city'        => '' !== $local_city ? $local_city : null,
+		'genre'             => '' !== $genre ? $genre : null,
 		'profile_image_id'  => $profile_image_id ? (int) $profile_image_id : null,
 		'profile_image_url' => $profile_image_url,
 		'header_image_id'   => $header_image_id ? (int) $header_image_id : null,

--- a/inc/abilities/handlers/get-link-page-data.php
+++ b/inc/abilities/handlers/get-link-page-data.php
@@ -22,6 +22,14 @@ function extrachill_artist_platform_ability_get_link_page_data( $input ) {
 		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
 	}
 
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+
+	if ( $link_page_id && ! extrachill_artist_platform_ability_link_page_belongs_to_artist( $artist_id, $link_page_id ) ) {
+		return new WP_Error( 'invalid_link_page', 'The link page does not belong to this artist.' );
+	}
+
 	$data = ec_get_link_page_data( $artist_id, $link_page_id );
 
 	if ( empty( $data ) || empty( $data['link_page_id'] ) ) {

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -11,22 +11,101 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Permission callback for artist platform abilities that require management access.
  *
- * Allows WP-CLI, Action Scheduler, and network admins unconditionally.
- * For other contexts the caller must supply artist_id via the input array
- * so that ec_can_manage_artist() can check membership.
+ * Delegated principals are bounded to their acting user and capability ceiling.
+ * Direct WP-CLI and Action Scheduler execution retain the existing trusted path.
  *
  * @return bool
  */
 function extrachill_artist_platform_ability_admin_permission() {
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		return true;
+	$actor = extrachill_artist_platform_ability_actor( 'manage_network_options' );
+
+	return $actor['trusted_system'] || ( $actor['user_id'] && user_can( $actor['user_id'], 'manage_network_options' ) );
+}
+
+/**
+ * Resolve the trusted actor for an ability execution.
+ *
+ * A resolved Agents API principal takes precedence over the ambient WordPress
+ * session. This prevents a delegated runtime from inheriting the capabilities
+ * of a more privileged logged-in user.
+ *
+ * @param string $capability Capability required by a delegated principal ceiling.
+ * @return array{user_id:int,trusted_system:bool}
+ */
+function extrachill_artist_platform_ability_actor( $capability ) {
+	$principal_class = '\\AgentsAPI\\AI\\WP_Agent_Execution_Principal';
+	$principal       = null;
+
+	if ( class_exists( $principal_class ) ) {
+		$request_context = ( defined( 'WP_CLI' ) && WP_CLI ) ? 'cli' : ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ? 'cron' : 'rest' );
+		try {
+			$principal = $principal_class::resolve( array( 'request_context' => $request_context ) );
+		} catch ( Throwable $throwable ) {
+			return array(
+				'user_id'        => 0,
+				'trusted_system' => false,
+			);
+		}
 	}
 
-	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
-		return true;
+	if ( $principal ) {
+		$trusted_system = 0 === (int) $principal->acting_user_id
+			&& 'system' === (string) $principal->auth_source
+			&& in_array( (string) $principal->request_context, array( 'cli', 'cron' ), true );
+
+		if ( $trusted_system ) {
+			return array(
+				'user_id'        => 0,
+				'trusted_system' => true,
+			);
+		}
+
+		$user_id = (int) $principal->acting_user_id;
+		$ceiling = $principal->capability_ceiling;
+		if ( $user_id <= 0 ) {
+			return array(
+				'user_id'        => 0,
+				'trusted_system' => false,
+			);
+		}
+
+		if ( $ceiling instanceof WP_Agent_Capability_Ceiling ) {
+			if ( (int) $ceiling->user_id !== $user_id || ! $ceiling->allows_capability( $capability ) ) {
+				return array(
+					'user_id'        => 0,
+					'trusted_system' => false,
+				);
+			}
+		}
+
+		return array(
+			'user_id'        => $user_id,
+			'trusted_system' => false,
+		);
 	}
 
-	return current_user_can( 'manage_network_options' );
+	if ( ( defined( 'WP_CLI' ) && WP_CLI ) || ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) ) {
+		return array(
+			'user_id'        => get_current_user_id(),
+			'trusted_system' => true,
+		);
+	}
+
+	return array(
+		'user_id'        => get_current_user_id(),
+		'trusted_system' => false,
+	);
+}
+
+/**
+ * Return the trusted acting user rather than an ambient delegated session.
+ *
+ * @return int
+ */
+function extrachill_artist_platform_ability_acting_user_id() {
+	$actor = extrachill_artist_platform_ability_actor( 'manage_artist' );
+
+	return (int) $actor['user_id'];
 }
 
 /**
@@ -36,19 +115,26 @@ function extrachill_artist_platform_ability_admin_permission() {
  * @return bool
  */
 function extrachill_artist_platform_ability_artist_permission( $input ) {
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		return true;
-	}
-
-	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
-		return true;
-	}
-
 	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : absint( $input['id'] ?? 0 );
+	$actor     = extrachill_artist_platform_ability_actor( 'manage_artist' );
+
+	if ( isset( $input['user_id'] ) && absint( $input['user_id'] ) !== (int) $actor['user_id'] && ! $actor['trusted_system'] ) {
+		return false;
+	}
+
+	if ( $actor['trusted_system'] ) {
+		return (bool) $artist_id;
+	}
 
 	return $artist_id
-		&& function_exists( 'ec_can_manage_artist' )
-		&& ec_can_manage_artist( get_current_user_id(), $artist_id );
+		&& function_exists( 'ec_user_can' )
+		&& ec_user_can(
+			'manage_artist',
+			array(
+				'artist_id' => $artist_id,
+				'user_id'   => (int) $actor['user_id'],
+			)
+		);
 }
 
 /**
@@ -58,20 +144,49 @@ function extrachill_artist_platform_ability_artist_permission( $input ) {
  * @return bool
  */
 function extrachill_artist_platform_ability_create_permission( $input ) {
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		return true;
+	$actor          = extrachill_artist_platform_ability_actor( 'create_artist_profile' );
+	$actor_user_id  = (int) $actor['user_id'];
+	$target_user_id = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : $actor_user_id;
+
+	if ( $actor['trusted_system'] ) {
+		return $target_user_id > 0;
 	}
 
-	if ( class_exists( 'ActionScheduler' ) && did_action( 'action_scheduler_before_execute' ) ) {
-		return true;
+	if ( $actor_user_id <= 0 || $target_user_id <= 0 ) {
+		return false;
 	}
 
-	$current_user_id = get_current_user_id();
-	$target_user_id  = isset( $input['user_id'] ) ? absint( $input['user_id'] ) : $current_user_id;
+	if ( $actor_user_id !== $target_user_id ) {
+		return user_can( $actor_user_id, 'manage_options' ) || user_can( $actor_user_id, 'manage_network_options' );
+	}
 
-	return $current_user_id
-		&& $target_user_id
-		&& ( $current_user_id === $target_user_id || current_user_can( 'manage_options' ) || current_user_can( 'manage_network_options' ) );
+	return function_exists( 'ec_user_can' )
+		&& ec_user_can( 'create_artist_profile', array( 'user_id' => $actor_user_id ) );
+}
+
+/**
+ * Confirm an explicitly supplied link page belongs to the authorized artist.
+ *
+ * @param int $artist_id    Artist profile post ID.
+ * @param int $link_page_id Link page post ID.
+ * @return bool
+ */
+function extrachill_artist_platform_ability_link_page_belongs_to_artist( $artist_id, $link_page_id ) {
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : 0;
+	$did_switch     = $artist_blog_id && get_current_blog_id() !== (int) $artist_blog_id;
+
+	if ( $did_switch ) {
+		switch_to_blog( $artist_blog_id );
+	}
+
+	try {
+		return 'artist_link_page' === get_post_type( $link_page_id )
+			&& (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) === (int) $artist_id;
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
 }
 
 /**
@@ -81,7 +196,7 @@ function extrachill_artist_platform_ability_create_permission( $input ) {
  * @return bool
  */
 function extrachill_artist_platform_ability_local_support_producer_permission( $input ) {
-	if ( current_user_can( 'manage_network_options' ) ) {
+	if ( extrachill_artist_platform_ability_admin_permission() ) {
 		return true;
 	}
 

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -567,7 +567,9 @@ function extrachill_artist_platform_register_abilities() {
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_get_artist_platform_stats',
 			'permission_callback' => function () {
-				return current_user_can( 'manage_options' ) || ( defined( 'WP_CLI' ) && WP_CLI );
+				$actor = extrachill_artist_platform_ability_actor( 'manage_options' );
+
+				return $actor['trusted_system'] || ( $actor['user_id'] && user_can( $actor['user_id'], 'manage_options' ) );
 			},
 			'meta'                => array(
 				'show_in_rest' => true,

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -8,28 +8,33 @@ final class AbilityAuthorizationTest extends TestCase {
 		extrachill_artist_platform_register_abilities();
 	}
 
-	public function test_artist_owned_abilities_use_target_aware_permissions(): void {
-		$abilities = array(
-			'extrachill/get-artist-data'            => array( 'artist_id' => 42 ),
-			'extrachill/get-link-page-data'         => array( 'artist_id' => 42 ),
-			'extrachill/update-artist'              => array( 'artist_id' => 42 ),
-			'extrachill/save-link-page-links'       => array( 'artist_id' => 42 ),
-			'extrachill/save-link-page-styles'      => array( 'artist_id' => 42 ),
-			'extrachill/save-link-page-settings'    => array( 'artist_id' => 42 ),
-			'extrachill/save-social-links'          => array( 'artist_id' => 42 ),
-			'extrachill/artist-update-links'        => array( 'id' => 42 ),
-			'extrachill/artist-get-links'           => array( 'id' => 42 ),
-			'extrachill/artist-get-roster'          => array( 'id' => 42 ),
-			'extrachill/artist-list-socials'        => array( 'id' => 42 ),
-			'extrachill/artist-create-social'       => array( 'id' => 42 ),
-			'extrachill/artist-update-social'       => array( 'id' => 42 ),
-			'extrachill/artist-delete-social'       => array( 'id' => 42 ),
-			'extrachill/artist-list-subscribers'    => array( 'id' => 42 ),
-			'extrachill/artist-export-subscribers'  => array( 'id' => 42 ),
-			'extrachill/artist-get-analytics'       => array( 'id' => 42 ),
+	private function artistAbilityMatrix(): array {
+		return array(
+			'extrachill/get-artist-data' => array( array( 'artist_id' => 42 ), 'extrachill_artist_platform_ability_get_artist_data' ),
+			'extrachill/get-link-page-data' => array( array( 'artist_id' => 42 ), 'extrachill_artist_platform_ability_get_link_page_data' ),
+			'extrachill/update-artist' => array( array( 'artist_id' => 42, 'name' => 'Band' ), 'extrachill_artist_platform_ability_update_artist' ),
+			'extrachill/save-link-page-links' => array( array( 'artist_id' => 42, 'links' => array() ), 'extrachill_artist_platform_ability_save_link_page_links' ),
+			'extrachill/save-link-page-styles' => array( array( 'artist_id' => 42, 'css_vars' => array() ), 'extrachill_artist_platform_ability_save_link_page_styles' ),
+			'extrachill/save-link-page-settings' => array( array( 'artist_id' => 42, 'bio' => 'Bio' ), 'extrachill_artist_platform_ability_save_link_page_settings' ),
+			'extrachill/save-social-links' => array( array( 'artist_id' => 42, 'social_links' => array() ), 'extrachill_artist_platform_ability_save_social_links' ),
+			'extrachill/artist-get-links' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_get_links' ),
+			'extrachill/artist-get-local-support-availability' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_get_local_support_availability' ),
+			'extrachill/artist-update-local-support-availability' => array( array( 'id' => 42, 'available' => true ), 'extrachill_artist_platform_ability_update_local_support_availability' ),
+			'extrachill/artist-update-links' => array( array( 'id' => 42, 'links' => array() ), 'extrachill_artist_platform_ability_artist_update_links' ),
+			'extrachill/artist-get-roster' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_get_roster' ),
+			'extrachill/artist-list-socials' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_list_socials' ),
+			'extrachill/artist-create-social' => array( array( 'id' => 42, 'type' => 'website', 'url' => 'https://example.com' ), 'extrachill_artist_platform_ability_artist_create_social' ),
+			'extrachill/artist-update-social' => array( array( 'id' => 42, 'social_id' => '42-social-1' ), 'extrachill_artist_platform_ability_artist_update_social' ),
+			'extrachill/artist-delete-social' => array( array( 'id' => 42, 'social_id' => '42-social-1' ), 'extrachill_artist_platform_ability_artist_delete_social' ),
+			'extrachill/artist-list-subscribers' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_list_subscribers' ),
+			'extrachill/artist-export-subscribers' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_export_subscribers' ),
+			'extrachill/artist-get-analytics' => array( array( 'id' => 42 ), 'extrachill_artist_platform_ability_artist_get_analytics' ),
 		);
+	}
 
-		foreach ( $abilities as $name => $input ) {
+	public function test_artist_owned_abilities_use_target_aware_permissions(): void {
+		foreach ( $this->artistAbilityMatrix() as $name => [ $input ] ) {
+
 			$ability = wp_get_ability( $name );
 			$this->assertFalse( $ability->check_permissions( $input ), $name . ' allowed an anonymous user.' );
 
@@ -39,13 +44,127 @@ final class AbilityAuthorizationTest extends TestCase {
 			$GLOBALS['ec_test']['managed_artists'][7] = array( 42 );
 			$this->assertTrue( $ability->check_permissions( $input ), $name . ' denied the artist owner.' );
 
-			$GLOBALS['ec_test']['current_user_id']          = 9;
+			$GLOBALS['ec_test']['current_user_id'] = 9;
 			$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
 			$this->assertTrue( $ability->check_permissions( $input ), $name . ' denied an administrator.' );
 
 			$GLOBALS['ec_test']['current_user_id'] = 0;
 			$GLOBALS['ec_test']['capabilities']    = array();
 			$GLOBALS['ec_test']['managed_artists'] = array();
+		}
+	}
+
+	public function test_every_sensitive_registration_uses_an_approved_permission_contract(): void {
+		$public = array(
+			'extrachill/onboard-external-artist',
+			'extrachill/artist-invitation',
+			'extrachill/artists-list',
+			'extrachill/artist-get',
+			'extrachill/artist-get-permissions',
+			'extrachill/artist-subscribe',
+			'extrachill/artist-query-local-support-candidates',
+		);
+		$special = array(
+			'extrachill/create-artist',
+			'extrachill/get-artist-platform-stats',
+			'extrachill/admin-list-artist-relationships',
+			'extrachill/admin-link-artist-relationship',
+			'extrachill/admin-unlink-artist-relationship',
+			'extrachill/admin-list-orphan-artist-relationships',
+			'extrachill/admin-cleanup-artist-relationships',
+		);
+
+		$expected_artist_abilities = array_keys( $this->artistAbilityMatrix() );
+		$actual_artist_abilities   = array();
+		foreach ( $GLOBALS['ec_test']['abilities'] as $name => $ability ) {
+			if ( 'extrachill_artist_platform_ability_artist_permission' === $ability->get_permission_callback() ) {
+				$actual_artist_abilities[] = $name;
+				continue;
+			}
+
+			$this->assertContains( $name, array_merge( $public, $special ), $name . ' introduced an unclassified authorization contract.' );
+		}
+
+		sort( $expected_artist_abilities );
+		sort( $actual_artist_abilities );
+		$this->assertSame( $expected_artist_abilities, $actual_artist_abilities );
+	}
+
+	public function test_handlers_fail_closed_when_called_directly(): void {
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		foreach ( $this->artistAbilityMatrix() as $name => [ $input, $handler ] ) {
+			$result = $handler( $input );
+			$this->assertInstanceOf( WP_Error::class, $result, $name . ' direct callback did not fail closed.' );
+			$this->assertSame( 'artist_access_denied', $result->get_error_code(), $name . ' returned the wrong denial.' );
+		}
+	}
+
+	public function test_execution_principal_overrides_ambient_session_and_enforces_ceiling(): void {
+		$GLOBALS['ec_test']['current_user_id']      = 1;
+		$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
+		$GLOBALS['ec_test']['managed_artists'][7]   = array( 42 );
+		$ability = wp_get_ability( 'extrachill/update-artist' );
+		$input   = array( 'artist_id' => 42, 'name' => 'Band' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 8 );
+		$this->assertFalse( $ability->check_permissions( $input ), 'Ambient administrator leaked into an unrelated principal.' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, 'agent_token', 'rest', new WP_Agent_Capability_Ceiling( 7, array() ) );
+		$this->assertFalse( $ability->check_permissions( $input ), 'Restricted principal exceeded its capability ceiling.' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, 'agent_token', 'rest', new WP_Agent_Capability_Ceiling( 8, array( 'manage_artist' ) ) );
+		$this->assertFalse( $ability->check_permissions( $input ), 'Mismatched ceiling identity was accepted.' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, 'agent_token', 'rest', new WP_Agent_Capability_Ceiling( 7, array( 'manage_artist' ) ) );
+		$this->assertTrue( $ability->check_permissions( $input ) );
+		$this->assertFalse( $ability->check_permissions( $input + array( 'user_id' => 8 ) ), 'Spoofed user_id was accepted.' );
+	}
+
+	public function test_system_principal_preserves_trusted_cli_execution_only(): void {
+		$ability = wp_get_ability( 'extrachill/update-artist' );
+		$input   = array( 'artist_id' => 42, 'name' => 'Band' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 0, 'system', 'cli' );
+		$this->assertTrue( $ability->check_permissions( $input ) );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 0, 'runtime', 'runtime' );
+		$this->assertFalse( $ability->check_permissions( $input ) );
+	}
+
+	public function test_missing_and_unpublished_targets_fail_canonical_authorization(): void {
+		$GLOBALS['ec_test']['current_user_id']       = 7;
+		$GLOBALS['ec_test']['managed_artists'][7]    = array( 42, 43 );
+		$GLOBALS['ec_test']['strict_artist_objects'] = true;
+		$GLOBALS['ec_test']['blogs'][4]['posts'][43] = (object) array( 'ID' => 43, 'post_type' => 'artist_profile', 'post_status' => 'draft' );
+
+		$this->assertFalse( wp_get_ability( 'extrachill/update-artist' )->check_permissions( array( 'artist_id' => 42 ) ) );
+		$this->assertFalse( wp_get_ability( 'extrachill/update-artist' )->check_permissions( array( 'artist_id' => 43 ) ) );
+	}
+
+	public function test_explicit_link_page_must_map_to_the_authorized_artist(): void {
+		$GLOBALS['ec_test']['current_user_id']    = 7;
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 42 );
+		$GLOBALS['ec_test']['blogs'][4] = array(
+			'posts' => array(
+				42 => (object) array( 'ID' => 42, 'post_type' => 'artist_profile', 'post_status' => 'publish' ),
+				99 => (object) array( 'ID' => 99, 'post_type' => 'artist_link_page', 'post_status' => 'publish' ),
+			),
+			'post_meta' => array( 99 => array( '_associated_artist_profile_id' => 84 ) ),
+		);
+
+		$result = extrachill_artist_platform_ability_get_link_page_data( array( 'artist_id' => 42, 'link_page_id' => 99 ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_link_page', $result->get_error_code() );
+	}
+
+	public function test_rest_exposed_sensitive_abilities_deny_unrelated_users_before_handlers(): void {
+		$GLOBALS['ec_test']['current_user_id'] = 7;
+
+		foreach ( $this->artistAbilityMatrix() as $name => [ $input ] ) {
+			$ability = wp_get_ability( $name );
+			$this->assertTrue( $ability->get_meta()['show_in_rest'], $name . ' is expected on the ability REST route.' );
+			$this->assertSame( 'ability_permission_denied', $ability->execute( $input )->get_error_code(), $name . ' REST execution was not denied.' );
 		}
 	}
 
@@ -61,6 +180,20 @@ final class AbilityAuthorizationTest extends TestCase {
 
 		$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
 		$this->assertTrue( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 8 ) ) );
+	}
+
+	public function test_create_artist_binds_user_claim_to_the_execution_principal(): void {
+		$GLOBALS['ec_test']['current_user_id'] = 1;
+		$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
+		$ability = wp_get_ability( 'extrachill/create-artist' );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, 'agent_token', 'rest', new WP_Agent_Capability_Ceiling( 7, array( 'create_artist_profile' ) ) );
+		$this->assertTrue( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 7 ) ) );
+		$this->assertFalse( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 8 ) ) );
+		$this->assertSame( 'artist_access_denied', extrachill_artist_platform_ability_create_artist( array( 'name' => 'Band', 'user_id' => 8 ) )->get_error_code() );
+
+		$GLOBALS['ec_test']['execution_principal'] = new AgentsAPI\AI\WP_Agent_Execution_Principal( 7, 'agent_token', 'rest', new WP_Agent_Capability_Ceiling( 7, array() ) );
+		$this->assertFalse( $ability->check_permissions( array( 'name' => 'Band', 'user_id' => 7 ) ) );
 	}
 
 	public function test_create_artist_rolls_back_profile_when_membership_fails(): void {
@@ -104,25 +237,6 @@ final class AbilityAuthorizationTest extends TestCase {
 
 		foreach ( $abilities as $name => $input ) {
 			$this->assertTrue( wp_get_ability( $name )->check_permissions( $input ), $name . ' is intentionally public.' );
-		}
-	}
-
-	public function test_artist_mutation_handlers_recheck_access_before_state_changes(): void {
-		$GLOBALS['ec_test']['current_user_id'] = 7;
-
-		$mutations = array(
-			'extrachill_artist_platform_ability_create_artist' => array( 'name' => 'Band', 'user_id' => 8 ),
-			'extrachill_artist_platform_ability_update_artist' => array( 'artist_id' => 42, 'name' => 'Unauthorized Rename' ),
-			'extrachill_artist_platform_ability_save_link_page_links' => array( 'artist_id' => 42, 'links' => array() ),
-			'extrachill_artist_platform_ability_save_social_links' => array( 'artist_id' => 42, 'social_links' => array() ),
-			'extrachill_artist_platform_ability_artist_export_subscribers' => array( 'id' => 42 ),
-		);
-
-		foreach ( $mutations as $handler => $input ) {
-			$result = $handler( $input );
-
-			$this->assertInstanceOf( WP_Error::class, $result, $handler . ' did not fail closed.' );
-			$this->assertSame( 'artist_access_denied', $result->get_error_code(), $handler . ' returned the wrong denial.' );
 		}
 	}
 

--- a/tests/AdminArtistRelationshipsTest.php
+++ b/tests/AdminArtistRelationshipsTest.php
@@ -7,6 +7,7 @@ final class AdminArtistRelationshipsTest extends TestCase {
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 4,
 			'blog_stack'      => array(),
+			'current_user_id' => 1,
 			'blogs'           => array(
 				4 => array(
 					'posts' => array(

--- a/tests/ArtistMembershipContractTest.php
+++ b/tests/ArtistMembershipContractTest.php
@@ -9,6 +9,7 @@ final class ArtistMembershipContractTest extends TestCase {
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 1,
 			'blog_stack'      => array(),
+			'current_user_id' => 1,
 			'blogs'           => array(
 				4 => array(
 					'posts' => array(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__ . '/fixtures/ExecutionPrincipal.php';
+
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'OBJECT', 'OBJECT' );
 define( 'MINUTE_IN_SECONDS', 60 );
@@ -218,6 +220,10 @@ class EcTestRegisteredAbility {
 	public function get_output_schema() {
 		return $this->args['output_schema'] ?? array();
 	}
+
+	public function get_permission_callback() {
+		return $this->args['permission_callback'];
+	}
 }
 
 function wp_register_ability( $name, $args ) {
@@ -241,6 +247,10 @@ function current_user_can( $capability ) {
 }
 
 function user_can( $user_id, $capability ) {
+	if ( (int) $user_id === get_current_user_id() && ! empty( $GLOBALS['ec_test']['capabilities'][ $capability ] ) ) {
+		return true;
+	}
+
 	return ! empty( $GLOBALS['ec_test']['user_capabilities'][ (int) $user_id ][ $capability ] );
 }
 
@@ -272,11 +282,32 @@ function did_action( $hook_name ) {
 }
 
 function ec_can_manage_artist( $user_id, $artist_id ) {
-	if ( ! empty( $GLOBALS['ec_test']['capabilities']['manage_options'] ) ) {
+	if ( user_can( $user_id, 'manage_options' ) ) {
 		return true;
 	}
 
+	if ( ! empty( $GLOBALS['ec_test']['strict_artist_objects'] ) ) {
+		$artist = get_post( $artist_id );
+		if ( ! $artist || 'artist_profile' !== ( $artist->post_type ?? '' ) || 'publish' !== ( $artist->post_status ?? '' ) ) {
+			return false;
+		}
+	}
+
 	return in_array( (int) $artist_id, $GLOBALS['ec_test']['managed_artists'][ (int) $user_id ] ?? array(), true );
+}
+
+function ec_user_can( $capability, array $context = array() ) {
+	$user_id = isset( $context['user_id'] ) ? (int) $context['user_id'] : get_current_user_id();
+
+	if ( 'manage_artist' === $capability ) {
+		return ec_can_manage_artist( $user_id, (int) ( $context['artist_id'] ?? 0 ) );
+	}
+
+	if ( 'create_artist_profile' === $capability ) {
+		return $user_id > 0 && empty( $GLOBALS['ec_test']['cannot_create_artist'][ $user_id ] );
+	}
+
+	return user_can( $user_id, $capability );
 }
 
 function sanitize_text_field( $value ) {
@@ -828,6 +859,9 @@ function extrachill_users_entity_subscription_recipients( $producer, $entity_typ
 }
 
 function apply_filters( $hook_name, $value, ...$args ) {
+	if ( 'agents_api_execution_principal' === $hook_name ) {
+		return $GLOBALS['ec_test']['execution_principal'] ?? $value;
+	}
 	if ( 'extrachill_allow_external_artist_onboarding' === $hook_name ) {
 		return ! empty( $GLOBALS['ec_test']['allow_external_artist_onboarding'] );
 	}
@@ -944,9 +978,22 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/onboard-external-arti
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-invitation.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-styles.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-settings.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-social-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/get-artist-data.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/get-link-page-data.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-update-links.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get-permissions.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get-roster.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-list-socials.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-create-social.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-update-social.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-delete-social.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-export-subscribers.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-list-subscribers.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get-analytics.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-local-support.php';
 require_once dirname( __DIR__ ) . '/inc/core/actions/save.php';
 require_once dirname( __DIR__ ) . '/inc/core/platform-artist-provisioning.php';

--- a/tests/fixtures/ExecutionPrincipal.php
+++ b/tests/fixtures/ExecutionPrincipal.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace {
+	final class WP_Agent_Capability_Ceiling {
+		public int $user_id;
+		public ?array $allowed_capabilities;
+
+		public function __construct( int $user_id, ?array $allowed_capabilities = null ) {
+			$this->user_id              = $user_id;
+			$this->allowed_capabilities = $allowed_capabilities;
+		}
+
+		public function allows_capability( string $capability ): bool {
+			return null === $this->allowed_capabilities || in_array( $capability, $this->allowed_capabilities, true );
+		}
+	}
+}
+
+namespace AgentsAPI\AI {
+	final class WP_Agent_Execution_Principal {
+		public int $acting_user_id;
+		public string $auth_source;
+		public string $request_context;
+		public ?\WP_Agent_Capability_Ceiling $capability_ceiling;
+
+		public function __construct( int $acting_user_id, string $auth_source = 'user', string $request_context = 'rest', ?\WP_Agent_Capability_Ceiling $capability_ceiling = null ) {
+			$this->acting_user_id    = $acting_user_id;
+			$this->auth_source       = $auth_source;
+			$this->request_context   = $request_context;
+			$this->capability_ceiling = $capability_ceiling;
+		}
+
+		public static function resolve( array $request_context = array() ): ?self {
+			$principal = \apply_filters( 'agents_api_execution_principal', null, $request_context );
+
+			return $principal instanceof self ? $principal : null;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- bind artist ability authorization to the resolved Agents API acting principal instead of a potentially more privileged ambient WordPress session
- enforce canonical `ec_user_can( 'manage_artist', ... )` object authorization across all artist mutations and sensitive reads, including direct callback execution
- reject conflicting user claims and mismatched link-page ownership while preserving public reads, reciprocal members, administrators, and trusted CLI/system jobs

Closes #161

## Authorization invariants
- A resolved execution principal always takes precedence over `get_current_user_id()`.
- Delegated principals must match their capability-ceiling user and include the required `manage_artist`, `create_artist_profile`, `manage_options`, or `manage_network_options` ceiling capability.
- Non-user runtime/audience principals fail closed; only host-attested `system` principals in CLI/cron context retain the trusted system path.
- Artist access delegates to `ec_user_can( 'manage_artist', [ 'artist_id' => ..., 'user_id' => ... ] )`, preserving reciprocal membership and administrator behavior without introducing grants.
- Permission callbacks and execute handlers both authorize the target, limiting permission/execution TOCTOU and making direct callback invocation fail closed.
- Explicit `link_page_id` input must resolve to an `artist_link_page` associated with the authorized artist, with multisite context restored in `finally`.
- Artist creation binds optional `user_id` to the trusted actor unless that actor is an administrator or trusted system job.

## Audited ability matrix
Object-authorized reads:
- `extrachill/get-artist-data`
- `extrachill/get-link-page-data`
- `extrachill/artist-get-links`
- `extrachill/artist-get-local-support-availability`
- `extrachill/artist-get-roster`
- `extrachill/artist-list-socials`
- `extrachill/artist-list-subscribers`
- `extrachill/artist-get-analytics`

Object-authorized mutations/exports:
- `extrachill/update-artist`
- `extrachill/save-link-page-links`
- `extrachill/save-link-page-styles`
- `extrachill/save-link-page-settings`
- `extrachill/save-social-links`
- `extrachill/artist-update-local-support-availability`
- `extrachill/artist-update-links`
- `extrachill/artist-create-social`
- `extrachill/artist-update-social`
- `extrachill/artist-delete-social`
- `extrachill/artist-export-subscribers`

Separately audited:
- `extrachill/create-artist` now binds target identity and reauthorizes in the handler.
- admin relationship abilities, platform stats, and the private local-support producer admin path use principal-aware administrative authorization.
- intentional public reads, subscription, invitation-token, and external-onboarding contracts remain public/specialized.

## Compatibility impact
- Existing reciprocal artist members and WordPress administrators retain access.
- Existing direct WP-CLI and Action Scheduler execution remains trusted; explicit system principals are accepted only for CLI/cron.
- Existing public artist list/detail/permission reads, fan subscription, invitation tokens, and external onboarding are unchanged.
- Draft, deleted, missing, unrelated, or mismatched artist/link-page targets now fail closed.
- Delegated agents may no longer inherit an ambient admin session and must carry an appropriate capability ceiling.

## Tests
Passing:
- `vendor/bin/phpunit` (162 tests, 1,049 assertions)
- `npm run test:js` (2 suites, 5 tests)
- `npm run build`
- `php -l` for every changed PHP file
- `git diff --check`
- Homeboy audit: no introduced findings (`08663697-e9ff-4922-b2a2-1a2bce6e7388`)

Verified baseline/tooling limitations:
- `composer lint:php` cannot start because `composer.json` does not install the configured WordPress coding standard.
- repository-wide `npm run lint:js` and `npm run lint:css` report 2,026 and 1,566 existing errors respectively in untouched frontend files.
- Homeboy changed-file lint reports 119 legacy findings in touched files, primarily existing registry formatting and PHP 8 union types against the declared PHP 7.4 floor; ESLint reports zero changed-file findings.
- Homeboy test evidence hits known `Extra-Chill/homeboy#10439`: the adapter retains only `artifact://` pointers and reports `wp-codebox-unknown` (156 false failures) despite the direct PHPUnit suite passing all 162 tests.