### PR TITLE
refactor: add Link Page owner reference seam

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -67,6 +67,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/class-templates.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/owner-reference.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';

--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -17,6 +17,7 @@ define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
 
 if ( ! defined( 'EXTRCH_LINKPAGE_DEV' ) ) {
     define( 'EXTRCH_LINKPAGE_DEV', false );
@@ -68,6 +69,7 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/owner-reference.php';
+        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-compatibility.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -145,6 +145,23 @@ function ec_create_link_page( $artist_id, $force = false ) {
 	if ( is_wp_error( $owner_reference ) ) {
 		return $owner_reference;
 	}
+	if ( $force && $previous_link_page_id ) {
+		$previous_owner_references = ec_get_stored_link_page_owner_references( $previous_link_page_id );
+		if ( count( $previous_owner_references ) > 1 ) {
+			return new WP_Error(
+				'link_page_previous_detach_failed',
+				'The previous Link Page has duplicate owner references.',
+				array( 'retryable' => false )
+			);
+		}
+		if ( ! empty( $previous_owner_references ) && $owner_reference !== $previous_owner_references[0] ) {
+			return new WP_Error(
+				'link_page_previous_owner_conflict',
+				'The previous Link Page canonical owner conflicts with its legacy artist association.',
+				array( 'retryable' => false )
+			);
+		}
+	}
 
 	$new_link_page_id = wp_insert_post(
 		array(
@@ -204,6 +221,14 @@ function ec_create_link_page( $artist_id, $force = false ) {
 			);
 		}
 		$previous_owner_reference = $previous_owner_references[0] ?? '';
+		if ( $previous_owner_reference && $owner_reference !== $previous_owner_reference ) {
+			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+			return is_wp_error( $rollback ) ? $rollback : new WP_Error(
+				'link_page_previous_owner_conflict',
+				'The previous Link Page canonical owner conflicts with its legacy artist association.',
+				array( 'retryable' => false )
+			);
+		}
 		if ( $previous_owner_reference ) {
 			delete_post_meta( $previous_link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $previous_owner_reference );
 			if ( ! empty( ec_get_stored_link_page_owner_references( $previous_link_page_id ) ) ) {
@@ -219,6 +244,18 @@ function ec_create_link_page( $artist_id, $force = false ) {
 		if ( $artist_id === (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) ) {
 			if ( $previous_owner_reference ) {
 				update_post_meta( $previous_link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $previous_owner_reference );
+				$restored_owner_references = ec_get_stored_link_page_owner_references( $previous_link_page_id );
+				if ( 1 !== count( $restored_owner_references ) || $previous_owner_reference !== $restored_owner_references[0] ) {
+					$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+					if ( is_wp_error( $rollback ) ) {
+						return $rollback;
+					}
+					return new WP_Error(
+						'link_page_association_compensation_failed',
+						'The previous Link Page canonical owner could not be restored. Manual reconciliation is required.',
+						array( 'retryable' => false )
+					);
+				}
 			}
 			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
 			if ( is_wp_error( $rollback ) ) {

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -66,12 +66,15 @@ function ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous
 		update_post_meta( $artist_id, '_extrch_link_page_id', $previous_link_page_id );
 	}
 	delete_post_meta( $new_link_page_id, '_associated_artist_profile_id', $artist_id );
+	delete_post_meta( $new_link_page_id, EC_LINK_PAGE_OWNER_META_KEY );
 
 	$profile_link_id      = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
 	$new_associated_id    = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
+	$new_owner_references = ec_get_stored_link_page_owner_references( $new_link_page_id );
 	$previous_associated_id = $previous_link_page_id ? (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) : 0;
 	$metadata_restored    = $profile_link_id === (int) $previous_link_page_id
 		&& $new_associated_id !== (int) $artist_id
+		&& empty( $new_owner_references )
 		&& ( ! $previous_link_page_id || $previous_associated_id === (int) $artist_id );
 	if ( ! $metadata_restored ) {
 		return new WP_Error(
@@ -131,6 +134,17 @@ function ec_create_link_page( $artist_id, $force = false ) {
 	if ( empty( $link_page_title ) || empty( $artist_profile_slug ) ) {
 		return new WP_Error( 'incomplete_data', 'Artist profile must have title and slug for link page creation' );
 	}
+	$owner_reference = ec_normalize_link_page_owner_reference(
+		array(
+			'kind'      => 'post',
+			'blog_id'   => get_current_blog_id(),
+			'subtype'   => 'artist_profile',
+			'object_id' => $artist_id,
+		)
+	);
+	if ( is_wp_error( $owner_reference ) ) {
+		return $owner_reference;
+	}
 
 	$new_link_page_id = wp_insert_post(
 		array(
@@ -152,6 +166,19 @@ function ec_create_link_page( $artist_id, $force = false ) {
 		return new WP_Error( 'creation_failed', 'Failed to create link page' );
 	}
 
+	$owner_assigned = ec_assign_link_page_owner( $new_link_page_id, $owner_reference, $force ? $previous_link_page_id : 0 );
+	if ( is_wp_error( $owner_assigned ) ) {
+		$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $force ? $previous_link_page_id : 0 );
+		if ( is_wp_error( $rollback ) ) {
+			return $rollback;
+		}
+		return new WP_Error(
+			'link_page_owner_assignment_failed',
+			'Link Page owner assignment could not be persisted. No Link Page was created.',
+			array( 'cause' => $owner_assigned->get_error_code(), 'retryable' => true )
+		);
+	}
+
 	update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
 	$profile_link_id      = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
 	$associated_artist_id = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
@@ -167,8 +194,32 @@ function ec_create_link_page( $artist_id, $force = false ) {
 		);
 	}
 	if ( $force && $previous_link_page_id && $previous_link_page_id !== (int) $new_link_page_id ) {
+		$previous_owner_references = ec_get_stored_link_page_owner_references( $previous_link_page_id );
+		if ( count( $previous_owner_references ) > 1 ) {
+			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+			return is_wp_error( $rollback ) ? $rollback : new WP_Error(
+				'link_page_previous_detach_failed',
+				'The previous Link Page has duplicate owner references. The original association was restored.',
+				array( 'retryable' => false )
+			);
+		}
+		$previous_owner_reference = $previous_owner_references[0] ?? '';
+		if ( $previous_owner_reference ) {
+			delete_post_meta( $previous_link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $previous_owner_reference );
+			if ( ! empty( ec_get_stored_link_page_owner_references( $previous_link_page_id ) ) ) {
+				$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+				return is_wp_error( $rollback ) ? $rollback : new WP_Error(
+					'link_page_previous_detach_failed',
+					'The previous Link Page owner could not be detached. The original association was restored.',
+					array( 'retryable' => true )
+				);
+			}
+		}
 		delete_post_meta( $previous_link_page_id, '_associated_artist_profile_id', $artist_id );
 		if ( $artist_id === (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) ) {
+			if ( $previous_owner_reference ) {
+				update_post_meta( $previous_link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $previous_owner_reference );
+			}
 			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
 			if ( is_wp_error( $rollback ) ) {
 				return $rollback;

--- a/inc/link-pages/artist-owner-compatibility.php
+++ b/inc/link-pages/artist-owner-compatibility.php
@@ -43,9 +43,16 @@ add_filter( 'ec_link_page_legacy_owner_reference', 'ec_artist_link_page_legacy_o
  *
  * @param int[]  $link_page_ids Existing compatibility candidates.
  * @param string $reference     Normalized owner reference.
- * @return int[]
+ * @return int[]|WP_Error
  */
 function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference ) {
+	if ( is_wp_error( $link_page_ids ) ) {
+		return $link_page_ids;
+	}
+	if ( ! is_array( $link_page_ids ) ) {
+		return new WP_Error( 'invalid_link_page_owner_candidates', 'A Link Page owner compatibility provider returned an invalid candidate accumulator.' );
+	}
+
 	$owner = ec_parse_link_page_owner_reference( $reference );
 	if ( is_wp_error( $owner ) ) {
 		return $link_page_ids;
@@ -54,6 +61,22 @@ function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
 	if ( 'post' !== $owner['kind'] || $artist_blog_id !== $owner['blog_id'] || 'artist_profile' !== $owner['subtype'] ) {
 		return $link_page_ids;
+	}
+	foreach ( $link_page_ids as $link_page_id ) {
+		if ( ! is_int( $link_page_id ) || $link_page_id <= 0 || EC_LINK_PAGE_POST_TYPE !== get_post_type( $link_page_id ) ) {
+			continue;
+		}
+		$legacy_artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
+		if ( $legacy_artist_id && $legacy_artist_id !== $owner['object_id'] ) {
+			return new WP_Error(
+				'link_page_owner_divergence',
+				'The Link Page canonical owner conflicts with its legacy artist association.',
+				array(
+					'link_page_id' => $link_page_id,
+					'retryable'    => false,
+				)
+			);
+		}
 	}
 
 	// Compatibility lookup requires the legacy reciprocal metadata value.
@@ -72,6 +95,30 @@ function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 
-	return array_merge( $link_page_ids, array_map( 'absint', $legacy_ids ) );
+	foreach ( $legacy_ids as $legacy_id ) {
+		$stored = ec_get_stored_link_page_owner_references( $legacy_id );
+		if ( count( $stored ) > 1 ) {
+			return new WP_Error( 'duplicate_link_page_owner_references', 'A legacy artist Link Page has duplicate canonical owner references.' );
+		}
+		if ( ! empty( $stored ) ) {
+			$canonical = ec_normalize_link_page_owner_reference( $stored[0] );
+			if ( is_wp_error( $canonical ) ) {
+				return $canonical;
+			}
+			if ( $canonical !== $reference ) {
+				return new WP_Error(
+					'link_page_owner_divergence',
+					'The Link Page canonical owner conflicts with its legacy artist association.',
+					array(
+						'link_page_id' => (int) $legacy_id,
+						'retryable'    => false,
+					)
+				);
+			}
+		}
+		$link_page_ids[] = (int) $legacy_id;
+	}
+
+	return $link_page_ids;
 }
 add_filter( 'ec_link_page_legacy_owner_candidates', 'ec_artist_link_page_legacy_owner_candidates', 10, 2 );

--- a/inc/link-pages/artist-owner-compatibility.php
+++ b/inc/link-pages/artist-owner-compatibility.php
@@ -8,75 +8,43 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Resolve a legacy artist association as a normalized owner reference.
+ * Return artist compatibility claims for one provider operation.
  *
- * @param string $reference    Existing fallback reference.
- * @param int    $link_page_id Link Page post ID.
- * @return string
+ * @param string $operation Provider operation.
+ * @param array  $context   Operation context.
+ * @return array|WP_Error
  */
-function ec_artist_link_page_legacy_owner_reference( $reference, $link_page_id ) {
-	if ( '' !== $reference ) {
-		return $reference;
-	}
-
-	$artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
-	$blog_id   = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
-	if ( ! $artist_id || ! $blog_id ) {
-		return '';
-	}
-
-	$reference = ec_format_link_page_owner_reference(
-		array(
-			'kind'      => 'post',
-			'blog_id'   => $blog_id,
-			'subtype'   => 'artist_profile',
-			'object_id' => $artist_id,
-		)
-	);
-
-	return is_wp_error( $reference ) ? '' : $reference;
-}
-add_filter( 'ec_link_page_legacy_owner_reference', 'ec_artist_link_page_legacy_owner_reference', 10, 2 );
-
-/**
- * Find all Link Pages carrying the matching legacy artist association.
- *
- * @param int[]  $link_page_ids Existing compatibility candidates.
- * @param string $reference     Normalized owner reference.
- * @return int[]|WP_Error
- */
-function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference ) {
-	if ( is_wp_error( $link_page_ids ) ) {
-		return $link_page_ids;
-	}
-	if ( ! is_array( $link_page_ids ) ) {
-		return new WP_Error( 'invalid_link_page_owner_candidates', 'A Link Page owner compatibility provider returned an invalid candidate accumulator.' );
-	}
-
-	$owner = ec_parse_link_page_owner_reference( $reference );
-	if ( is_wp_error( $owner ) ) {
-		return $link_page_ids;
-	}
-
+function ec_artist_link_page_owner_compatibility_provider( $operation, $context ) {
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
-	if ( 'post' !== $owner['kind'] || $artist_blog_id !== $owner['blog_id'] || 'artist_profile' !== $owner['subtype'] ) {
-		return $link_page_ids;
+	if ( 'page_owner' === $operation ) {
+		$link_page_id = (int) ( $context['link_page_id'] ?? 0 );
+		$artist_id    = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
+		if ( ! $artist_id || ! $artist_blog_id ) {
+			return array();
+		}
+		$reference = ec_format_link_page_owner_reference(
+			array(
+				'kind'      => 'post',
+				'blog_id'   => $artist_blog_id,
+				'subtype'   => 'artist_profile',
+				'object_id' => $artist_id,
+			)
+		);
+		return is_wp_error( $reference ) ? $reference : array(
+			array(
+				'link_page_id'    => $link_page_id,
+				'owner_reference' => $reference,
+			),
+		);
 	}
-	foreach ( $link_page_ids as $link_page_id ) {
-		if ( ! is_int( $link_page_id ) || $link_page_id <= 0 || EC_LINK_PAGE_POST_TYPE !== get_post_type( $link_page_id ) ) {
-			continue;
-		}
-		$legacy_artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
-		if ( $legacy_artist_id && $legacy_artist_id !== $owner['object_id'] ) {
-			return new WP_Error(
-				'link_page_owner_divergence',
-				'The Link Page canonical owner conflicts with its legacy artist association.',
-				array(
-					'link_page_id' => $link_page_id,
-					'retryable'    => false,
-				)
-			);
-		}
+
+	$reference = $context['owner_reference'] ?? '';
+	$owner     = ec_parse_link_page_owner_reference( $reference );
+	if ( is_wp_error( $owner ) ) {
+		return $owner;
+	}
+	if ( 'owner_pages' !== $operation || 'post' !== $owner['kind'] || $artist_blog_id !== $owner['blog_id'] || 'artist_profile' !== $owner['subtype'] ) {
+		return array();
 	}
 
 	// Compatibility lookup requires the legacy reciprocal metadata value.
@@ -95,30 +63,13 @@ function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 
+	$claims = array();
 	foreach ( $legacy_ids as $legacy_id ) {
-		$stored = ec_get_stored_link_page_owner_references( $legacy_id );
-		if ( count( $stored ) > 1 ) {
-			return new WP_Error( 'duplicate_link_page_owner_references', 'A legacy artist Link Page has duplicate canonical owner references.' );
-		}
-		if ( ! empty( $stored ) ) {
-			$canonical = ec_normalize_link_page_owner_reference( $stored[0] );
-			if ( is_wp_error( $canonical ) ) {
-				return $canonical;
-			}
-			if ( $canonical !== $reference ) {
-				return new WP_Error(
-					'link_page_owner_divergence',
-					'The Link Page canonical owner conflicts with its legacy artist association.',
-					array(
-						'link_page_id' => (int) $legacy_id,
-						'retryable'    => false,
-					)
-				);
-			}
-		}
-		$link_page_ids[] = (int) $legacy_id;
+		$claims[] = array(
+			'link_page_id'    => (int) $legacy_id,
+			'owner_reference' => $reference,
+		);
 	}
-
-	return $link_page_ids;
+	return $claims;
 }
-add_filter( 'ec_link_page_legacy_owner_candidates', 'ec_artist_link_page_legacy_owner_candidates', 10, 2 );
+ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );

--- a/inc/link-pages/artist-owner-compatibility.php
+++ b/inc/link-pages/artist-owner-compatibility.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Artist compatibility adapter for Link Page owner references.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve a legacy artist association as a normalized owner reference.
+ *
+ * @param string $reference    Existing fallback reference.
+ * @param int    $link_page_id Link Page post ID.
+ * @return string
+ */
+function ec_artist_link_page_legacy_owner_reference( $reference, $link_page_id ) {
+	if ( '' !== $reference ) {
+		return $reference;
+	}
+
+	$artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
+	$blog_id   = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+	if ( ! $artist_id || ! $blog_id ) {
+		return '';
+	}
+
+	$reference = ec_format_link_page_owner_reference(
+		array(
+			'kind'      => 'post',
+			'blog_id'   => $blog_id,
+			'subtype'   => 'artist_profile',
+			'object_id' => $artist_id,
+		)
+	);
+
+	return is_wp_error( $reference ) ? '' : $reference;
+}
+add_filter( 'ec_link_page_legacy_owner_reference', 'ec_artist_link_page_legacy_owner_reference', 10, 2 );
+
+/**
+ * Find all Link Pages carrying the matching legacy artist association.
+ *
+ * @param int[]  $link_page_ids Existing compatibility candidates.
+ * @param string $reference     Normalized owner reference.
+ * @return int[]
+ */
+function ec_artist_link_page_legacy_owner_candidates( $link_page_ids, $reference ) {
+	$owner = ec_parse_link_page_owner_reference( $reference );
+	if ( is_wp_error( $owner ) ) {
+		return $link_page_ids;
+	}
+
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+	if ( 'post' !== $owner['kind'] || $artist_blog_id !== $owner['blog_id'] || 'artist_profile' !== $owner['subtype'] ) {
+		return $link_page_ids;
+	}
+
+	// Compatibility lookup requires the legacy reciprocal metadata value.
+	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$legacy_ids = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'any',
+			'meta_key'       => '_associated_artist_profile_id',
+			'meta_value'     => (string) $owner['object_id'],
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+		)
+	);
+	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+	return array_merge( $link_page_ids, array_map( 'absint', $legacy_ids ) );
+}
+add_filter( 'ec_link_page_legacy_owner_candidates', 'ec_artist_link_page_legacy_owner_candidates', 10, 2 );

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -10,6 +10,47 @@ defined( 'ABSPATH' ) || exit;
 const EC_LINK_PAGE_OWNER_META_KEY = '_ec_link_page_owner_reference';
 
 /**
+ * Register an append-only owner compatibility provider.
+ *
+ * @param string   $name     Stable provider name.
+ * @param callable $callback Provider callback.
+ * @param int      $priority Provider ordering priority.
+ * @return true|WP_Error
+ */
+function ec_register_link_page_owner_compatibility_provider( $name, $callback, $priority = 10 ) {
+	if ( ! is_string( $name ) || 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $name ) || ! is_callable( $callback ) || ! is_int( $priority ) ) {
+		return new WP_Error( 'invalid_link_page_owner_provider', 'The Link Page owner compatibility provider registration is invalid.' );
+	}
+	if ( isset( $GLOBALS['ec_link_page_owner_compatibility_providers'][ $name ] ) ) {
+		return new WP_Error( 'duplicate_link_page_owner_provider', 'The Link Page owner compatibility provider is already registered.' );
+	}
+
+	$GLOBALS['ec_link_page_owner_compatibility_providers'][ $name ] = array(
+		'name'     => $name,
+		'callback' => $callback,
+		'priority' => $priority,
+	);
+	return true;
+}
+
+/**
+ * Return providers in deterministic priority and name order.
+ *
+ * @return array
+ */
+function ec_get_link_page_owner_compatibility_providers() {
+	$providers = array_values( $GLOBALS['ec_link_page_owner_compatibility_providers'] ?? array() );
+	usort(
+		$providers,
+		static function ( $left, $right ) {
+			$priority = (int) $left['priority'] <=> (int) $right['priority'];
+			return 0 !== $priority ? $priority : strcmp( $left['name'], $right['name'] );
+		}
+	);
+	return $providers;
+}
+
+/**
  * Parse an opaque owner reference without resolving its object.
  *
  * @param string $reference Owner reference in kind:blog:subtype:id form.
@@ -110,6 +151,100 @@ function ec_get_stored_link_page_owner_references( $link_page_id ) {
 }
 
 /**
+ * Validate one structured compatibility claim.
+ *
+ * @param mixed  $claim     Provider claim.
+ * @param string $operation Compatibility operation.
+ * @param array  $context   Operation context.
+ * @return array{link_page_id:int,owner_reference:string}|WP_Error
+ */
+function ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $context ) {
+	if ( ! is_array( $claim ) || ! isset( $claim['link_page_id'], $claim['owner_reference'] ) || 2 !== count( $claim ) ) {
+		return new WP_Error( 'invalid_link_page_owner_claim', 'A Link Page owner compatibility provider returned a malformed claim.' );
+	}
+	$link_page_id = $claim['link_page_id'];
+	if ( ! is_int( $link_page_id ) || $link_page_id <= 0 || EC_LINK_PAGE_POST_TYPE !== get_post_type( $link_page_id ) ) {
+		return new WP_Error( 'invalid_link_page_owner_candidate', 'A Link Page owner compatibility provider returned an invalid storage candidate.' );
+	}
+	$reference = ec_normalize_link_page_owner_reference( $claim['owner_reference'] );
+	if ( is_wp_error( $reference ) ) {
+		return $reference;
+	}
+	if ( 'page_owner' === $operation && (int) $context['link_page_id'] !== $link_page_id ) {
+		return new WP_Error( 'invalid_link_page_owner_claim', 'A compatibility provider claimed the wrong Link Page.' );
+	}
+	if ( 'owner_pages' === $operation && $context['owner_reference'] !== $reference ) {
+		return new WP_Error( 'link_page_owner_claim_mismatch', 'A compatibility provider returned a claim for a different owner.' );
+	}
+
+	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+	if ( count( $stored ) > 1 ) {
+		return new WP_Error( 'duplicate_link_page_owner_references', 'A claimed Link Page has duplicate canonical owner references.' );
+	}
+	if ( ! empty( $stored ) ) {
+		$canonical = ec_normalize_link_page_owner_reference( $stored[0] );
+		if ( is_wp_error( $canonical ) ) {
+			return $canonical;
+		}
+		if ( $canonical !== $reference ) {
+			return new WP_Error( 'link_page_owner_divergence', 'A compatibility claim conflicts with the canonical Link Page owner.' );
+		}
+	}
+
+	return array(
+		'link_page_id'    => $link_page_id,
+		'owner_reference' => $reference,
+	);
+}
+
+/**
+ * Collect immutable claims from every registered compatibility provider.
+ *
+ * @param string $operation Compatibility operation.
+ * @param array  $context   Operation context.
+ * @return array|WP_Error
+ */
+function ec_collect_link_page_owner_compatibility_claims( $operation, $context ) {
+	if ( ! in_array( $operation, array( 'page_owner', 'owner_pages' ), true ) || ! is_array( $context ) ) {
+		return new WP_Error( 'invalid_link_page_owner_provider_context', 'The Link Page owner provider context is invalid.' );
+	}
+
+	$claims = array();
+	$errors = array();
+	foreach ( ec_get_link_page_owner_compatibility_providers() as $provider ) {
+		try {
+			$result = call_user_func( $provider['callback'], $operation, $context );
+		} catch ( Throwable $throwable ) {
+			$errors[] = new WP_Error( 'link_page_owner_provider_exception', 'A Link Page owner compatibility provider failed.' );
+			continue;
+		}
+		if ( is_wp_error( $result ) ) {
+			$errors[] = $result;
+			continue;
+		}
+		if ( ! is_array( $result ) ) {
+			$errors[] = new WP_Error( 'invalid_link_page_owner_provider_result', 'A Link Page owner compatibility provider returned an invalid result.' );
+			continue;
+		}
+		foreach ( $result as $claim ) {
+			$claim = ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $context );
+			if ( is_wp_error( $claim ) ) {
+				$errors[] = $claim;
+				continue;
+			}
+			$key = $claim['link_page_id'] . '|' . $claim['owner_reference'];
+			if ( isset( $claims[ $key ] ) ) {
+				$errors[] = new WP_Error( 'duplicate_link_page_owner_claim', 'Multiple compatibility providers returned the same owner claim.' );
+				continue;
+			}
+			$claims[ $key ] = $claim;
+		}
+	}
+
+	return empty( $errors ) ? array_values( $claims ) : $errors[0];
+}
+
+/**
  * Resolve the normalized owner fields for a Link Page.
  *
  * @param int $link_page_id Link Page post ID on the current blog.
@@ -126,21 +261,30 @@ function ec_get_link_page_owner( $link_page_id ) {
 		return new WP_Error( 'duplicate_link_page_owner_references', 'The Link Page has duplicate stored owner references.' );
 	}
 
-	if ( empty( $stored ) ) {
-		$reference = apply_filters( 'ec_link_page_legacy_owner_reference', '', $link_page_id );
-		if ( ! is_string( $reference ) || '' === $reference ) {
-			return new WP_Error( 'link_page_owner_not_found', 'The Link Page has no owner association.' );
+	$references = array();
+	if ( ! empty( $stored ) ) {
+		$normalized = ec_normalize_link_page_owner_reference( $stored[0] );
+		if ( is_wp_error( $normalized ) ) {
+			return $normalized;
 		}
-	} else {
-		$reference = $stored[0];
+		$references[] = $normalized;
+	}
+	$claims = ec_collect_link_page_owner_compatibility_claims( 'page_owner', array( 'link_page_id' => $link_page_id ) );
+	if ( is_wp_error( $claims ) ) {
+		return $claims;
+	}
+	foreach ( $claims as $claim ) {
+		$references[] = $claim['owner_reference'];
+	}
+	$references = array_values( array_unique( $references ) );
+	if ( empty( $references ) ) {
+		return new WP_Error( 'link_page_owner_not_found', 'The Link Page has no owner association.' );
+	}
+	if ( count( $references ) > 1 ) {
+		return new WP_Error( 'multiple_link_page_owner_claims', 'Multiple owners are claimed for the Link Page.' );
 	}
 
-	$normalized = ec_normalize_link_page_owner_reference( $reference );
-	if ( is_wp_error( $normalized ) ) {
-		return $normalized;
-	}
-
-	return ec_parse_link_page_owner_reference( $normalized );
+	return ec_parse_link_page_owner_reference( $references[0] );
 }
 
 /**
@@ -171,12 +315,13 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) 
 		)
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-	$compatibility_ids = apply_filters( 'ec_link_page_legacy_owner_candidates', $link_page_ids, $reference );
-	if ( is_wp_error( $compatibility_ids ) ) {
-		return $compatibility_ids;
+	$claims = ec_collect_link_page_owner_compatibility_claims( 'owner_pages', array( 'owner_reference' => $reference ) );
+	if ( is_wp_error( $claims ) ) {
+		return $claims;
 	}
-	if ( ! is_array( $compatibility_ids ) ) {
-		return new WP_Error( 'invalid_link_page_owner_candidates', 'A Link Page owner compatibility provider returned invalid candidates.' );
+	$compatibility_ids = array();
+	foreach ( $claims as $claim ) {
+		$compatibility_ids[] = $claim['link_page_id'];
 	}
 	$candidate_ids = ec_validate_link_page_owner_candidate_ids( array_merge( $link_page_ids, $compatibility_ids ) );
 	if ( is_wp_error( $candidate_ids ) ) {

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -171,13 +171,18 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) 
 		)
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-	$compatibility_ids = apply_filters( 'ec_link_page_legacy_owner_candidates', array(), $reference );
+	$compatibility_ids = apply_filters( 'ec_link_page_legacy_owner_candidates', $link_page_ids, $reference );
+	if ( is_wp_error( $compatibility_ids ) ) {
+		return $compatibility_ids;
+	}
 	if ( ! is_array( $compatibility_ids ) ) {
 		return new WP_Error( 'invalid_link_page_owner_candidates', 'A Link Page owner compatibility provider returned invalid candidates.' );
 	}
-	$candidate_ids      = array_values( array_unique( array_map( 'absint', array_merge( $link_page_ids, $compatibility_ids ) ) ) );
+	$candidate_ids = ec_validate_link_page_owner_candidate_ids( array_merge( $link_page_ids, $compatibility_ids ) );
+	if ( is_wp_error( $candidate_ids ) ) {
+		return $candidate_ids;
+	}
 	$allowed_link_pages = array_values( array_unique( array_map( 'absint', $allowed_link_pages ) ) );
-	$candidate_ids      = array_values( array_filter( $candidate_ids ) );
 	$allowed_link_pages = array_values( array_filter( $allowed_link_pages ) );
 	sort( $candidate_ids, SORT_NUMERIC );
 	sort( $allowed_link_pages, SORT_NUMERIC );
@@ -186,6 +191,24 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) 
 	}
 
 	return empty( $candidate_ids ) ? 0 : (int) $candidate_ids[0];
+}
+
+/**
+ * Validate candidate IDs against the current Link Page storage context.
+ *
+ * @param array $candidate_ids Candidate IDs returned by canonical queries and providers.
+ * @return int[]|WP_Error
+ */
+function ec_validate_link_page_owner_candidate_ids( $candidate_ids ) {
+	$validated = array();
+	foreach ( $candidate_ids as $candidate_id ) {
+		if ( ! is_int( $candidate_id ) || $candidate_id <= 0 || EC_LINK_PAGE_POST_TYPE !== get_post_type( $candidate_id ) ) {
+			return new WP_Error( 'invalid_link_page_owner_candidate', 'A Link Page owner provider returned an invalid storage candidate.' );
+		}
+		$validated[] = $candidate_id;
+	}
+
+	return array_values( array_unique( $validated ) );
 }
 
 /**
@@ -227,19 +250,32 @@ function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id
 		return true;
 	}
 
-	update_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
+	$owner_meta_id = add_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference, true );
+	if ( ! $owner_meta_id ) {
+		$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+		if ( 1 === count( $stored ) && $reference === $stored[0] ) {
+			$persisted_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_link_pages );
+			return is_wp_error( $persisted_link_page_id ) ? $persisted_link_page_id : true;
+		}
+		if ( ! empty( $stored ) ) {
+			return new WP_Error( 'link_page_owner_conflict', 'A different owner was assigned before this Link Page could be claimed.' );
+		}
+		return new WP_Error( 'link_page_owner_assignment_failed', 'The Link Page owner could not be persisted.' );
+	}
+
 	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
 	if ( 1 !== count( $stored ) || $reference !== $stored[0] ) {
 		return ec_compensate_link_page_owner_assignment(
 			$link_page_id,
 			$reference,
+			$owner_meta_id,
 			new WP_Error( 'link_page_owner_assignment_failed', 'The Link Page owner could not be persisted.' )
 		);
 	}
 
 	$persisted_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_link_pages );
 	if ( is_wp_error( $persisted_link_page_id ) ) {
-		return ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $persisted_link_page_id );
+		return ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $owner_meta_id, $persisted_link_page_id );
 	}
 
 	return true;
@@ -250,13 +286,24 @@ function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id
  *
  * @param int      $link_page_id Link Page post ID.
  * @param string   $reference    Attempted owner reference.
- * @param WP_Error $error        Assignment error to return after compensation.
+ * @param int      $owner_meta_id Metadata row created by this assignment.
+ * @param WP_Error $error         Assignment error to return after compensation.
  * @return WP_Error
  */
-function ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $error ) {
-	delete_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
-	$remaining = ec_get_stored_link_page_owner_references( $link_page_id );
-	if ( in_array( $reference, $remaining, true ) ) {
+function ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $owner_meta_id, $error ) {
+	$metadata = get_metadata_by_mid( 'post', $owner_meta_id );
+	if ( ! $metadata ) {
+		return $error;
+	}
+	if ( (int) $metadata->post_id !== (int) $link_page_id || EC_LINK_PAGE_OWNER_META_KEY !== $metadata->meta_key || $reference !== $metadata->meta_value ) {
+		return new WP_Error(
+			'link_page_owner_compensation_failed',
+			'The metadata created by a failed owner assignment changed before compensation. Manual reconciliation is required.',
+			array( 'retryable' => false )
+		);
+	}
+	delete_metadata_by_mid( 'post', $owner_meta_id );
+	if ( get_metadata_by_mid( 'post', $owner_meta_id ) ) {
 		return new WP_Error(
 			'link_page_owner_compensation_failed',
 			'A failed owner assignment could not be compensated. Manual reconciliation is required.',
@@ -265,6 +312,23 @@ function ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $e
 	}
 
 	return $error;
+}
+
+/**
+ * Return a halted backfill result without advancing past the hazardous record.
+ *
+ * @param array  $result       Current backfill result.
+ * @param int    $link_page_id Hazardous Link Page ID.
+ * @param string $error_code   Ownership error code.
+ * @param int    $offset       Starting backfill offset.
+ * @return array
+ */
+function ec_halt_link_page_owner_backfill( $result, $link_page_id, $error_code, $offset ) {
+	$result['errors'][ (int) $link_page_id ] = $error_code;
+	return array_merge(
+		$result,
+		array( 'next_offset' => $offset + $result['processed'] - 1 )
+	);
 }
 
 /**
@@ -302,8 +366,12 @@ function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
 		if ( ! empty( $stored ) ) {
 			$owner = ec_get_link_page_owner( $link_page_id );
 			if ( is_wp_error( $owner ) ) {
-				$result['errors'][ (int) $link_page_id ] = $owner->get_error_code();
-				continue;
+				return ec_halt_link_page_owner_backfill( $result, $link_page_id, $owner->get_error_code(), $offset );
+			}
+			$resolved_link_page_id = ec_get_link_page_id_for_owner( $owner );
+			if ( is_wp_error( $resolved_link_page_id ) || (int) $link_page_id !== (int) $resolved_link_page_id ) {
+				$error_code = is_wp_error( $resolved_link_page_id ) ? $resolved_link_page_id->get_error_code() : 'link_page_owner_resolution_failed';
+				return ec_halt_link_page_owner_backfill( $result, $link_page_id, $error_code, $offset );
 			}
 			++$result['skipped'];
 			continue;
@@ -311,17 +379,12 @@ function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
 
 		$owner = ec_get_link_page_owner( $link_page_id );
 		if ( is_wp_error( $owner ) ) {
-			$result['errors'][ (int) $link_page_id ] = $owner->get_error_code();
-			continue;
+			return ec_halt_link_page_owner_backfill( $result, $link_page_id, $owner->get_error_code(), $offset );
 		}
 
 		$assigned = ec_assign_link_page_owner( $link_page_id, $owner );
 		if ( is_wp_error( $assigned ) ) {
-			$result['errors'][ (int) $link_page_id ] = $assigned->get_error_code();
-			if ( 'link_page_owner_compensation_failed' === $assigned->get_error_code() ) {
-				break;
-			}
-			continue;
+			return ec_halt_link_page_owner_backfill( $result, $link_page_id, $assigned->get_error_code(), $offset );
 		}
 		++$result['updated'];
 	}

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -10,6 +10,67 @@ defined( 'ABSPATH' ) || exit;
 const EC_LINK_PAGE_OWNER_META_KEY = '_ec_link_page_owner_reference';
 
 /**
+ * Return the function-private owner compatibility registry.
+ *
+ * @return object
+ */
+function ec_link_page_owner_compatibility_registry() {
+	static $registry = null;
+	if ( null === $registry ) {
+		$registry = new class() {
+			/**
+			 * Registered compatibility providers.
+			 *
+			 * @var array
+			 */
+			private $providers = array();
+
+			/**
+			 * Register one validated provider.
+			 *
+			 * @param string   $name     Stable provider name.
+			 * @param callable $callback Provider callback.
+			 * @param int      $priority Provider ordering priority.
+			 * @return true|WP_Error
+			 */
+			public function register( $name, $callback, $priority ) {
+				if ( ! is_string( $name ) || 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $name ) || ! is_callable( $callback ) || ! is_int( $priority ) ) {
+					return new WP_Error( 'invalid_link_page_owner_provider', 'The Link Page owner compatibility provider registration is invalid.' );
+				}
+				if ( isset( $this->providers[ $name ] ) ) {
+					return new WP_Error( 'duplicate_link_page_owner_provider', 'The Link Page owner compatibility provider is already registered.' );
+				}
+
+				$this->providers[ $name ] = array(
+					'name'     => $name,
+					'callback' => $callback,
+					'priority' => $priority,
+				);
+				return true;
+			}
+
+			/**
+			 * Return a deterministically ordered provider snapshot.
+			 *
+			 * @return array
+			 */
+			public function snapshot() {
+				$providers = array_values( $this->providers );
+				usort(
+					$providers,
+					static function ( $left, $right ) {
+						$priority = (int) $left['priority'] <=> (int) $right['priority'];
+						return 0 !== $priority ? $priority : strcmp( $left['name'], $right['name'] );
+					}
+				);
+				return $providers;
+			}
+		};
+	}
+	return $registry;
+}
+
+/**
  * Register an append-only owner compatibility provider.
  *
  * @param string   $name     Stable provider name.
@@ -18,36 +79,7 @@ const EC_LINK_PAGE_OWNER_META_KEY = '_ec_link_page_owner_reference';
  * @return true|WP_Error
  */
 function ec_register_link_page_owner_compatibility_provider( $name, $callback, $priority = 10 ) {
-	if ( ! is_string( $name ) || 1 !== preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $name ) || ! is_callable( $callback ) || ! is_int( $priority ) ) {
-		return new WP_Error( 'invalid_link_page_owner_provider', 'The Link Page owner compatibility provider registration is invalid.' );
-	}
-	if ( isset( $GLOBALS['ec_link_page_owner_compatibility_providers'][ $name ] ) ) {
-		return new WP_Error( 'duplicate_link_page_owner_provider', 'The Link Page owner compatibility provider is already registered.' );
-	}
-
-	$GLOBALS['ec_link_page_owner_compatibility_providers'][ $name ] = array(
-		'name'     => $name,
-		'callback' => $callback,
-		'priority' => $priority,
-	);
-	return true;
-}
-
-/**
- * Return providers in deterministic priority and name order.
- *
- * @return array
- */
-function ec_get_link_page_owner_compatibility_providers() {
-	$providers = array_values( $GLOBALS['ec_link_page_owner_compatibility_providers'] ?? array() );
-	usort(
-		$providers,
-		static function ( $left, $right ) {
-			$priority = (int) $left['priority'] <=> (int) $right['priority'];
-			return 0 !== $priority ? $priority : strcmp( $left['name'], $right['name'] );
-		}
-	);
-	return $providers;
+	return ec_link_page_owner_compatibility_registry()->register( $name, $callback, $priority );
 }
 
 /**
@@ -198,26 +230,77 @@ function ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $c
 }
 
 /**
- * Collect immutable claims from every registered compatibility provider.
+ * Restore the exact multisite context captured before provider execution.
+ *
+ * @param int   $blog_id  Entry blog ID.
+ * @param array $stack    Entry switch stack.
+ * @param bool  $switched Entry switched flag.
+ * @return bool
+ */
+function ec_restore_link_page_owner_provider_context( $blog_id, $stack, $switched ) {
+	$current_stack = isset( $GLOBALS['_wp_switched_stack'] ) && is_array( $GLOBALS['_wp_switched_stack'] ) ? $GLOBALS['_wp_switched_stack'] : array();
+	$attempts      = 0;
+	$current_depth = count( $current_stack );
+	$target_depth  = count( $stack );
+	while ( $current_depth > $target_depth && $attempts < 100 ) {
+		restore_current_blog();
+		$current_stack = isset( $GLOBALS['_wp_switched_stack'] ) && is_array( $GLOBALS['_wp_switched_stack'] ) ? $GLOBALS['_wp_switched_stack'] : array();
+		$current_depth = count( $current_stack );
+		++$attempts;
+	}
+	if ( get_current_blog_id() !== $blog_id ) {
+		switch_to_blog( $blog_id );
+	}
+	$GLOBALS['_wp_switched_stack'] = $stack;
+	$GLOBALS['switched']           = $switched;
+
+	return get_current_blog_id() === $blog_id && $GLOBALS['_wp_switched_stack'] === $stack;
+}
+
+/**
+ * Invoke one provider without allowing multisite context leakage.
+ *
+ * @param array  $provider  Provider registration.
+ * @param string $operation Compatibility operation.
+ * @param array  $context   Operation context.
+ * @return mixed|WP_Error
+ */
+function ec_invoke_link_page_owner_compatibility_provider( $provider, $operation, $context ) {
+	$blog_id  = get_current_blog_id();
+	$stack    = isset( $GLOBALS['_wp_switched_stack'] ) && is_array( $GLOBALS['_wp_switched_stack'] ) ? $GLOBALS['_wp_switched_stack'] : array();
+	$switched = ! empty( $GLOBALS['switched'] );
+	$result   = null;
+	$error    = null;
+	try {
+		$result = call_user_func( $provider['callback'], $operation, $context );
+	} catch ( Throwable $throwable ) {
+		$error = new WP_Error( 'link_page_owner_provider_exception', 'A Link Page owner compatibility provider failed.' );
+	} finally {
+		$restored = ec_restore_link_page_owner_provider_context( $blog_id, $stack, $switched );
+	}
+	if ( ! $restored ) {
+		return new WP_Error( 'link_page_owner_provider_context_leak', 'A Link Page owner compatibility provider did not restore the storage context.' );
+	}
+
+	return $error ? $error : $result;
+}
+
+/**
+ * Collect raw immutable claims from every provider in one snapshot.
  *
  * @param string $operation Compatibility operation.
  * @param array  $context   Operation context.
  * @return array|WP_Error
  */
-function ec_collect_link_page_owner_compatibility_claims( $operation, $context ) {
+function ec_collect_raw_link_page_owner_compatibility_claims( $operation, $context ) {
 	if ( ! in_array( $operation, array( 'page_owner', 'owner_pages' ), true ) || ! is_array( $context ) ) {
 		return new WP_Error( 'invalid_link_page_owner_provider_context', 'The Link Page owner provider context is invalid.' );
 	}
 
 	$claims = array();
 	$errors = array();
-	foreach ( ec_get_link_page_owner_compatibility_providers() as $provider ) {
-		try {
-			$result = call_user_func( $provider['callback'], $operation, $context );
-		} catch ( Throwable $throwable ) {
-			$errors[] = new WP_Error( 'link_page_owner_provider_exception', 'A Link Page owner compatibility provider failed.' );
-			continue;
-		}
+	foreach ( ec_link_page_owner_compatibility_registry()->snapshot() as $provider ) {
+		$result = ec_invoke_link_page_owner_compatibility_provider( $provider, $operation, $context );
 		if ( is_wp_error( $result ) ) {
 			$errors[] = $result;
 			continue;
@@ -242,6 +325,37 @@ function ec_collect_link_page_owner_compatibility_claims( $operation, $context )
 	}
 
 	return empty( $errors ) ? array_values( $claims ) : $errors[0];
+}
+
+/**
+ * Collect claims and reconcile owner-page claims against page-owner claims.
+ *
+ * @param string $operation Compatibility operation.
+ * @param array  $context   Operation context.
+ * @return array|WP_Error
+ */
+function ec_collect_link_page_owner_compatibility_claims( $operation, $context ) {
+	$claims = ec_collect_raw_link_page_owner_compatibility_claims( $operation, $context );
+	if ( is_wp_error( $claims ) || 'owner_pages' !== $operation ) {
+		return $claims;
+	}
+
+	foreach ( $claims as $claim ) {
+		$page_claims = ec_collect_raw_link_page_owner_compatibility_claims(
+			'page_owner',
+			array( 'link_page_id' => $claim['link_page_id'] )
+		);
+		if ( is_wp_error( $page_claims ) ) {
+			return $page_claims;
+		}
+		foreach ( $page_claims as $page_claim ) {
+			if ( $page_claim['owner_reference'] !== $context['owner_reference'] ) {
+				return new WP_Error( 'link_page_owner_divergence', 'Owner compatibility providers disagree about the Link Page owner.' );
+			}
+		}
+	}
+
+	return $claims;
 }
 
 /**

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * Typed owner references for Link Pages.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+const EC_LINK_PAGE_OWNER_META_KEY = '_ec_link_page_owner_reference';
+
+/**
+ * Parse an opaque owner reference without resolving its object.
+ *
+ * @param string $reference Owner reference in kind:blog:subtype:id form.
+ * @return array{kind:string,blog_id:int,subtype:string,object_id:int,reference:string}|WP_Error
+ */
+function ec_parse_link_page_owner_reference( $reference ) {
+	if ( ! is_string( $reference ) || 1 !== preg_match( '/^(post|term):([1-9][0-9]*):([a-z0-9_-]+):([1-9][0-9]*)$/', $reference, $matches ) ) {
+		return new WP_Error( 'invalid_link_page_owner_reference', 'The Link Page owner reference is malformed.' );
+	}
+
+	return array(
+		'kind'      => $matches[1],
+		'blog_id'   => (int) $matches[2],
+		'subtype'   => $matches[3],
+		'object_id' => (int) $matches[4],
+		'reference' => $reference,
+	);
+}
+
+/**
+ * Format owner fields as an opaque owner reference.
+ *
+ * @param array{kind:mixed,blog_id:mixed,subtype:mixed,object_id:mixed} $owner Owner fields.
+ * @return string|WP_Error
+ */
+function ec_format_link_page_owner_reference( $owner ) {
+	if ( ! is_array( $owner ) ) {
+		return new WP_Error( 'invalid_link_page_owner', 'Link Page owner fields must be an array.' );
+	}
+
+	$kind      = isset( $owner['kind'] ) && is_string( $owner['kind'] ) ? $owner['kind'] : '';
+	$blog_id   = isset( $owner['blog_id'] ) ? absint( $owner['blog_id'] ) : 0;
+	$subtype   = isset( $owner['subtype'] ) && is_string( $owner['subtype'] ) ? $owner['subtype'] : '';
+	$object_id = isset( $owner['object_id'] ) ? absint( $owner['object_id'] ) : 0;
+	$reference = sprintf( '%s:%d:%s:%d', $kind, $blog_id, $subtype, $object_id );
+	$parsed    = ec_parse_link_page_owner_reference( $reference );
+
+	return is_wp_error( $parsed ) ? $parsed : $reference;
+}
+
+/**
+ * Normalize and validate an owner reference against its WordPress object.
+ *
+ * @param string|array $owner Owner reference or fields.
+ * @return string|WP_Error
+ */
+function ec_normalize_link_page_owner_reference( $owner ) {
+	$reference = is_array( $owner ) ? ec_format_link_page_owner_reference( $owner ) : $owner;
+	if ( is_wp_error( $reference ) ) {
+		return $reference;
+	}
+
+	$parsed = ec_parse_link_page_owner_reference( $reference );
+	if ( is_wp_error( $parsed ) ) {
+		return $parsed;
+	}
+
+	$site = get_site( $parsed['blog_id'] );
+	if ( ! $site || ! empty( $site->deleted ) || ! empty( $site->archived ) || ! empty( $site->spam ) ) {
+		return new WP_Error( 'invalid_link_page_owner_blog', 'The Link Page owner blog is unavailable.' );
+	}
+
+	$did_switch = get_current_blog_id() !== $parsed['blog_id'];
+	if ( $did_switch ) {
+		switch_to_blog( $parsed['blog_id'] );
+	}
+
+	try {
+		if ( 'post' === $parsed['kind'] ) {
+			if ( ! post_type_exists( $parsed['subtype'] ) || get_post_type( $parsed['object_id'] ) !== $parsed['subtype'] ) {
+				return new WP_Error( 'invalid_link_page_owner_object', 'The Link Page post owner does not match its declared type.' );
+			}
+		} elseif ( ! taxonomy_exists( $parsed['subtype'] ) || ! get_term( $parsed['object_id'], $parsed['subtype'] ) ) {
+			return new WP_Error( 'invalid_link_page_owner_object', 'The Link Page term owner does not match its declared taxonomy.' );
+		}
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+
+	return ec_format_link_page_owner_reference( $parsed );
+}
+
+/**
+ * Return all stored owner values without treating duplicate rows as valid.
+ *
+ * @param int $link_page_id Link Page post ID.
+ * @return array
+ */
+function ec_get_stored_link_page_owner_references( $link_page_id ) {
+	$values = get_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, false );
+	if ( ! is_array( $values ) ) {
+		$values = array( $values );
+	}
+
+	return array_values( $values );
+}
+
+/**
+ * Resolve the normalized owner fields for a Link Page.
+ *
+ * Legacy artist associations are a read-only fallback.
+ *
+ * @param int $link_page_id Link Page post ID on the current blog.
+ * @return array{kind:string,blog_id:int,subtype:string,object_id:int,reference:string}|WP_Error
+ */
+function ec_get_link_page_owner( $link_page_id ) {
+	$link_page_id = absint( $link_page_id );
+	if ( ! $link_page_id || 'artist_link_page' !== get_post_type( $link_page_id ) ) {
+		return new WP_Error( 'invalid_link_page', 'The Link Page does not exist.' );
+	}
+
+	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+	if ( count( $stored ) > 1 ) {
+		return new WP_Error( 'duplicate_link_page_owner_references', 'The Link Page has duplicate stored owner references.' );
+	}
+
+	if ( empty( $stored ) ) {
+		$artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
+		$blog_id   = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+		if ( ! $artist_id || ! $blog_id ) {
+			return new WP_Error( 'link_page_owner_not_found', 'The Link Page has no owner association.' );
+		}
+		$reference = ec_format_link_page_owner_reference(
+			array(
+				'kind'      => 'post',
+				'blog_id'   => $blog_id,
+				'subtype'   => 'artist_profile',
+				'object_id' => $artist_id,
+			)
+		);
+	} else {
+		$reference = $stored[0];
+	}
+
+	$normalized = ec_normalize_link_page_owner_reference( $reference );
+	if ( is_wp_error( $normalized ) ) {
+		return $normalized;
+	}
+
+	return ec_parse_link_page_owner_reference( $normalized );
+}
+
+/**
+ * Find the unique Link Page assigned to an owner on the current blog.
+ *
+ * @param string|array $owner                 Owner reference or fields.
+ * @param int[]        $allowed_legacy_pages Known temporary legacy duplicates during replacement.
+ * @return int|WP_Error Link Page ID, zero when absent, or a conflict error.
+ */
+function ec_get_link_page_id_for_owner( $owner, $allowed_legacy_pages = array() ) {
+	$reference = ec_normalize_link_page_owner_reference( $owner );
+	if ( is_wp_error( $reference ) ) {
+		return $reference;
+	}
+
+	// Owner uniqueness requires an exact lookup on the canonical metadata value.
+	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$link_page_ids = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'any',
+			'meta_key'       => EC_LINK_PAGE_OWNER_META_KEY,
+			'meta_value'     => $reference,
+			'posts_per_page' => 2,
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+		)
+	);
+	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	if ( count( $link_page_ids ) > 1 ) {
+		$allowed_owner_pages = array_values( array_unique( array_map( 'absint', $allowed_legacy_pages ) ) );
+		sort( $allowed_owner_pages, SORT_NUMERIC );
+		$normalized_link_page_ids = array_values( array_unique( array_map( 'absint', $link_page_ids ) ) );
+		sort( $normalized_link_page_ids, SORT_NUMERIC );
+		if ( $allowed_owner_pages !== $normalized_link_page_ids ) {
+			return new WP_Error( 'duplicate_link_pages_for_owner', 'Multiple Link Pages store the same owner reference.' );
+		}
+	}
+	if ( ! empty( $link_page_ids ) ) {
+		return (int) $link_page_ids[0];
+	}
+
+	$parsed         = ec_parse_link_page_owner_reference( $reference );
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+	if ( 'post' !== $parsed['kind'] || $artist_blog_id !== $parsed['blog_id'] || 'artist_profile' !== $parsed['subtype'] ) {
+		return 0;
+	}
+
+	// The compatibility fallback must query the legacy reciprocal association.
+	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$legacy_ids = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'any',
+			'meta_key'       => '_associated_artist_profile_id',
+			'meta_value'     => (string) $parsed['object_id'],
+			'posts_per_page' => 2,
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+		)
+	);
+	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	if ( count( $legacy_ids ) > 1 ) {
+		$allowed_legacy_pages = array_values( array_unique( array_map( 'absint', $allowed_legacy_pages ) ) );
+		sort( $allowed_legacy_pages, SORT_NUMERIC );
+		$normalized_legacy_ids = array_values( array_unique( array_map( 'absint', $legacy_ids ) ) );
+		sort( $normalized_legacy_ids, SORT_NUMERIC );
+		if ( $allowed_legacy_pages !== $normalized_legacy_ids ) {
+			return new WP_Error( 'duplicate_link_pages_for_owner', 'Multiple legacy Link Pages are associated with the same owner.' );
+		}
+	}
+
+	return empty( $legacy_ids ) ? 0 : (int) $legacy_ids[0];
+}
+
+/**
+ * Assign the unique normalized owner of a Link Page.
+ *
+ * @param int          $link_page_id          Link Page post ID.
+ * @param string|array $owner                 Owner reference or fields.
+ * @param int          $replace_link_page_id  Existing page intentionally being replaced.
+ * @return true|WP_Error
+ */
+function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id = 0 ) {
+	$link_page_id = absint( $link_page_id );
+	if ( ! $link_page_id || 'artist_link_page' !== get_post_type( $link_page_id ) ) {
+		return new WP_Error( 'invalid_link_page', 'The Link Page does not exist.' );
+	}
+
+	$reference = ec_normalize_link_page_owner_reference( $owner );
+	if ( is_wp_error( $reference ) ) {
+		return $reference;
+	}
+
+	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+	if ( count( $stored ) > 1 ) {
+		return new WP_Error( 'duplicate_link_page_owner_references', 'The Link Page has duplicate stored owner references.' );
+	}
+	if ( ! empty( $stored ) && $stored[0] !== $reference ) {
+		return new WP_Error( 'link_page_owner_conflict', 'The Link Page is already assigned to another owner.' );
+	}
+
+	$allowed_legacy_pages  = $replace_link_page_id ? array( $link_page_id, $replace_link_page_id ) : array();
+	$existing_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_legacy_pages );
+	if ( is_wp_error( $existing_link_page_id ) ) {
+		return $existing_link_page_id;
+	}
+	if ( $existing_link_page_id && $link_page_id !== $existing_link_page_id && absint( $replace_link_page_id ) !== $existing_link_page_id ) {
+		return new WP_Error( 'link_page_owner_conflict', 'The owner is already assigned to another Link Page.' );
+	}
+	if ( 1 === count( $stored ) && $stored[0] === $reference ) {
+		return true;
+	}
+
+	update_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
+	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+	if ( 1 !== count( $stored ) || $reference !== $stored[0] ) {
+		return new WP_Error( 'link_page_owner_assignment_failed', 'The Link Page owner could not be persisted.' );
+	}
+
+	$persisted_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_legacy_pages );
+	if ( is_wp_error( $persisted_link_page_id ) ) {
+		delete_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
+		if ( ! empty( ec_get_stored_link_page_owner_references( $link_page_id ) ) ) {
+			return new WP_Error( 'link_page_owner_compensation_failed', 'A conflicting owner assignment could not be compensated safely.' );
+		}
+		return $persisted_link_page_id;
+	}
+
+	return true;
+}
+
+/**
+ * Backfill a bounded page of legacy owner associations.
+ *
+ * @param int $limit  Number of Link Pages to inspect, capped at 500.
+ * @param int $offset Query offset for resumable CLI use.
+ * @return array{processed:int,updated:int,skipped:int,errors:array,next_offset:int}
+ */
+function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
+	$limit         = min( 500, max( 1, absint( $limit ) ) );
+	$offset        = absint( $offset );
+	$link_page_ids = get_posts(
+		array(
+			'post_type'      => 'artist_link_page',
+			'post_status'    => 'any',
+			'posts_per_page' => $limit,
+			'offset'         => $offset,
+			'fields'         => 'ids',
+			'orderby'        => 'ID',
+			'order'          => 'ASC',
+		)
+	);
+	$result        = array(
+		'processed'   => 0,
+		'updated'     => 0,
+		'skipped'     => 0,
+		'errors'      => array(),
+		'next_offset' => $offset,
+	);
+
+	foreach ( $link_page_ids as $link_page_id ) {
+		++$result['processed'];
+		$stored = ec_get_stored_link_page_owner_references( $link_page_id );
+		if ( ! empty( $stored ) ) {
+			$owner = ec_get_link_page_owner( $link_page_id );
+			if ( is_wp_error( $owner ) ) {
+				$result['errors'][ (int) $link_page_id ] = $owner->get_error_code();
+				continue;
+			}
+			++$result['skipped'];
+			continue;
+		}
+
+		$owner = ec_get_link_page_owner( $link_page_id );
+		if ( is_wp_error( $owner ) ) {
+			$result['errors'][ (int) $link_page_id ] = $owner->get_error_code();
+			continue;
+		}
+
+		$assigned = ec_assign_link_page_owner( $link_page_id, $owner );
+		if ( is_wp_error( $assigned ) ) {
+			$result['errors'][ (int) $link_page_id ] = $assigned->get_error_code();
+			continue;
+		}
+		++$result['updated'];
+	}
+
+	$result['next_offset'] = $offset + $result['processed'];
+	return $result;
+}

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -2,7 +2,7 @@
 /**
  * Typed owner references for Link Pages.
  *
- * @package ExtraChillArtistPlatform
+ * @package ExtraChillLinkPages
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -112,14 +112,12 @@ function ec_get_stored_link_page_owner_references( $link_page_id ) {
 /**
  * Resolve the normalized owner fields for a Link Page.
  *
- * Legacy artist associations are a read-only fallback.
- *
  * @param int $link_page_id Link Page post ID on the current blog.
  * @return array{kind:string,blog_id:int,subtype:string,object_id:int,reference:string}|WP_Error
  */
 function ec_get_link_page_owner( $link_page_id ) {
 	$link_page_id = absint( $link_page_id );
-	if ( ! $link_page_id || 'artist_link_page' !== get_post_type( $link_page_id ) ) {
+	if ( ! $link_page_id || EC_LINK_PAGE_POST_TYPE !== get_post_type( $link_page_id ) ) {
 		return new WP_Error( 'invalid_link_page', 'The Link Page does not exist.' );
 	}
 
@@ -129,19 +127,10 @@ function ec_get_link_page_owner( $link_page_id ) {
 	}
 
 	if ( empty( $stored ) ) {
-		$artist_id = (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true );
-		$blog_id   = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
-		if ( ! $artist_id || ! $blog_id ) {
+		$reference = apply_filters( 'ec_link_page_legacy_owner_reference', '', $link_page_id );
+		if ( ! is_string( $reference ) || '' === $reference ) {
 			return new WP_Error( 'link_page_owner_not_found', 'The Link Page has no owner association.' );
 		}
-		$reference = ec_format_link_page_owner_reference(
-			array(
-				'kind'      => 'post',
-				'blog_id'   => $blog_id,
-				'subtype'   => 'artist_profile',
-				'object_id' => $artist_id,
-			)
-		);
 	} else {
 		$reference = $stored[0];
 	}
@@ -158,10 +147,10 @@ function ec_get_link_page_owner( $link_page_id ) {
  * Find the unique Link Page assigned to an owner on the current blog.
  *
  * @param string|array $owner                 Owner reference or fields.
- * @param int[]        $allowed_legacy_pages Known temporary legacy duplicates during replacement.
+ * @param int[]        $allowed_link_pages Known temporary duplicates during replacement.
  * @return int|WP_Error Link Page ID, zero when absent, or a conflict error.
  */
-function ec_get_link_page_id_for_owner( $owner, $allowed_legacy_pages = array() ) {
+function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) {
 	$reference = ec_normalize_link_page_owner_reference( $owner );
 	if ( is_wp_error( $reference ) ) {
 		return $reference;
@@ -171,62 +160,32 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_legacy_pages = array() 
 	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 	$link_page_ids = get_posts(
 		array(
-			'post_type'      => 'artist_link_page',
+			'post_type'      => EC_LINK_PAGE_POST_TYPE,
 			'post_status'    => 'any',
 			'meta_key'       => EC_LINK_PAGE_OWNER_META_KEY,
 			'meta_value'     => $reference,
-			'posts_per_page' => 2,
+			'posts_per_page' => -1,
 			'fields'         => 'ids',
 			'orderby'        => 'ID',
 			'order'          => 'ASC',
 		)
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-	if ( count( $link_page_ids ) > 1 ) {
-		$allowed_owner_pages = array_values( array_unique( array_map( 'absint', $allowed_legacy_pages ) ) );
-		sort( $allowed_owner_pages, SORT_NUMERIC );
-		$normalized_link_page_ids = array_values( array_unique( array_map( 'absint', $link_page_ids ) ) );
-		sort( $normalized_link_page_ids, SORT_NUMERIC );
-		if ( $allowed_owner_pages !== $normalized_link_page_ids ) {
-			return new WP_Error( 'duplicate_link_pages_for_owner', 'Multiple Link Pages store the same owner reference.' );
-		}
+	$compatibility_ids = apply_filters( 'ec_link_page_legacy_owner_candidates', array(), $reference );
+	if ( ! is_array( $compatibility_ids ) ) {
+		return new WP_Error( 'invalid_link_page_owner_candidates', 'A Link Page owner compatibility provider returned invalid candidates.' );
 	}
-	if ( ! empty( $link_page_ids ) ) {
-		return (int) $link_page_ids[0];
-	}
-
-	$parsed         = ec_parse_link_page_owner_reference( $reference );
-	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
-	if ( 'post' !== $parsed['kind'] || $artist_blog_id !== $parsed['blog_id'] || 'artist_profile' !== $parsed['subtype'] ) {
-		return 0;
+	$candidate_ids      = array_values( array_unique( array_map( 'absint', array_merge( $link_page_ids, $compatibility_ids ) ) ) );
+	$allowed_link_pages = array_values( array_unique( array_map( 'absint', $allowed_link_pages ) ) );
+	$candidate_ids      = array_values( array_filter( $candidate_ids ) );
+	$allowed_link_pages = array_values( array_filter( $allowed_link_pages ) );
+	sort( $candidate_ids, SORT_NUMERIC );
+	sort( $allowed_link_pages, SORT_NUMERIC );
+	if ( count( $candidate_ids ) > 1 && $allowed_link_pages !== $candidate_ids ) {
+		return new WP_Error( 'duplicate_link_pages_for_owner', 'Multiple Link Pages resolve to the same owner.' );
 	}
 
-	// The compatibility fallback must query the legacy reciprocal association.
-	// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-	$legacy_ids = get_posts(
-		array(
-			'post_type'      => 'artist_link_page',
-			'post_status'    => 'any',
-			'meta_key'       => '_associated_artist_profile_id',
-			'meta_value'     => (string) $parsed['object_id'],
-			'posts_per_page' => 2,
-			'fields'         => 'ids',
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
-		)
-	);
-	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-	if ( count( $legacy_ids ) > 1 ) {
-		$allowed_legacy_pages = array_values( array_unique( array_map( 'absint', $allowed_legacy_pages ) ) );
-		sort( $allowed_legacy_pages, SORT_NUMERIC );
-		$normalized_legacy_ids = array_values( array_unique( array_map( 'absint', $legacy_ids ) ) );
-		sort( $normalized_legacy_ids, SORT_NUMERIC );
-		if ( $allowed_legacy_pages !== $normalized_legacy_ids ) {
-			return new WP_Error( 'duplicate_link_pages_for_owner', 'Multiple legacy Link Pages are associated with the same owner.' );
-		}
-	}
-
-	return empty( $legacy_ids ) ? 0 : (int) $legacy_ids[0];
+	return empty( $candidate_ids ) ? 0 : (int) $candidate_ids[0];
 }
 
 /**
@@ -239,7 +198,7 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_legacy_pages = array() 
  */
 function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id = 0 ) {
 	$link_page_id = absint( $link_page_id );
-	if ( ! $link_page_id || 'artist_link_page' !== get_post_type( $link_page_id ) ) {
+	if ( ! $link_page_id || EC_LINK_PAGE_POST_TYPE !== get_post_type( $link_page_id ) ) {
 		return new WP_Error( 'invalid_link_page', 'The Link Page does not exist.' );
 	}
 
@@ -256,8 +215,8 @@ function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id
 		return new WP_Error( 'link_page_owner_conflict', 'The Link Page is already assigned to another owner.' );
 	}
 
-	$allowed_legacy_pages  = $replace_link_page_id ? array( $link_page_id, $replace_link_page_id ) : array();
-	$existing_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_legacy_pages );
+	$allowed_link_pages    = $replace_link_page_id ? array( $link_page_id, $replace_link_page_id ) : array();
+	$existing_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_link_pages );
 	if ( is_wp_error( $existing_link_page_id ) ) {
 		return $existing_link_page_id;
 	}
@@ -271,19 +230,41 @@ function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id
 	update_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
 	$stored = ec_get_stored_link_page_owner_references( $link_page_id );
 	if ( 1 !== count( $stored ) || $reference !== $stored[0] ) {
-		return new WP_Error( 'link_page_owner_assignment_failed', 'The Link Page owner could not be persisted.' );
+		return ec_compensate_link_page_owner_assignment(
+			$link_page_id,
+			$reference,
+			new WP_Error( 'link_page_owner_assignment_failed', 'The Link Page owner could not be persisted.' )
+		);
 	}
 
-	$persisted_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_legacy_pages );
+	$persisted_link_page_id = ec_get_link_page_id_for_owner( $reference, $allowed_link_pages );
 	if ( is_wp_error( $persisted_link_page_id ) ) {
-		delete_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
-		if ( ! empty( ec_get_stored_link_page_owner_references( $link_page_id ) ) ) {
-			return new WP_Error( 'link_page_owner_compensation_failed', 'A conflicting owner assignment could not be compensated safely.' );
-		}
-		return $persisted_link_page_id;
+		return ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $persisted_link_page_id );
 	}
 
 	return true;
+}
+
+/**
+ * Remove and verify canonical metadata written by a failed assignment.
+ *
+ * @param int      $link_page_id Link Page post ID.
+ * @param string   $reference    Attempted owner reference.
+ * @param WP_Error $error        Assignment error to return after compensation.
+ * @return WP_Error
+ */
+function ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $error ) {
+	delete_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, $reference );
+	$remaining = ec_get_stored_link_page_owner_references( $link_page_id );
+	if ( in_array( $reference, $remaining, true ) ) {
+		return new WP_Error(
+			'link_page_owner_compensation_failed',
+			'A failed owner assignment could not be compensated. Manual reconciliation is required.',
+			array( 'retryable' => false )
+		);
+	}
+
+	return $error;
 }
 
 /**
@@ -298,7 +279,7 @@ function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
 	$offset        = absint( $offset );
 	$link_page_ids = get_posts(
 		array(
-			'post_type'      => 'artist_link_page',
+			'post_type'      => EC_LINK_PAGE_POST_TYPE,
 			'post_status'    => 'any',
 			'posts_per_page' => $limit,
 			'offset'         => $offset,
@@ -337,6 +318,9 @@ function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
 		$assigned = ec_assign_link_page_owner( $link_page_id, $owner );
 		if ( is_wp_error( $assigned ) ) {
 			$result['errors'][ (int) $link_page_id ] = $assigned->get_error_code();
+			if ( 'link_page_owner_compensation_failed' === $assigned->get_error_code() ) {
+				break;
+			}
 			continue;
 		}
 		++$result['updated'];

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -296,35 +296,69 @@ function ec_collect_raw_link_page_owner_compatibility_claims( $operation, $conte
 	if ( ! in_array( $operation, array( 'page_owner', 'owner_pages' ), true ) || ! is_array( $context ) ) {
 		return new WP_Error( 'invalid_link_page_owner_provider_context', 'The Link Page owner provider context is invalid.' );
 	}
+	static $active_collections = array();
+	$collection_key            = $operation . '|' . md5( (string) wp_json_encode( $context ) );
+	if ( isset( $active_collections[ $collection_key ] ) ) {
+		return new WP_Error( 'link_page_owner_provider_reentrancy', 'A Link Page owner compatibility provider recursively requested the same ownership context.' );
+	}
 
-	$claims = array();
-	$errors = array();
-	foreach ( ec_link_page_owner_compatibility_registry()->snapshot() as $provider ) {
-		$result = ec_invoke_link_page_owner_compatibility_provider( $provider, $operation, $context );
-		if ( is_wp_error( $result ) ) {
-			$errors[] = $result;
-			continue;
-		}
-		if ( ! is_array( $result ) ) {
-			$errors[] = new WP_Error( 'invalid_link_page_owner_provider_result', 'A Link Page owner compatibility provider returned an invalid result.' );
-			continue;
-		}
-		foreach ( $result as $claim ) {
-			$claim = ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $context );
-			if ( is_wp_error( $claim ) ) {
-				$errors[] = $claim;
+	$active_collections[ $collection_key ] = true;
+	try {
+		$claims = array();
+		$errors = array();
+		foreach ( ec_link_page_owner_compatibility_registry()->snapshot() as $provider ) {
+			$result = ec_invoke_link_page_owner_compatibility_provider( $provider, $operation, $context );
+			if ( is_wp_error( $result ) ) {
+				$errors[] = $result;
 				continue;
 			}
-			$key = $claim['link_page_id'] . '|' . $claim['owner_reference'];
-			if ( isset( $claims[ $key ] ) ) {
-				$errors[] = new WP_Error( 'duplicate_link_page_owner_claim', 'Multiple compatibility providers returned the same owner claim.' );
+			if ( ! is_array( $result ) ) {
+				$errors[] = new WP_Error( 'invalid_link_page_owner_provider_result', 'A Link Page owner compatibility provider returned an invalid result.' );
 				continue;
 			}
-			$claims[ $key ] = $claim;
+			foreach ( $result as $claim ) {
+				$claim = ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $context );
+				if ( is_wp_error( $claim ) ) {
+					$errors[] = $claim;
+					continue;
+				}
+				$key = $claim['link_page_id'] . '|' . $claim['owner_reference'];
+				if ( isset( $claims[ $key ] ) ) {
+					$errors[] = new WP_Error( 'duplicate_link_page_owner_claim', 'Multiple compatibility providers returned the same owner claim.' );
+					continue;
+				}
+				$claims[ $key ] = $claim;
+			}
+		}
+
+		return empty( $errors ) ? array_values( $claims ) : $errors[0];
+	} finally {
+		unset( $active_collections[ $collection_key ] );
+	}
+}
+
+/**
+ * Require every compatibility provider to agree with one candidate's owner.
+ *
+ * @param int    $link_page_id   Link Page candidate ID.
+ * @param string $owner_reference Normalized owner reference.
+ * @return true|WP_Error
+ */
+function ec_reconcile_link_page_owner_candidate( $link_page_id, $owner_reference ) {
+	$page_claims = ec_collect_raw_link_page_owner_compatibility_claims(
+		'page_owner',
+		array( 'link_page_id' => $link_page_id )
+	);
+	if ( is_wp_error( $page_claims ) ) {
+		return $page_claims;
+	}
+	foreach ( $page_claims as $page_claim ) {
+		if ( $page_claim['owner_reference'] !== $owner_reference ) {
+			return new WP_Error( 'link_page_owner_divergence', 'Owner compatibility providers disagree about the Link Page owner.' );
 		}
 	}
 
-	return empty( $errors ) ? array_values( $claims ) : $errors[0];
+	return true;
 }
 
 /**
@@ -341,17 +375,9 @@ function ec_collect_link_page_owner_compatibility_claims( $operation, $context )
 	}
 
 	foreach ( $claims as $claim ) {
-		$page_claims = ec_collect_raw_link_page_owner_compatibility_claims(
-			'page_owner',
-			array( 'link_page_id' => $claim['link_page_id'] )
-		);
-		if ( is_wp_error( $page_claims ) ) {
-			return $page_claims;
-		}
-		foreach ( $page_claims as $page_claim ) {
-			if ( $page_claim['owner_reference'] !== $context['owner_reference'] ) {
-				return new WP_Error( 'link_page_owner_divergence', 'Owner compatibility providers disagree about the Link Page owner.' );
-			}
+		$reconciled = ec_reconcile_link_page_owner_candidate( $claim['link_page_id'], $context['owner_reference'] );
+		if ( is_wp_error( $reconciled ) ) {
+			return $reconciled;
 		}
 	}
 
@@ -429,6 +455,12 @@ function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) 
 		)
 	);
 	// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key,WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	foreach ( $link_page_ids as $link_page_id ) {
+		$reconciled = ec_reconcile_link_page_owner_candidate( (int) $link_page_id, $reference );
+		if ( is_wp_error( $reconciled ) ) {
+			return $reconciled;
+		}
+	}
 	$claims = ec_collect_link_page_owner_compatibility_claims( 'owner_pages', array( 'owner_reference' => $reference ) );
 	if ( is_wp_error( $claims ) ) {
 		return $claims;

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -163,7 +163,7 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
 	}
 
-	public function test_same_page_canonical_and_legacy_divergence_fails_for_legacy_owner(): void {
+	public function test_same_page_canonical_and_legacy_divergence_fails_for_both_owners(): void {
 		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
 		$this->addPost( 4, 40, 'artist_link_page', 'divergent' );
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
@@ -173,7 +173,24 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$canonical_owner = ec_get_link_page_id_for_owner( $this->postOwner( 21 ) );
 
 		$this->assertSame( 'link_page_owner_divergence', $legacy_owner->get_error_code() );
-		$this->assertSame( 40, $canonical_owner );
+		$this->assertSame( 'link_page_owner_divergence', $canonical_owner->get_error_code() );
+	}
+
+	public function test_provider_same_subject_reentrancy_fails_closed(): void {
+		ec_register_link_page_owner_compatibility_provider(
+			'reentrant-provider',
+			function ( $operation, $context ) {
+				if ( 'owner_pages' !== $operation ) {
+					return array();
+				}
+				return ec_collect_raw_link_page_owner_compatibility_claims( $operation, $context );
+			},
+			5
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'link_page_owner_provider_reentrancy', $result->get_error_code() );
 	}
 
 	public function test_later_provider_cannot_suppress_earlier_error(): void {

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class LinkPageOwnerReferenceTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'blogs'           => array(
+				4 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+				7 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+			),
+		);
+		extrachill_register_artist_profile_cpt();
+		extrachill_register_artist_link_page_cpt();
+		$this->addPost( 4, 20, 'artist_profile', 'test-artist' );
+		$this->addTerm( 7, 30, 'place' );
+	}
+
+	private function addPost( $blog_id, $post_id, $post_type, $slug ): void {
+		$GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ] = (object) array(
+			'ID'          => $post_id,
+			'post_type'   => $post_type,
+			'post_status' => 'publish',
+			'post_title'  => ucwords( str_replace( '-', ' ', $slug ) ),
+			'post_name'   => $slug,
+		);
+	}
+
+	private function addTerm( $blog_id, $term_id, $taxonomy ): void {
+		$GLOBALS['ec_test']['blogs'][ $blog_id ]['terms'][ $term_id ] = (object) array(
+			'term_id'  => $term_id,
+			'taxonomy' => $taxonomy,
+			'slug'     => 'object-' . $term_id,
+		);
+	}
+
+	private function postOwner( $object_id = 20 ): array {
+		return array(
+			'kind'      => 'post',
+			'blog_id'   => 4,
+			'subtype'   => 'artist_profile',
+			'object_id' => $object_id,
+		);
+	}
+
+	public function test_post_and_term_references_parse_format_and_normalize_round_trip(): void {
+		$post_reference = ec_format_link_page_owner_reference( $this->postOwner() );
+		$term_reference = ec_format_link_page_owner_reference(
+			array( 'kind' => 'term', 'blog_id' => 7, 'subtype' => 'place', 'object_id' => 30 )
+		);
+
+		$this->assertSame( 'post:4:artist_profile:20', $post_reference );
+		$this->assertSame( $post_reference, ec_normalize_link_page_owner_reference( $post_reference ) );
+		$this->assertSame( $this->postOwner() + array( 'reference' => $post_reference ), ec_parse_link_page_owner_reference( $post_reference ) );
+		$this->assertSame( 'term:7:place:30', $term_reference );
+		$this->assertSame( $term_reference, ec_normalize_link_page_owner_reference( $term_reference ) );
+		$this->assertSame( 4, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
+	}
+
+	/**
+	 * @dataProvider invalidReferenceProvider
+	 */
+	public function test_malformed_and_invalid_owner_references_fail( $reference, $error_code ): void {
+		$result = ec_normalize_link_page_owner_reference( $reference );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $error_code, $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+	}
+
+	public function invalidReferenceProvider(): array {
+		return array(
+			'malformed'        => array( 'post/4/artist_profile/20', 'invalid_link_page_owner_reference' ),
+			'invalid kind'     => array( 'user:4:subscriber:20', 'invalid_link_page_owner_reference' ),
+			'invalid blog'     => array( 'post:99:artist_profile:20', 'invalid_link_page_owner_blog' ),
+			'invalid subtype'  => array( 'post:4:event:20', 'invalid_link_page_owner_object' ),
+			'invalid taxonomy' => array( 'term:7:venue:30', 'invalid_link_page_owner_object' ),
+			'invalid object'   => array( 'post:4:artist_profile:999', 'invalid_link_page_owner_object' ),
+			'zero object'      => array( 'term:7:place:0', 'invalid_link_page_owner_reference' ),
+		);
+	}
+
+	public function test_legacy_artist_fallback_does_not_write_during_read(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+
+		$owner = ec_get_link_page_owner( 40 );
+
+		$this->assertSame( 'post:4:artist_profile:20', $owner['reference'] );
+		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][40] );
+		$this->assertArrayNotHasKey( 'post_meta_update_calls', $GLOBALS['ec_test'] );
+	}
+
+	public function test_artist_creation_dual_writes_without_changing_id_or_slug(): void {
+		$link_page_id = ec_create_link_page( 20 );
+
+		$this->assertSame( 21, $link_page_id );
+		$this->assertSame( 'test-artist', get_post_field( 'post_name', $link_page_id ) );
+		$this->assertSame( 20, (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) );
+		$this->assertSame( 21, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 'post:4:artist_profile:20', get_post_meta( $link_page_id, EC_LINK_PAGE_OWNER_META_KEY, true ) );
+	}
+
+	public function test_owner_conflict_and_duplicate_references_fail_deterministically(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$this->addPost( 4, 41, 'artist_link_page', 'second' );
+		$this->addPost( 4, 42, 'artist_link_page', 'third' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+
+		$conflict = ec_assign_link_page_owner( 41, $this->postOwner() );
+		$this->assertSame( 'link_page_owner_conflict', $conflict->get_error_code() );
+
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		$duplicate_pages = ec_get_link_page_id_for_owner( $this->postOwner() );
+		$this->assertSame( 'duplicate_link_pages_for_owner', $duplicate_pages->get_error_code() );
+
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][42][ EC_LINK_PAGE_OWNER_META_KEY ] = array(
+			'post:4:artist_profile:20',
+			'post:4:artist_profile:20',
+		);
+		$duplicate_rows = ec_get_link_page_owner( 42 );
+		$this->assertSame( 'duplicate_link_page_owner_references', $duplicate_rows->get_error_code() );
+	}
+
+	public function test_malformed_stored_reference_does_not_fall_back_to_legacy_owner(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ]    = 'broken';
+
+		$owner = ec_get_link_page_owner( 40 );
+
+		$this->assertSame( 'invalid_link_page_owner_reference', $owner->get_error_code() );
+	}
+
+	public function test_conflict_created_during_assignment_is_compensated(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$this->addPost( 4, 41, 'artist_link_page', 'second' );
+		$GLOBALS['ec_test']['after_post_meta_update'] = static function () {
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][41][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		};
+
+		$result = ec_assign_link_page_owner( 40, $this->postOwner() );
+
+		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
+		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][40] );
+	}
+
+	public function test_cross_blog_post_and_term_validation_always_restores_context(): void {
+		$this->addPost( 7, 50, 'event', 'event-owner' );
+
+		$this->assertSame( 'post:7:event:50', ec_normalize_link_page_owner_reference( 'post:7:event:50' ) );
+		$this->assertSame( 'term:7:place:30', ec_normalize_link_page_owner_reference( 'term:7:place:30' ) );
+		$this->assertSame( 4, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
+	}
+
+	public function test_creation_rolls_back_when_owner_assignment_fails(): void {
+		$GLOBALS['ec_test']['fail_post_meta_update_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
+
+		$result = ec_create_link_page( 20 );
+
+		$this->assertSame( 'link_page_owner_assignment_failed', $result->get_error_code() );
+		$this->assertSame( array( 20 ), array_keys( $GLOBALS['ec_test']['blogs'][4]['posts'] ) );
+		$this->assertEmpty( get_post_meta( 20, '_extrch_link_page_id', true ) );
+	}
+
+	public function test_backfill_is_bounded_and_idempotent(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+
+		$first  = ec_backfill_link_page_owner_references( 1, 0 );
+		$second = ec_backfill_link_page_owner_references( 1, 0 );
+
+		$this->assertSame( array( 'processed' => 1, 'updated' => 1, 'skipped' => 0, 'errors' => array(), 'next_offset' => 1 ), $first );
+		$this->assertSame( array( 'processed' => 1, 'updated' => 0, 'skipped' => 1, 'errors' => array(), 'next_offset' => 1 ), $second );
+	}
+}

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -125,6 +125,28 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->assertSame( 'duplicate_link_page_owner_references', $duplicate_rows->get_error_code() );
 	}
 
+	public function test_three_canonical_pages_fail_even_when_two_are_allowed(): void {
+		foreach ( array( 40, 41, 42 ) as $link_page_id ) {
+			$this->addPost( 4, $link_page_id, 'artist_link_page', 'page-' . $link_page_id );
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][ $link_page_id ][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		}
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner(), array( 40, 41 ) );
+
+		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
+	}
+
+	public function test_canonical_and_separate_legacy_candidates_conflict(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'canonical' );
+		$this->addPost( 4, 41, 'artist_link_page', 'legacy' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41]['_associated_artist_profile_id'] = 20;
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
+	}
+
 	public function test_malformed_stored_reference_does_not_fall_back_to_legacy_owner(): void {
 		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
@@ -146,6 +168,69 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 
 		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
 		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][40] );
+	}
+
+	public function test_partial_duplicate_rows_are_compensated_before_uniqueness_check(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$GLOBALS['ec_test']['post_meta_conflict'] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
+
+		$result = ec_assign_link_page_owner( 40, $this->postOwner() );
+
+		$this->assertSame( 'link_page_owner_assignment_failed', $result->get_error_code() );
+		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][40] );
+	}
+
+	public function test_backfill_halts_after_failed_partial_assignment_compensation(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'second-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$this->addPost( 4, 41, 'artist_link_page', 'second' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41]['_associated_artist_profile_id'] = 21;
+		$GLOBALS['ec_test']['post_meta_conflict'] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
+
+		$result = ec_backfill_link_page_owner_references( 2, 0 );
+
+		$this->assertSame( 1, $result['processed'] );
+		$this->assertSame( array( 40 => 'link_page_owner_compensation_failed' ), $result['errors'] );
+		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][41] );
+	}
+
+	public function test_forced_replacement_rejects_mismatched_canonical_and_legacy_owners(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 30, 'artist_link_page', 'test-artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:21';
+
+		$result = ec_create_link_page( 20, true );
+
+		$this->assertSame( 'link_page_previous_owner_conflict', $result->get_error_code() );
+		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 20, (int) get_post_meta( 30, '_associated_artist_profile_id', true ) );
+		$this->assertSame( 'post:4:artist_profile:21', get_post_meta( 30, EC_LINK_PAGE_OWNER_META_KEY, true ) );
+		$this->assertSame( array( 20, 21, 30 ), array_keys( $GLOBALS['ec_test']['blogs'][4]['posts'] ) );
+		$this->assertArrayNotHasKey( 'deleted_posts', $GLOBALS['ec_test'] );
+	}
+
+	public function test_failed_previous_canonical_owner_restoration_requires_manual_reconciliation(): void {
+		$this->addPost( 4, 30, 'artist_link_page', 'test-artist' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][20]['_extrch_link_page_id'] = 30;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][30][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		$GLOBALS['ec_test']['fail_post_meta_delete_keys']['_associated_artist_profile_id'] = 1;
+		$GLOBALS['ec_test']['after_post_meta_update'] = static function () {
+			$GLOBALS['ec_test']['fail_post_meta_update_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
+		};
+
+		$result = ec_create_link_page( 20, true );
+
+		$this->assertSame( 'link_page_association_compensation_failed', $result->get_error_code() );
+		$this->assertFalse( $result->get_error_data()['retryable'] );
+		$this->assertSame( 30, (int) get_post_meta( 20, '_extrch_link_page_id', true ) );
+		$this->assertSame( 20, (int) get_post_meta( 30, '_associated_artist_profile_id', true ) );
+		$this->assertEmpty( get_post_meta( 30, EC_LINK_PAGE_OWNER_META_KEY, true ) );
+		$this->assertSame( array( 20, 30 ), array_keys( $GLOBALS['ec_test']['blogs'][4]['posts'] ) );
 	}
 
 	public function test_cross_blog_post_and_term_validation_always_restores_context(): void {
@@ -176,5 +261,12 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 
 		$this->assertSame( array( 'processed' => 1, 'updated' => 1, 'skipped' => 0, 'errors' => array(), 'next_offset' => 1 ), $first );
 		$this->assertSame( array( 'processed' => 1, 'updated' => 0, 'skipped' => 1, 'errors' => array(), 'next_offset' => 1 ), $second );
+	}
+
+	public function test_generic_owner_reference_helpers_have_no_domain_owner_knowledge(): void {
+		$source = strtolower( file_get_contents( dirname( __DIR__ ) . '/inc/link-pages/owner-reference.php' ) );
+
+		$this->assertStringNotContainsString( 'artist', $source );
+		$this->assertStringNotContainsString( 'venue', $source );
 	}
 }

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -147,6 +147,92 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
 	}
 
+	public function test_same_page_canonical_and_legacy_divergence_fails_for_legacy_owner(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'divergent' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:21';
+
+		$legacy_owner    = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
+		$canonical_owner = ec_get_link_page_id_for_owner( $this->postOwner( 21 ) );
+
+		$this->assertSame( 'link_page_owner_divergence', $legacy_owner->get_error_code() );
+		$this->assertSame( 'link_page_owner_divergence', $canonical_owner->get_error_code() );
+	}
+
+	public function test_malformed_earlier_compatibility_provider_fails_closed(): void {
+		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
+			'priority' => 5,
+			'callback' => static function () {
+				return 'malformed';
+			},
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'invalid_link_page_owner_candidates', $result->get_error_code() );
+	}
+
+	public function test_later_compatibility_provider_candidates_are_validated_in_current_context(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'legacy' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
+			'priority' => 20,
+			'callback' => static function ( $candidate_ids ) {
+				$GLOBALS['ec_test']['later_provider_received'] = $candidate_ids;
+				$candidate_ids[] = 20;
+				return $candidate_ids;
+			},
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( array( 40 ), $GLOBALS['ec_test']['later_provider_received'] );
+		$this->assertSame( 'invalid_link_page_owner_candidate', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider invalidCompatibilityCandidateProvider
+	 */
+	public function test_invalid_compatibility_candidate_ids_fail_closed( $candidate_id, $setup = null ): void {
+		if ( $setup ) {
+			$setup( $this );
+		}
+		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
+			'priority' => 20,
+			'callback' => static function ( $candidate_ids ) use ( $candidate_id ) {
+				$candidate_ids[] = $candidate_id;
+				return $candidate_ids;
+			},
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'invalid_link_page_owner_candidate', $result->get_error_code() );
+	}
+
+	public function invalidCompatibilityCandidateProvider(): array {
+		return array(
+			'zero'          => array( 0 ),
+			'malformed'     => array( '40' ),
+			'missing'       => array( 999 ),
+			'unrelated post' => array( 20 ),
+			'deleted'       => array(
+				40,
+				static function ( $test ) {
+					$test->addPost( 4, 40, 'artist_link_page', 'deleted' );
+					unset( $GLOBALS['ec_test']['blogs'][4]['posts'][40] );
+				},
+			),
+			'cross context' => array(
+				50,
+				static function ( $test ) {
+					$test->addPost( 7, 50, 'artist_link_page', 'other-site' );
+				},
+			),
+		);
+	}
+
 	public function test_malformed_stored_reference_does_not_fall_back_to_legacy_owner(): void {
 		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
@@ -160,7 +246,7 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 	public function test_conflict_created_during_assignment_is_compensated(): void {
 		$this->addPost( 4, 40, 'artist_link_page', 'first' );
 		$this->addPost( 4, 41, 'artist_link_page', 'second' );
-		$GLOBALS['ec_test']['after_post_meta_update'] = static function () {
+		$GLOBALS['ec_test']['after_post_meta_add'] = static function () {
 			$GLOBALS['ec_test']['blogs'][4]['post_meta'][41][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
 		};
 
@@ -172,12 +258,27 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 
 	public function test_partial_duplicate_rows_are_compensated_before_uniqueness_check(): void {
 		$this->addPost( 4, 40, 'artist_link_page', 'first' );
-		$GLOBALS['ec_test']['post_meta_conflict'] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
+		$GLOBALS['ec_test']['after_post_meta_add'] = static function () {
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
+		};
 
 		$result = ec_assign_link_page_owner( 40, $this->postOwner() );
 
 		$this->assertSame( 'link_page_owner_assignment_failed', $result->get_error_code() );
-		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][40] );
+		$this->assertSame( array( 'post:4:artist_profile:20' ), $GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] );
+	}
+
+	public function test_different_owner_inserted_immediately_before_assignment_is_not_overwritten(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$GLOBALS['ec_test']['before_post_meta_add'] = static function () {
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:21';
+		};
+
+		$result = ec_assign_link_page_owner( 40, $this->postOwner( 20 ) );
+
+		$this->assertSame( 'link_page_owner_conflict', $result->get_error_code() );
+		$this->assertSame( 'post:4:artist_profile:21', get_post_meta( 40, EC_LINK_PAGE_OWNER_META_KEY, true ) );
 	}
 
 	public function test_backfill_halts_after_failed_partial_assignment_compensation(): void {
@@ -186,13 +287,16 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->addPost( 4, 41, 'artist_link_page', 'second' );
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41]['_associated_artist_profile_id'] = 21;
-		$GLOBALS['ec_test']['post_meta_conflict'] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
-		$GLOBALS['ec_test']['fail_post_meta_delete_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
+		$GLOBALS['ec_test']['after_post_meta_add'] = static function () {
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = array( 'post:4:artist_profile:20', 'post:4:artist_profile:20' );
+		};
+		$GLOBALS['ec_test']['fail_metadata_delete_by_mid'] = true;
 
 		$result = ec_backfill_link_page_owner_references( 2, 0 );
 
 		$this->assertSame( 1, $result['processed'] );
 		$this->assertSame( array( 40 => 'link_page_owner_compensation_failed' ), $result['errors'] );
+		$this->assertSame( 0, $result['next_offset'] );
 		$this->assertArrayNotHasKey( EC_LINK_PAGE_OWNER_META_KEY, $GLOBALS['ec_test']['blogs'][4]['post_meta'][41] );
 	}
 
@@ -243,7 +347,7 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 	}
 
 	public function test_creation_rolls_back_when_owner_assignment_fails(): void {
-		$GLOBALS['ec_test']['fail_post_meta_update_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
+		$GLOBALS['ec_test']['fail_post_meta_add_keys'][ EC_LINK_PAGE_OWNER_META_KEY ] = 1;
 
 		$result = ec_create_link_page( 20 );
 
@@ -261,6 +365,42 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 
 		$this->assertSame( array( 'processed' => 1, 'updated' => 1, 'skipped' => 0, 'errors' => array(), 'next_offset' => 1 ), $first );
 		$this->assertSame( array( 'processed' => 1, 'updated' => 0, 'skipped' => 1, 'errors' => array(), 'next_offset' => 1 ), $second );
+	}
+
+	public function test_backfill_halts_before_skipping_globally_conflicting_canonical_owner(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'canonical' );
+		$this->addPost( 4, 41, 'artist_link_page', 'legacy' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:20';
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41]['_associated_artist_profile_id'] = 20;
+
+		$result = ec_backfill_link_page_owner_references( 2, 0 );
+
+		$this->assertSame( 1, $result['processed'] );
+		$this->assertSame( 0, $result['skipped'] );
+		$this->assertSame( array( 40 => 'duplicate_link_pages_for_owner' ), $result['errors'] );
+		$this->assertSame( 0, $result['next_offset'] );
+	}
+
+	public function test_backfill_halts_on_same_page_divergence_and_duplicate_canonical_rows(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'divergent' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:21';
+
+		$divergent = ec_backfill_link_page_owner_references( 1, 0 );
+
+		$this->assertSame( array( 40 => 'link_page_owner_divergence' ), $divergent['errors'] );
+		$this->assertSame( 0, $divergent['next_offset'] );
+
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = array(
+			'post:4:artist_profile:20',
+			'post:4:artist_profile:20',
+		);
+		$duplicate = ec_backfill_link_page_owner_references( 1, 0 );
+
+		$this->assertSame( array( 40 => 'duplicate_link_page_owner_references' ), $duplicate['errors'] );
+		$this->assertSame( 0, $duplicate['next_offset'] );
 	}
 
 	public function test_generic_owner_reference_helpers_have_no_domain_owner_knowledge(): void {

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -5,6 +5,8 @@ use PHPUnit\Framework\TestCase;
 final class LinkPageOwnerReferenceTest extends TestCase {
 	protected function setUp(): void {
 		$this->resetProviders();
+		$GLOBALS['_wp_switched_stack'] = array();
+		$GLOBALS['switched']           = false;
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 4,
 			'blog_stack'      => array(),
@@ -24,7 +26,11 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 	}
 
 	private function resetProviders(): void {
-		$GLOBALS['ec_link_page_owner_compatibility_providers'] = array();
+		$registry   = ec_link_page_owner_compatibility_registry();
+		$reflection = new ReflectionObject( $registry );
+		$providers  = $reflection->getProperty( 'providers' );
+		$providers->setAccessible( true );
+		$providers->setValue( $registry, array() );
 		ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );
 	}
 
@@ -193,6 +199,37 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->assertTrue( $GLOBALS['ec_test']['later_provider_called'] );
 	}
 
+	public function test_provider_cannot_mutate_private_registry_storage(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'legacy' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		ec_register_link_page_owner_compatibility_provider(
+			'registry-tamper',
+			static function () {
+				$GLOBALS['ec_link_page_owner_compatibility_providers'] = array(
+					'injected' => array( 'callback' => 'missing_callback' ),
+				);
+				return array();
+			},
+			5
+		);
+
+		$first  = ec_get_link_page_id_for_owner( $this->postOwner() );
+		$second = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 40, $first );
+		$this->assertSame( 40, $second );
+		$this->assertCount( 2, ec_link_page_owner_compatibility_registry()->snapshot() );
+	}
+
+	public function test_registry_exposes_no_reset_or_unregister_api(): void {
+		$registry = ec_link_page_owner_compatibility_registry();
+
+		$this->assertFalse( method_exists( $registry, 'reset' ) );
+		$this->assertFalse( method_exists( $registry, 'unregister' ) );
+		$this->assertFalse( function_exists( 'ec_reset_link_page_owner_compatibility_providers' ) );
+		$this->assertFalse( function_exists( 'ec_unregister_link_page_owner_compatibility_provider' ) );
+	}
+
 	public function test_later_provider_cannot_erase_earlier_candidates(): void {
 		$this->addPost( 4, 40, 'artist_link_page', 'first' );
 		$this->addPost( 4, 41, 'artist_link_page', 'second' );
@@ -221,6 +258,89 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$result = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
 
 		$this->assertSame( 'link_page_owner_divergence', $result->get_error_code() );
+	}
+
+	public function test_owner_pages_claim_must_agree_with_all_page_owner_claims(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'legacy-owner' );
+		$this->addPost( 4, 40, 'artist_link_page', 'uncanonicalized' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 21;
+		ec_register_link_page_owner_compatibility_provider(
+			'one-way-owner',
+			static function ( $operation, $context ) {
+				return 'owner_pages' === $operation
+					? array( array( 'link_page_id' => 40, 'owner_reference' => $context['owner_reference'] ) )
+					: array();
+			}
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
+
+		$this->assertSame( 'link_page_owner_divergence', $result->get_error_code() );
+	}
+
+	public function test_provider_switch_result_is_validated_after_storage_context_restoration(): void {
+		$this->addPost( 7, 50, 'artist_link_page', 'cross-site' );
+		ec_register_link_page_owner_compatibility_provider(
+			'context-switcher',
+			static function ( $operation, $context ) {
+				if ( 'owner_pages' !== $operation ) {
+					return array();
+				}
+				switch_to_blog( 7 );
+				return array( array( 'link_page_id' => 50, 'owner_reference' => $context['owner_reference'] ) );
+			},
+			5
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'invalid_link_page_owner_candidate', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
+		$this->assertSame( array(), $GLOBALS['_wp_switched_stack'] );
+		$this->assertFalse( $GLOBALS['switched'] );
+	}
+
+	public function test_provider_switch_exception_restores_storage_context(): void {
+		ec_register_link_page_owner_compatibility_provider(
+			'throwing-switcher',
+			static function () {
+				switch_to_blog( 7 );
+				throw new RuntimeException( 'failed' );
+			},
+			5
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 'link_page_owner_provider_exception', $result->get_error_code() );
+		$this->assertSame( 4, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
+		$this->assertSame( array(), $GLOBALS['_wp_switched_stack'] );
+	}
+
+	public function test_provider_restores_nested_entry_context_exactly(): void {
+		ec_register_link_page_owner_compatibility_provider(
+			'nested-switcher',
+			static function () {
+				switch_to_blog( 4 );
+				return array();
+			},
+			5
+		);
+		switch_to_blog( 7 );
+
+		$result = ec_collect_link_page_owner_compatibility_claims(
+			'owner_pages',
+			array( 'owner_reference' => 'post:4:artist_profile:20' )
+		);
+
+		$this->assertSame( array(), $result );
+		$this->assertSame( 7, get_current_blog_id() );
+		$this->assertSame( array( 4 ), $GLOBALS['ec_test']['blog_stack'] );
+		$this->assertSame( array( 4 ), $GLOBALS['_wp_switched_stack'] );
+		$this->assertTrue( $GLOBALS['switched'] );
+		restore_current_blog();
 	}
 
 	public function test_distinct_page_owner_claims_fail_closed(): void {

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -4,6 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 final class LinkPageOwnerReferenceTest extends TestCase {
 	protected function setUp(): void {
+		$this->resetProviders();
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 4,
 			'blog_stack'      => array(),
@@ -16,6 +17,15 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		extrachill_register_artist_link_page_cpt();
 		$this->addPost( 4, 20, 'artist_profile', 'test-artist' );
 		$this->addTerm( 7, 30, 'place' );
+	}
+
+	protected function tearDown(): void {
+		$this->resetProviders();
+	}
+
+	private function resetProviders(): void {
+		$GLOBALS['ec_link_page_owner_compatibility_providers'] = array();
+		ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );
 	}
 
 	private function addPost( $blog_id, $post_id, $post_type, $slug ): void {
@@ -157,38 +167,107 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$canonical_owner = ec_get_link_page_id_for_owner( $this->postOwner( 21 ) );
 
 		$this->assertSame( 'link_page_owner_divergence', $legacy_owner->get_error_code() );
-		$this->assertSame( 'link_page_owner_divergence', $canonical_owner->get_error_code() );
+		$this->assertSame( 40, $canonical_owner );
 	}
 
-	public function test_malformed_earlier_compatibility_provider_fails_closed(): void {
-		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
-			'priority' => 5,
-			'callback' => static function () {
-				return 'malformed';
+	public function test_later_provider_cannot_suppress_earlier_error(): void {
+		ec_register_link_page_owner_compatibility_provider(
+			'error-provider',
+			static function () {
+				return new WP_Error( 'provider_blocked', 'Provider blocked.' );
 			},
+			5
+		);
+		ec_register_link_page_owner_compatibility_provider(
+			'later-provider',
+			static function () {
+				$GLOBALS['ec_test']['later_provider_called'] = true;
+				return array();
+			},
+			20
 		);
 
 		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
 
-		$this->assertSame( 'invalid_link_page_owner_candidates', $result->get_error_code() );
+		$this->assertSame( 'provider_blocked', $result->get_error_code() );
+		$this->assertTrue( $GLOBALS['ec_test']['later_provider_called'] );
 	}
 
-	public function test_later_compatibility_provider_candidates_are_validated_in_current_context(): void {
-		$this->addPost( 4, 40, 'artist_link_page', 'legacy' );
+	public function test_later_provider_cannot_erase_earlier_candidates(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'first' );
+		$this->addPost( 4, 41, 'artist_link_page', 'second' );
 		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
-		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
-			'priority' => 20,
-			'callback' => static function ( $candidate_ids ) {
-				$GLOBALS['ec_test']['later_provider_received'] = $candidate_ids;
-				$candidate_ids[] = 20;
-				return $candidate_ids;
-			},
-		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][41]['_associated_artist_profile_id'] = 20;
+		ec_register_link_page_owner_compatibility_provider( 'empty-provider', static function () { return array(); }, 20 );
 
 		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
 
-		$this->assertSame( array( 40 ), $GLOBALS['ec_test']['later_provider_received'] );
-		$this->assertSame( 'invalid_link_page_owner_candidate', $result->get_error_code() );
+		$this->assertSame( 'duplicate_link_pages_for_owner', $result->get_error_code() );
+	}
+
+	public function test_provider_cannot_claim_page_canonically_owned_by_another_reference(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'other-owner' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40][ EC_LINK_PAGE_OWNER_META_KEY ] = 'post:4:artist_profile:21';
+		ec_register_link_page_owner_compatibility_provider(
+			'wrong-owner-provider',
+			static function ( $operation, $context ) {
+				return 'owner_pages' === $operation
+					? array( array( 'link_page_id' => 40, 'owner_reference' => $context['owner_reference'] ) )
+					: array();
+			}
+		);
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
+
+		$this->assertSame( 'link_page_owner_divergence', $result->get_error_code() );
+	}
+
+	public function test_distinct_page_owner_claims_fail_closed(): void {
+		$this->addPost( 4, 40, 'artist_link_page', 'multiple-owners' );
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][40]['_associated_artist_profile_id'] = 20;
+		ec_register_link_page_owner_compatibility_provider(
+			'term-provider',
+			static function ( $operation ) {
+				return 'page_owner' === $operation
+					? array( array( 'link_page_id' => 40, 'owner_reference' => 'term:7:place:30' ) )
+					: array();
+			}
+		);
+
+		$result = ec_get_link_page_owner( 40 );
+
+		$this->assertSame( 'multiple_link_page_owner_claims', $result->get_error_code() );
+	}
+
+	public function test_duplicate_and_wrong_owner_claims_fail_closed(): void {
+		$this->addPost( 4, 21, 'artist_profile', 'other-artist' );
+		$this->addPost( 4, 40, 'artist_link_page', 'claimed' );
+		$duplicate_claim = static function ( $operation, $context ) {
+			return 'owner_pages' === $operation
+				? array( array( 'link_page_id' => 40, 'owner_reference' => $context['owner_reference'] ) )
+				: array();
+		};
+		ec_register_link_page_owner_compatibility_provider( 'duplicate-one', $duplicate_claim );
+		ec_register_link_page_owner_compatibility_provider( 'duplicate-two', $duplicate_claim );
+
+		$duplicate = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
+
+		$this->assertSame( 'duplicate_link_page_owner_claim', $duplicate->get_error_code() );
+
+		$this->resetProviders();
+		ec_register_link_page_owner_compatibility_provider(
+			'wrong-reference',
+			static function ( $operation ) {
+				return 'owner_pages' === $operation
+					? array( array( 'link_page_id' => 40, 'owner_reference' => 'post:4:artist_profile:21' ) )
+					: array();
+			}
+		);
+
+		$wrong_owner = ec_get_link_page_id_for_owner( $this->postOwner( 20 ) );
+
+		$this->assertSame( 'link_page_owner_claim_mismatch', $wrong_owner->get_error_code() );
 	}
 
 	/**
@@ -198,17 +277,67 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		if ( $setup ) {
 			$setup( $this );
 		}
-		$GLOBALS['ec_test']['filter_callbacks']['ec_link_page_legacy_owner_candidates'][] = array(
-			'priority' => 20,
-			'callback' => static function ( $candidate_ids ) use ( $candidate_id ) {
-				$candidate_ids[] = $candidate_id;
-				return $candidate_ids;
-			},
+		ec_register_link_page_owner_compatibility_provider(
+			'invalid-candidate-provider',
+			static function ( $operation, $context ) use ( $candidate_id ) {
+				return 'owner_pages' === $operation
+					? array( array( 'link_page_id' => $candidate_id, 'owner_reference' => $context['owner_reference'] ) )
+					: array();
+			}
 		);
 
 		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
 
 		$this->assertSame( 'invalid_link_page_owner_candidate', $result->get_error_code() );
+	}
+
+	public function test_malformed_provider_registration_and_duplicate_name_fail(): void {
+		$invalid_name = ec_register_link_page_owner_compatibility_provider( 'Bad Name', '__return_true' );
+		$invalid_callback = ec_register_link_page_owner_compatibility_provider( 'bad-callback', 'missing_callback' );
+		$invalid_priority = ec_register_link_page_owner_compatibility_provider( 'bad-priority', '__return_true', '10' );
+		$duplicate = ec_register_link_page_owner_compatibility_provider( 'artist-platform', '__return_true' );
+
+		$this->assertSame( 'invalid_link_page_owner_provider', $invalid_name->get_error_code() );
+		$this->assertSame( 'invalid_link_page_owner_provider', $invalid_callback->get_error_code() );
+		$this->assertSame( 'invalid_link_page_owner_provider', $invalid_priority->get_error_code() );
+		$this->assertSame( 'duplicate_link_page_owner_provider', $duplicate->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider malformedProviderResultProvider
+	 */
+	public function test_malformed_provider_results_and_claims_fail_closed( $provider, $error_code ): void {
+		ec_register_link_page_owner_compatibility_provider( 'malformed-provider', $provider );
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( $error_code, $result->get_error_code() );
+	}
+
+	public function malformedProviderResultProvider(): array {
+		return array(
+			'invalid result' => array( static function () { return 'invalid'; }, 'invalid_link_page_owner_provider_result' ),
+			'exception'      => array( static function () { throw new RuntimeException( 'failed' ); }, 'link_page_owner_provider_exception' ),
+			'malformed claim' => array( static function () { return array( array( 'link_page_id' => 40 ) ); }, 'invalid_link_page_owner_claim' ),
+		);
+	}
+
+	public function test_provider_order_is_deterministic_without_affecting_result(): void {
+		foreach ( array( array( 'z-provider', 20 ), array( 'b-provider', 5 ), array( 'a-provider', 5 ) ) as $provider ) {
+			ec_register_link_page_owner_compatibility_provider(
+				$provider[0],
+				static function () use ( $provider ) {
+					$GLOBALS['ec_test']['provider_order'][] = $provider[0];
+					return array();
+				},
+				$provider[1]
+			);
+		}
+
+		$result = ec_get_link_page_id_for_owner( $this->postOwner() );
+
+		$this->assertSame( 0, $result );
+		$this->assertSame( array( 'a-provider', 'b-provider', 'z-provider' ), $GLOBALS['ec_test']['provider_order'] );
 	}
 
 	public function invalidCompatibilityCandidateProvider(): array {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -278,6 +278,10 @@ function absint( $value ) {
 	return abs( (int) $value );
 }
 
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+
 function get_current_user_id() {
 	return $GLOBALS['ec_test']['current_user_id'] ?? 0;
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ define( 'OBJECT', 'OBJECT' );
 define( 'MINUTE_IN_SECONDS', 60 );
 define( 'DAY_IN_SECONDS', 86400 );
 define( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED', 'artist_profile_created' );
+define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
 
 function plugin_dir_path( $file ) {
 	return trailingslashit( dirname( $file ) );
@@ -593,6 +594,25 @@ function delete_post_meta( $post_id, $key, $value = '' ) {
 		return false;
 	}
 	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] ?? null;
+	if ( EC_LINK_PAGE_OWNER_META_KEY === $key && is_array( $current ) && '' !== $value ) {
+		$remaining = array_values(
+			array_filter(
+				$current,
+				static function ( $stored_value ) use ( $value ) {
+					return (string) $stored_value !== (string) $value;
+				}
+			)
+		);
+		if ( count( $remaining ) === count( $current ) ) {
+			return false;
+		}
+		if ( empty( $remaining ) ) {
+			unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] );
+		} else {
+			$GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] = $remaining;
+		}
+		return true;
+	}
 	if ( '' === $value || (string) $current === (string) $value ) {
 		unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] );
 		return true;
@@ -919,6 +939,12 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		$producer = (string) ( $args[0] ?? '' );
 		return in_array( $producer, $GLOBALS['ec_test']['authorized_local_support_producers'] ?? array(), true );
 	}
+	if ( 'ec_link_page_legacy_owner_reference' === $hook_name ) {
+		return ec_artist_link_page_legacy_owner_reference( $value, (int) ( $args[0] ?? 0 ) );
+	}
+	if ( 'ec_link_page_legacy_owner_candidates' === $hook_name ) {
+		return ec_artist_link_page_legacy_owner_candidates( $value, (string) ( $args[0] ?? '' ) );
+	}
 	return $value;
 }
 
@@ -1017,6 +1043,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/create-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/onboard-external-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-invitation.php';
 require_once dirname( __DIR__ ) . '/inc/link-pages/owner-reference.php';
+require_once dirname( __DIR__ ) . '/inc/link-pages/artist-owner-compatibility.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-styles.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -448,7 +448,16 @@ function metadata_exists( $object_type, $object_id, $key ) {
 }
 
 function add_post_meta( $post_id, $key, $value, $unique = false ) {
+	if ( isset( $GLOBALS['ec_test']['before_post_meta_add'] ) ) {
+		$callback = $GLOBALS['ec_test']['before_post_meta_add'];
+		unset( $GLOBALS['ec_test']['before_post_meta_add'] );
+		$callback( $post_id, $key, $value );
+	}
 	if ( $unique && metadata_exists( 'post', $post_id, $key ) ) {
+		return false;
+	}
+	if ( ! empty( $GLOBALS['ec_test']['fail_post_meta_add_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_post_meta_add_keys'][ $key ];
 		return false;
 	}
 	if ( ! empty( $GLOBALS['ec_test']['fail_post_meta_add'] ) ) {
@@ -457,6 +466,67 @@ function add_post_meta( $post_id, $key, $value, $unique = false ) {
 	}
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ][ $key ] = $value;
+	$meta_id = ( $GLOBALS['ec_test']['next_post_meta_id'] ?? 0 ) + 1;
+	$GLOBALS['ec_test']['next_post_meta_id'] = $meta_id;
+	$GLOBALS['ec_test']['post_meta_rows'][ $meta_id ] = array(
+		'blog_id'    => $blog_id,
+		'post_id'    => (int) $post_id,
+		'meta_key'   => $key,
+		'meta_value' => $value,
+	);
+	if ( isset( $GLOBALS['ec_test']['after_post_meta_add'] ) ) {
+		$callback = $GLOBALS['ec_test']['after_post_meta_add'];
+		unset( $GLOBALS['ec_test']['after_post_meta_add'] );
+		$callback( $meta_id, $post_id, $key, $value );
+	}
+	return $meta_id;
+}
+
+function get_metadata_by_mid( $meta_type, $meta_id ) {
+	if ( 'post' !== $meta_type || ! isset( $GLOBALS['ec_test']['post_meta_rows'][ $meta_id ] ) ) {
+		return false;
+	}
+	$row     = $GLOBALS['ec_test']['post_meta_rows'][ $meta_id ];
+	$current = $GLOBALS['ec_test']['blogs'][ $row['blog_id'] ]['post_meta'][ $row['post_id'] ][ $row['meta_key'] ] ?? null;
+	if ( null === $current || ( is_array( $current ) && ! in_array( $row['meta_value'], $current, true ) ) ) {
+		unset( $GLOBALS['ec_test']['post_meta_rows'][ $meta_id ] );
+		return false;
+	}
+	if ( ! is_array( $current ) ) {
+		$row['meta_value'] = $current;
+	}
+	return (object) $row;
+}
+
+function delete_metadata_by_mid( $meta_type, $meta_id ) {
+	$row = get_metadata_by_mid( $meta_type, $meta_id );
+	if ( ! $row || ! empty( $GLOBALS['ec_test']['fail_metadata_delete_by_mid'] ) ) {
+		return false;
+	}
+	$current = $GLOBALS['ec_test']['blogs'][ $row->blog_id ]['post_meta'][ $row->post_id ][ $row->meta_key ];
+	if ( is_array( $current ) ) {
+		$removed = false;
+		$current = array_values(
+			array_filter(
+				$current,
+				static function ( $stored_value ) use ( $row, &$removed ) {
+					if ( ! $removed && $stored_value === $row->meta_value ) {
+						$removed = true;
+						return false;
+					}
+					return true;
+				}
+			)
+		);
+		if ( empty( $current ) ) {
+			unset( $GLOBALS['ec_test']['blogs'][ $row->blog_id ]['post_meta'][ $row->post_id ][ $row->meta_key ] );
+		} else {
+			$GLOBALS['ec_test']['blogs'][ $row->blog_id ]['post_meta'][ $row->post_id ][ $row->meta_key ] = $current;
+		}
+	} else {
+		unset( $GLOBALS['ec_test']['blogs'][ $row->blog_id ]['post_meta'][ $row->post_id ][ $row->meta_key ] );
+	}
+	unset( $GLOBALS['ec_test']['post_meta_rows'][ $meta_id ] );
 	return true;
 }
 
@@ -943,7 +1013,27 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		return ec_artist_link_page_legacy_owner_reference( $value, (int) ( $args[0] ?? 0 ) );
 	}
 	if ( 'ec_link_page_legacy_owner_candidates' === $hook_name ) {
-		return ec_artist_link_page_legacy_owner_candidates( $value, (string) ( $args[0] ?? '' ) );
+		$callbacks = $GLOBALS['ec_test']['filter_callbacks'][ $hook_name ] ?? array();
+		usort(
+			$callbacks,
+			static function ( $left, $right ) {
+				return (int) $left['priority'] <=> (int) $right['priority'];
+			}
+		);
+		foreach ( $callbacks as $callback ) {
+			if ( (int) $callback['priority'] >= 10 ) {
+				continue;
+			}
+			$value = $callback['callback']( $value, ...$args );
+		}
+		$value = ec_artist_link_page_legacy_owner_candidates( $value, (string) ( $args[0] ?? '' ) );
+		foreach ( $callbacks as $callback ) {
+			if ( (int) $callback['priority'] < 10 ) {
+				continue;
+			}
+			$value = $callback['callback']( $value, ...$args );
+		}
+		return $value;
 	}
 	return $value;
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1009,32 +1009,6 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		$producer = (string) ( $args[0] ?? '' );
 		return in_array( $producer, $GLOBALS['ec_test']['authorized_local_support_producers'] ?? array(), true );
 	}
-	if ( 'ec_link_page_legacy_owner_reference' === $hook_name ) {
-		return ec_artist_link_page_legacy_owner_reference( $value, (int) ( $args[0] ?? 0 ) );
-	}
-	if ( 'ec_link_page_legacy_owner_candidates' === $hook_name ) {
-		$callbacks = $GLOBALS['ec_test']['filter_callbacks'][ $hook_name ] ?? array();
-		usort(
-			$callbacks,
-			static function ( $left, $right ) {
-				return (int) $left['priority'] <=> (int) $right['priority'];
-			}
-		);
-		foreach ( $callbacks as $callback ) {
-			if ( (int) $callback['priority'] >= 10 ) {
-				continue;
-			}
-			$value = $callback['callback']( $value, ...$args );
-		}
-		$value = ec_artist_link_page_legacy_owner_candidates( $value, (string) ( $args[0] ?? '' ) );
-		foreach ( $callbacks as $callback ) {
-			if ( (int) $callback['priority'] < 10 ) {
-				continue;
-			}
-			$value = $callback['callback']( $value, ...$args );
-		}
-		return $value;
-	}
 	return $value;
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -170,6 +170,38 @@ function get_current_blog_id() {
 	return $GLOBALS['ec_test']['current_blog_id'] ?? 4;
 }
 
+function get_site( $blog_id = null ) {
+	$blog_id = $blog_id ?: get_current_blog_id();
+	if ( ! isset( $GLOBALS['ec_test']['blogs'][ $blog_id ] ) ) {
+		return null;
+	}
+	return (object) array_merge(
+		array( 'blog_id' => (int) $blog_id, 'deleted' => '0', 'archived' => '0', 'spam' => '0' ),
+		$GLOBALS['ec_test']['sites'][ $blog_id ] ?? array()
+	);
+}
+
+function post_type_exists( $post_type ) {
+	if ( isset( $GLOBALS['ec_test']['registered_post_types'][ $post_type ] ) ) {
+		return true;
+	}
+	foreach ( ec_test_blog_store( 'posts' ) as $post ) {
+		if ( $post_type === $post->post_type ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function taxonomy_exists( $taxonomy ) {
+	foreach ( ec_test_blog_store( 'terms' ) as $term ) {
+		if ( $taxonomy === $term->taxonomy ) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function add_action() {
 	return true;
 }
@@ -690,7 +722,15 @@ function get_posts( $args ) {
 		}
 		$ids[] = (int) $post_id;
 	}
-	return $ids;
+	if ( 'ID' === ( $args['orderby'] ?? '' ) ) {
+		sort( $ids, SORT_NUMERIC );
+		if ( 'DESC' === ( $args['order'] ?? 'ASC' ) ) {
+			$ids = array_reverse( $ids );
+		}
+	}
+	$offset = (int) ( $args['offset'] ?? 0 );
+	$limit  = isset( $args['posts_per_page'] ) && $args['posts_per_page'] >= 0 ? (int) $args['posts_per_page'] : null;
+	return array_slice( $ids, $offset, $limit );
 }
 
 function wp_insert_term( $title, $taxonomy, $args = array() ) {
@@ -976,6 +1016,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/update-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/create-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/onboard-external-artist.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-invitation.php';
+require_once dirname( __DIR__ ) . '/inc/link-pages/owner-reference.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-styles.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -144,8 +144,11 @@ function ec_test_blog_store( $type ) {
 }
 
 function switch_to_blog( $blog_id ) {
-	$GLOBALS['ec_test']['blog_stack'][] = $GLOBALS['ec_test']['current_blog_id'] ?? 4;
+	$previous_blog_id = $GLOBALS['ec_test']['current_blog_id'] ?? 4;
+	$GLOBALS['ec_test']['blog_stack'][] = $previous_blog_id;
+	$GLOBALS['_wp_switched_stack'][]    = $previous_blog_id;
 	$GLOBALS['ec_test']['current_blog_id'] = (int) $blog_id;
+	$GLOBALS['switched'] = true;
 	return true;
 }
 
@@ -153,6 +156,10 @@ function restore_current_blog() {
 	if ( ! empty( $GLOBALS['ec_test']['blog_stack'] ) ) {
 		$GLOBALS['ec_test']['current_blog_id'] = array_pop( $GLOBALS['ec_test']['blog_stack'] );
 	}
+	if ( ! empty( $GLOBALS['_wp_switched_stack'] ) ) {
+		array_pop( $GLOBALS['_wp_switched_stack'] );
+	}
+	$GLOBALS['switched'] = ! empty( $GLOBALS['_wp_switched_stack'] );
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- add an opaque, normalized Link Page owner reference while preserving existing blog-4 records and artist-facing behavior
- dual-write new artist Link Pages and retain read-only legacy fallback for existing `_associated_artist_profile_id` records
- enforce deterministic owner uniqueness, rollback/compensation, and bounded idempotent backfill behavior

## Compatibility contract
Existing `artist_link_page` post IDs, slugs, public URLs, analytics associations, abilities, REST routes, Roadie behavior, and editing workflows remain unchanged. The existing `_associated_artist_profile_id` and `_extrch_link_page_id` reciprocal metadata remains in place and authoritative as the compatibility fallback for records without the new owner metadata.

No existing record is mutated during reads. The backfill is an explicitly invoked, bounded callable and is not scheduled or run automatically.

## Owner reference
The new `_ec_link_page_owner_reference` metadata stores a canonical opaque string:

`kind:blog_id:subtype:object_id`

Examples:
- `post:4:artist_profile:123`
- `term:7:venue:456`

Parsing accepts only `post` or `term`, positive blog/object IDs, and normalized subtype identifiers. Normalization verifies that the multisite blog exists and is active, switches to that blog, and validates the exact post type or taxonomy/object pair with WordPress APIs. Blog context is restored in all paths.

## Fallback and dual-write
Existing Link Pages without `_ec_link_page_owner_reference` resolve `_associated_artist_profile_id` as a blog-4 `artist_profile` post without writing metadata. New artist Link Page creation retains both legacy reciprocal writes and additionally assigns the normalized owner reference.

## Conflicts and rollback
Owner lookup fails closed when multiple pages store the same owner, multiple legacy pages resolve to one owner, or a page has duplicate owner rows. Assignment rejects invalid references, pages already owned by another object, and owners already assigned elsewhere. It rechecks uniqueness after persistence and compensates its own write if a conflict appears during assignment.

Creation rollback now removes the owner reference along with both legacy association directions. Forced replacement permits only the known old/new temporary pair, detaches the old normalized owner, and restores the prior association if detachment fails. Unsafe compensation still returns the existing manual-reconciliation failure.

## Backfill
`ec_backfill_link_page_owner_references( $limit, $offset )` inspects at most 500 records per call, reports processed/updated/skipped/errors plus the next offset, remains idempotent, and does not mutate malformed or already normalized records.

## Verification
- `vendor/bin/phpunit` (178 tests, 1,100 assertions)
- focused owner-reference and creation rollback tests
- PHP syntax checks for changed production files
- WordPress Coding Standards on `inc/link-pages/owner-reference.php` (clean)
- `git diff --check`

The repository-wide WordPress PHPCS target was also run and remains red on longstanding baseline violations throughout existing files, including the plugin bootstrap and creation file. No new-file WPCS findings remain. No JavaScript was touched, so JS checks were not applicable.

## Deferred work
This PR does not create the dedicated `extrachill-link-pages` plugin or multisite site, move records or attachments, map `extrachill.link`, extract the editor block/renderer, add venue behavior, or add new REST/database/analytics/cache/media infrastructure. Those remain phased extraction work after this compatibility seam is proven.

Refs #152
