### PR TITLE
Add exact date ranges to Artist Analytics

### DIFF
--- a/inc/abilities/handlers/artist-get-analytics.php
+++ b/inc/abilities/handlers/artist-get-analytics.php
@@ -15,14 +15,18 @@ defined( 'ABSPATH' ) || exit;
  * Get link page analytics for an artist.
  *
  * @param array $input {
- *     @type int $id         Artist profile post ID.
- *     @type int $date_range Number of days to query (default 30, max 90).
+ *     @type int    $id         Artist profile post ID.
+ *     @type int    $date_range Number of days to query (default 30, max 90).
+ *     @type string $start_date Inclusive exact window start in Y-m-d format.
+ *     @type string $end_date   Inclusive exact window end in Y-m-d format.
  * }
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_artist_get_analytics( array $input ): array|WP_Error {
 	$artist_id  = isset( $input['id'] ) ? (int) $input['id'] : 0;
 	$date_range = isset( $input['date_range'] ) ? (int) $input['date_range'] : 30;
+	$start_date = isset( $input['start_date'] ) ? (string) $input['start_date'] : '';
+	$end_date   = isset( $input['end_date'] ) ? (string) $input['end_date'] : '';
 
 	if ( ! $artist_id ) {
 		return new WP_Error( 'missing_id', 'id is required.' );
@@ -47,11 +51,13 @@ function extrachill_artist_platform_ability_artist_get_analytics( array $input )
 	/**
 	 * Retrieve link page analytics via filter hook.
 	 *
-	 * @param mixed $result       Previous filter result (null if no handler).
-	 * @param int   $link_page_id The link page post ID.
-	 * @param int   $date_range   Number of days to query.
+	 * @param mixed  $result       Previous filter result (null if no handler).
+	 * @param int    $link_page_id The link page post ID.
+	 * @param int    $date_range   Number of days to query.
+	 * @param string $start_date   Inclusive exact window start in Y-m-d format.
+	 * @param string $end_date     Inclusive exact window end in Y-m-d format.
 	 */
-	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range );
+	$result = apply_filters( 'extrachill_get_link_page_analytics', null, $link_page_id, $date_range, $start_date, $end_date );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -1147,6 +1147,8 @@ function extrachill_artist_platform_register_abilities() {
 				'properties'           => array(
 					'id'         => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
 					'date_range' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 90, 'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ) ),
+					'start_date' => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$', 'description' => __( 'Inclusive exact window start in Y-m-d format.', 'extrachill-artist-platform' ) ),
+					'end_date'   => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$', 'description' => __( 'Inclusive exact window end in Y-m-d format.', 'extrachill-artist-platform' ) ),
 				),
 				'additionalProperties' => false,
 			),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@extrachill/api-client": "^0.2.1",
+        "@extrachill/api-client": "^0.9.0",
         "@extrachill/components": "^0.9.1",
         "@wordpress/api-fetch": "^7.0.0",
         "@wordpress/block-editor": "^14.0.0",
@@ -2596,9 +2596,9 @@
       }
     },
     "node_modules/@extrachill/api-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.2.1.tgz",
-      "integrity": "sha512-72mBcsQYyVH+8DcQyJNPvxXV9wMAcDet94HWxzBc55+tFaFeXtiTcogS1jmcC/yLEvNiFXmxFleGO9ptOM3nCg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.9.0.tgz",
+      "integrity": "sha512-1XumtlrpKlHOEIoBiEwA6a6PnZEQTfKLhcAQj/btJlstU9N/I10Mny3Qyl+doX1TpBzNCH9I1Y9S+Vq1k/Pq+Q==",
       "license": "GPL-2.0+"
     },
     "node_modules/@extrachill/components": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@extrachill/api-client": "^0.2.1",
+    "@extrachill/api-client": "^0.9.0",
     "@extrachill/components": "^0.9.1",
     "@wordpress/api-fetch": "^7.0.0",
     "@wordpress/block-editor": "^14.0.0",

--- a/src/blocks/artist-analytics/components/Analytics.js
+++ b/src/blocks/artist-analytics/components/Analytics.js
@@ -4,16 +4,35 @@
  * Main analytics dashboard with Chart.js visualization.
  */
 
-import { useEffect, useRef, useCallback } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { ActionRow, BlockShell, BlockShellHeader, BlockShellInner, Panel, PanelHeader, Section } from '@extrachill/components';
+import {
+	ActionRow,
+	BlockShell,
+	BlockShellHeader,
+	BlockShellInner,
+	Panel,
+	PanelHeader,
+	Section,
+} from '@extrachill/components';
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import useAnalytics from '../hooks/useAnalytics';
 import ArtistSwitcher from '../../shared/components/ArtistSwitcher';
+import DateRangeControl from './DateRangeControl';
 
 export default function Analytics() {
-	const { artistId, userArtists, switchArtist, linkPageBaseUrl } = useAnalyticsContext();
-	const { analytics, dateRange, setDateRange, isLoading, error } = useAnalytics( artistId );
+	const { artistId, userArtists, switchArtist, linkPageBaseUrl } =
+		useAnalyticsContext();
+	const {
+		analytics,
+		selection,
+		selectPreset,
+		selectCustom,
+		selectExact,
+		reset,
+		isLoading,
+		error,
+	} = useAnalytics( artistId );
 	const currentArtist = userArtists.find( ( a ) => a.id === artistId );
 	const artistSlug = currentArtist?.slug || '';
 	const chartRef = useRef( null );
@@ -32,7 +51,7 @@ export default function Analytics() {
 			// scales, and elements already registered). Resolve defensively
 			// across those shapes. The external mapping is why the
 			// extraneous-dependency lint rule is suppressed here.
-			// eslint-disable-next-line import/no-extraneous-dependencies
+			// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 			const ChartModule = await import( 'chart.js/auto' );
 			const Chart =
 				ChartModule?.default || ChartModule?.Chart || ChartModule;
@@ -47,16 +66,26 @@ export default function Analytics() {
 					labels: analytics.chart_data?.labels || [],
 					datasets: [
 						{
-							label: __( 'Page Views', 'extrachill-artist-platform' ),
-							data: analytics.chart_data?.datasets?.[ 0 ]?.data || [],
+							label: __(
+								'Page Views',
+								'extrachill-artist-platform'
+							),
+							data:
+								analytics.chart_data?.datasets?.[ 0 ]?.data ||
+								[],
 							borderColor: '#e94560',
 							backgroundColor: 'rgba(233, 69, 96, 0.1)',
 							tension: 0.4,
 							fill: true,
 						},
 						{
-							label: __( 'Link Clicks', 'extrachill-artist-platform' ),
-							data: analytics.chart_data?.datasets?.[ 1 ]?.data || [],
+							label: __(
+								'Link Clicks',
+								'extrachill-artist-platform'
+							),
+							data:
+								analytics.chart_data?.datasets?.[ 1 ]?.data ||
+								[],
 							borderColor: '#4ecdc4',
 							backgroundColor: 'rgba(78, 205, 196, 0.1)',
 							tension: 0.4,
@@ -90,15 +119,14 @@ export default function Analytics() {
 		};
 	}, [ analytics ] );
 
-	const handleDateRangeChange = useCallback( ( e ) => {
-		setDateRange( parseInt( e.target.value, 10 ) );
-	}, [ setDateRange ] );
-
 	return (
 		<BlockShell className="ec-aa">
 			<BlockShellInner maxWidth="wide">
 				<BlockShellHeader
-					title={ __( 'Artist Analytics', 'extrachill-artist-platform' ) }
+					title={ __(
+						'Artist Analytics',
+						'extrachill-artist-platform'
+					) }
 					actions={
 						<ActionRow align="end" className="ec-aa__toolbar">
 							<ArtistSwitcher
@@ -111,26 +139,33 @@ export default function Analytics() {
 									href={ `${ linkPageBaseUrl }/${ artistSlug }` }
 									className="button-3 button-small"
 								>
-									{ __( 'View Link Page', 'extrachill-artist-platform' ) }
+									{ __(
+										'View Link Page',
+										'extrachill-artist-platform'
+									) }
 								</a>
 							) }
-							<select
-								value={ dateRange }
-								onChange={ handleDateRangeChange }
-								className="ec-aa__date-range"
-							>
-								<option value={ 7 }>{ __( 'Last 7 days', 'extrachill-artist-platform' ) }</option>
-								<option value={ 30 }>{ __( 'Last 30 days', 'extrachill-artist-platform' ) }</option>
-								<option value={ 90 }>{ __( 'Last 90 days', 'extrachill-artist-platform' ) }</option>
-							</select>
+							<DateRangeControl
+								selection={ selection }
+								onSelectPreset={ selectPreset }
+								onSelectCustom={ selectCustom }
+								onSelectExact={ selectExact }
+								onReset={ reset }
+							/>
 						</ActionRow>
 					}
 				/>
 
+				{ /* eslint-disable-next-line no-nested-ternary */ }
 				{ isLoading ? (
 					<div className="ec-aa ec-aa--loading">
 						<span className="spinner is-active"></span>
-						<p>{ __( 'Loading analytics...', 'extrachill-artist-platform' ) }</p>
+						<p>
+							{ __(
+								'Loading analytics…',
+								'extrachill-artist-platform'
+							) }
+						</p>
 					</div>
 				) : error ? (
 					<div className="notice notice-error">
@@ -140,20 +175,45 @@ export default function Analytics() {
 					<>
 						<Section className="ec-aa__stats" depth={ 1 }>
 							<div className="ec-aa__stat">
-								<span className="ec-aa__stat-value">{ analytics?.summary?.total_views || 0 }</span>
-								<span className="ec-aa__stat-label">{ __( 'Total Views', 'extrachill-artist-platform' ) }</span>
+								<span className="ec-aa__stat-value">
+									{ analytics?.summary?.total_views || 0 }
+								</span>
+								<span className="ec-aa__stat-label">
+									{ __(
+										'Total Views',
+										'extrachill-artist-platform'
+									) }
+								</span>
 							</div>
 							<div className="ec-aa__stat">
-								<span className="ec-aa__stat-value">{ analytics?.summary?.total_clicks || 0 }</span>
-								<span className="ec-aa__stat-label">{ __( 'Total Clicks', 'extrachill-artist-platform' ) }</span>
+								<span className="ec-aa__stat-value">
+									{ analytics?.summary?.total_clicks || 0 }
+								</span>
+								<span className="ec-aa__stat-label">
+									{ __(
+										'Total Clicks',
+										'extrachill-artist-platform'
+									) }
+								</span>
 							</div>
 							<div className="ec-aa__stat">
 								<span className="ec-aa__stat-value">
 									{ analytics?.summary?.total_views
-										? `${ ( ( analytics.summary.total_clicks / analytics.summary.total_views ) * 100 ).toFixed( 1 ) }%`
+										? `${ (
+												( analytics.summary
+													.total_clicks /
+													analytics.summary
+														.total_views ) *
+												100
+										  ).toFixed( 1 ) }%`
 										: '0%' }
 								</span>
-								<span className="ec-aa__stat-label">{ __( 'Click Rate', 'extrachill-artist-platform' ) }</span>
+								<span className="ec-aa__stat-label">
+									{ __(
+										'Click Rate',
+										'extrachill-artist-platform'
+									) }
+								</span>
 							</div>
 						</Section>
 
@@ -162,30 +222,59 @@ export default function Analytics() {
 						</Panel>
 
 						<Panel className="ec-aa__top-links" compact depth={ 1 }>
-							<PanelHeader title={ __( 'Top Links', 'extrachill-artist-platform' ) } />
+							<PanelHeader
+								title={ __(
+									'Top Links',
+									'extrachill-artist-platform'
+								) }
+							/>
 							<table className="ec-aa__table">
 								<thead>
 									<tr>
-										<th>{ __( 'Link Text / URL', 'extrachill-artist-platform' ) }</th>
-										<th>{ __( 'Clicks', 'extrachill-artist-platform' ) }</th>
+										<th>
+											{ __(
+												'Link Text / URL',
+												'extrachill-artist-platform'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Clicks',
+												'extrachill-artist-platform'
+											) }
+										</th>
 									</tr>
 								</thead>
 								<tbody>
 									{ analytics?.top_links?.length > 0 ? (
-										analytics.top_links.map( ( link, index ) => (
-											<tr key={ index }>
-												<td>
-													<span className="ec-aa__link-title">{ link.text || link.identifier }</span>
-													{ link.identifier && (
-														<span className="ec-aa__link-url">{ link.identifier }</span>
-													) }
-												</td>
-												<td>{ link.clicks }</td>
-											</tr>
-										) )
+										analytics.top_links.map(
+											( link, index ) => (
+												<tr key={ index }>
+													<td>
+														<span className="ec-aa__link-title">
+															{ link.text ||
+																link.identifier }
+														</span>
+														{ link.identifier && (
+															<span className="ec-aa__link-url">
+																{
+																	link.identifier
+																}
+															</span>
+														) }
+													</td>
+													<td>{ link.clicks }</td>
+												</tr>
+											)
+										)
 									) : (
 										<tr>
-											<td colSpan="2">{ __( 'No link click data available.', 'extrachill-artist-platform' ) }</td>
+											<td colSpan="2">
+												{ __(
+													'No link click data available.',
+													'extrachill-artist-platform'
+												) }
+											</td>
 										</tr>
 									) }
 								</tbody>
@@ -193,7 +282,10 @@ export default function Analytics() {
 						</Panel>
 
 						<p className="ec-aa__note">
-							{ __( 'Analytics data is updated daily. Data older than 90 days is automatically pruned.', 'extrachill-artist-platform' ) }
+							{ __(
+								'Analytics data is updated daily. Data older than 90 days is automatically pruned.',
+								'extrachill-artist-platform'
+							) }
 						</p>
 					</>
 				) }

--- a/src/blocks/artist-analytics/components/DateRangeControl.js
+++ b/src/blocks/artist-analytics/components/DateRangeControl.js
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const PRESETS = [ 7, 30, 90 ];
+
+export default function DateRangeControl( {
+	selection,
+	onSelectPreset,
+	onSelectCustom,
+	onSelectExact,
+	onReset,
+} ) {
+	const inputRef = useRef( null );
+	const controllerRef = useRef( null );
+	const [ dateError, setDateError ] = useState( '' );
+	const presetLabels = {
+		7: __( 'Last 7 days', 'extrachill-artist-platform' ),
+		30: __( 'Last 30 days', 'extrachill-artist-platform' ),
+		90: __( 'Last 90 days', 'extrachill-artist-platform' ),
+	};
+
+	useEffect( () => {
+		if ( selection.mode !== 'exact' || ! inputRef.current ) {
+			return undefined;
+		}
+
+		const runtime = window.ExtraChillAnalyticsDateRange;
+		if ( ! runtime?.create ) {
+			setDateError(
+				__(
+					'The custom date picker is temporarily unavailable.',
+					'extrachill-artist-platform'
+				)
+			);
+			return undefined;
+		}
+
+		try {
+			controllerRef.current = runtime.create( inputRef.current, {
+				maxDays: 90,
+				onChange: ( range ) => {
+					setDateError( '' );
+					onSelectExact( range );
+				},
+				onError: ( error ) => {
+					setDateError(
+						error?.message ||
+							__(
+								'Choose a date range of 90 days or fewer.',
+								'extrachill-artist-platform'
+							)
+					);
+				},
+			} );
+		} catch ( error ) {
+			setDateError(
+				error?.message ||
+					__(
+						'The custom date picker could not be initialized.',
+						'extrachill-artist-platform'
+					)
+			);
+		}
+
+		return () => {
+			controllerRef.current?.destroy();
+			controllerRef.current = null;
+		};
+	}, [ selection.mode, onSelectExact ] );
+
+	const handleSelectionChange = useCallback(
+		( event ) => {
+			if ( event.target.value === 'exact' ) {
+				onSelectCustom();
+				return;
+			}
+
+			onSelectPreset( parseInt( event.target.value, 10 ) );
+		},
+		[ onSelectCustom, onSelectPreset ]
+	);
+
+	const handleReset = useCallback( () => {
+		controllerRef.current?.reset();
+		setDateError( '' );
+		onReset();
+	}, [ onReset ] );
+
+	return (
+		<div className="ec-aa__date-controls">
+			<select
+				value={ selection.mode === 'preset' ? selection.days : 'exact' }
+				onChange={ handleSelectionChange }
+				className="ec-aa__date-range"
+				aria-label={ __(
+					'Analytics date range',
+					'extrachill-artist-platform'
+				) }
+			>
+				{ PRESETS.map( ( days ) => (
+					<option key={ days } value={ days }>
+						{ presetLabels[ days ] }
+					</option>
+				) ) }
+				<option value="exact">
+					{ __( 'Custom dates', 'extrachill-artist-platform' ) }
+				</option>
+			</select>
+			{ selection.mode === 'exact' && (
+				<input
+					ref={ inputRef }
+					type="text"
+					readOnly
+					className="ec-aa__exact-dates"
+					placeholder={ __(
+						'Choose dates',
+						'extrachill-artist-platform'
+					) }
+					aria-label={ __(
+						'Custom analytics dates',
+						'extrachill-artist-platform'
+					) }
+					aria-describedby={
+						dateError ? 'ec-aa-date-error' : undefined
+					}
+				/>
+			) }
+			<button
+				type="button"
+				className="button-3 button-small"
+				onClick={ handleReset }
+			>
+				{ __( 'Reset', 'extrachill-artist-platform' ) }
+			</button>
+			{ dateError && (
+				<span
+					id="ec-aa-date-error"
+					className="ec-aa__date-error"
+					role="alert"
+				>
+					{ dateError }
+				</span>
+			) }
+		</div>
+	);
+}

--- a/src/blocks/artist-analytics/hooks/useAnalytics.js
+++ b/src/blocks/artist-analytics/hooks/useAnalytics.js
@@ -4,43 +4,97 @@
  * Manages analytics data fetching, date range state, and loading/error states.
  */
 
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { getAnalytics } from '../../shared/api/client';
 
-export default function useAnalytics( artistId ) {
-	const [ dateRange, setDateRange ] = useState( 30 );
-	const [ analytics, setAnalytics ] = useState( null );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ error, setError ] = useState( null );
+const DEFAULT_SELECTION = { mode: 'preset', days: 30 };
 
-	const fetchAnalytics = useCallback( async () => {
-		if ( ! artistId ) {
-			return;
+export default function useAnalytics( artistId ) {
+	const [ selection, setSelection ] = useState( DEFAULT_SELECTION );
+	const [ analytics, setAnalytics ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+	const requestId = useRef( 0 );
+
+	useEffect( () => {
+		let range = null;
+		if ( selection.mode === 'preset' ) {
+			range = selection.days;
+		} else if ( selection.startDate && selection.endDate ) {
+			range = {
+				start_date: selection.startDate,
+				end_date: selection.endDate,
+			};
 		}
+		const currentRequest = ++requestId.current;
+
+		if ( ! artistId || ! range ) {
+			setIsLoading( false );
+			setError( null );
+			return undefined;
+		}
+
+		let active = true;
 
 		setIsLoading( true );
 		setError( null );
 
-		try {
-			const data = await getAnalytics( artistId, dateRange );
-			setAnalytics( data );
-		} catch ( err ) {
-			setError( err.message || 'Failed to load analytics' );
-		} finally {
-			setIsLoading( false );
-		}
-	}, [ artistId, dateRange ] );
+		getAnalytics( artistId, range )
+			.then( ( data ) => {
+				if ( active && currentRequest === requestId.current ) {
+					setAnalytics( data );
+				}
+			} )
+			.catch( ( err ) => {
+				if ( active && currentRequest === requestId.current ) {
+					setError( err.message || 'Failed to load analytics' );
+				}
+			} )
+			.finally( () => {
+				if ( active && currentRequest === requestId.current ) {
+					setIsLoading( false );
+				}
+			} );
 
-	useEffect( () => {
-		fetchAnalytics();
-	}, [ fetchAnalytics ] );
+		return () => {
+			active = false;
+		};
+	}, [ artistId, selection, refreshKey ] );
+
+	const selectPreset = useCallback( ( days ) => {
+		setSelection( { mode: 'preset', days } );
+	}, [] );
+
+	const selectCustom = useCallback( () => {
+		setSelection( { mode: 'exact', startDate: null, endDate: null } );
+	}, [] );
+
+	const selectExact = useCallback( ( range ) => {
+		setSelection( {
+			mode: 'exact',
+			startDate: range?.startDate || null,
+			endDate: range?.endDate || null,
+		} );
+	}, [] );
+
+	const reset = useCallback( () => {
+		setSelection( DEFAULT_SELECTION );
+	}, [] );
+
+	const refetch = useCallback( () => {
+		setRefreshKey( ( current ) => current + 1 );
+	}, [] );
 
 	return {
 		analytics,
-		dateRange,
-		setDateRange,
+		selection,
+		selectPreset,
+		selectCustom,
+		selectExact,
+		reset,
 		isLoading,
 		error,
-		refetch: fetchAnalytics,
+		refetch,
 	};
 }

--- a/src/blocks/artist-analytics/hooks/useAnalytics.js
+++ b/src/blocks/artist-analytics/hooks/useAnalytics.js
@@ -30,6 +30,7 @@ export default function useAnalytics( artistId ) {
 		const currentRequest = ++requestId.current;
 
 		if ( ! artistId || ! range ) {
+			setAnalytics( null );
 			setIsLoading( false );
 			setError( null );
 			return undefined;

--- a/src/blocks/artist-analytics/render.php
+++ b/src/blocks/artist-analytics/render.php
@@ -120,16 +120,16 @@ $config = array(
 // Enqueue the frontend script with localized data
 $asset_file = include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'build/blocks/artist-analytics/view.asset.php';
 
-// Chart.js is consumed from extrachill-analytics' (ECA) shared, network-
-// activated handle ('extrachill-analytics-chart' → window.ExtraChillChart)
-// rather than bundled locally (extrachill-artist-platform#89,
-// extrachill-analytics#93). Declare it as an explicit dependency so the global
-// is present before this view script runs. wp-scripts won't add it to
-// view.asset.php because it's resolved as a webpack external, so append it here.
+// Analytics owns both shared runtimes. Declare them explicitly so Chart.js and
+// the date-range controller are available before this view script executes.
 $analytics_deps = $asset_file['dependencies'];
-if ( ! in_array( 'extrachill-analytics-chart', $analytics_deps, true ) ) {
-	$analytics_deps[] = 'extrachill-analytics-chart';
+foreach ( array( 'extrachill-analytics-chart', 'extrachill-analytics-date-range' ) as $dependency ) {
+	if ( ! in_array( $dependency, $analytics_deps, true ) ) {
+		$analytics_deps[] = $dependency;
+	}
 }
+
+wp_enqueue_style( 'extrachill-analytics-date-range' );
 
 wp_enqueue_script(
 	'ec-artist-analytics-frontend',

--- a/src/blocks/artist-analytics/style.scss
+++ b/src/blocks/artist-analytics/style.scss
@@ -2,7 +2,7 @@
  * Artist Analytics Block - Frontend Styles
  */
 
-@use '../../../node_modules/@extrachill/components/styles/components' as *;
+@use "../../../node_modules/@extrachill/components/styles/components" as *;
 
 .ec-artist-analytics {
 	max-width: 1200px;
@@ -42,6 +42,13 @@
 	gap: 12px;
 }
 
+.ec-aa__date-controls {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	position: relative;
+}
+
 .ec-aa__date-range {
 	padding: 8px 12px;
 	border-radius: 6px;
@@ -59,6 +66,24 @@
 		border-color: var(--accent);
 		box-shadow: 0 0 0 2px rgba(var(--accent-rgb), 0.2);
 	}
+}
+
+.ec-aa__exact-dates {
+	min-width: 210px;
+	padding: 8px 12px;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	background: var(--background-color);
+}
+
+.ec-aa__date-error {
+	position: absolute;
+	top: calc(100% + 4px);
+	right: 0;
+	max-width: 320px;
+	color: var(--error-color, #b32d2e);
+	font-size: 12px;
+	line-height: 1.4;
 }
 
 .ec-aa__stats {
@@ -135,18 +160,18 @@
 		font-size: 14px;
 	}
 
+	td:last-child {
+		text-align: right;
+		font-weight: 600;
+		color: var(--accent);
+	}
+
 	tr:last-child td {
 		border-bottom: none;
 	}
 
 	tr:hover td {
 		background: var(--card-background);
-	}
-
-	td:last-child {
-		text-align: right;
-		font-weight: 600;
-		color: var(--accent);
 	}
 }
 
@@ -171,12 +196,25 @@
 
 /* Responsive - Tablet */
 @media (max-width: 768px) {
+
 	.ec-aa {
 		gap: 16px;
 	}
 
-	.ec-aa__date-range {
+	.ec-aa__date-controls,
+	.ec-aa__date-range,
+	.ec-aa__exact-dates {
 		width: 100%;
+	}
+
+	.ec-aa__date-controls {
+		flex-wrap: wrap;
+	}
+
+	.ec-aa__date-error {
+		position: static;
+		flex-basis: 100%;
+		max-width: none;
 	}
 
 	.ec-aa__stats {
@@ -194,7 +232,9 @@
 
 /* Responsive - Mobile */
 @media (max-width: 480px) {
+
 	.ec-aa__table {
+
 		th,
 		td {
 			padding: 10px 12px;

--- a/src/blocks/shared/api/client.js
+++ b/src/blocks/shared/api/client.js
@@ -95,8 +95,8 @@ export const updateSocials = ( artistId, data ) =>
 
 // ─── Analytics ──────────────────────────────────────────────────────────────
 
-export const getAnalytics = ( artistId, dateRange = 30 ) =>
-	client.artists.getAnalytics( artistId, dateRange );
+export const getAnalytics = ( artistId, range = 30 ) =>
+	client.artists.getAnalytics( artistId, range );
 
 // ─── Media ──────────────────────────────────────────────────────────────────
 

--- a/tests/ArtistAnalyticsContractTest.php
+++ b/tests/ArtistAnalyticsContractTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistAnalyticsContractTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'current_user_id' => 7,
+			'managed_artists' => array( 7 => array( 42 ) ),
+			'analytics_result' => array(
+				'summary'    => array( 'total_views' => 1, 'total_clicks' => 0 ),
+				'chart_data' => array( 'labels' => array(), 'datasets' => array() ),
+				'top_links'  => array(),
+			),
+			'blogs' => array(
+				4 => array(
+					'posts' => array(
+						42  => (object) array(
+							'ID'          => 42,
+							'post_type'   => 'artist_profile',
+							'post_status' => 'publish',
+						),
+						142 => (object) array(
+							'ID'          => 142,
+							'post_type'   => 'artist_link_page',
+							'post_status' => 'publish',
+						),
+					),
+					'post_meta' => array(
+						142 => array( '_associated_artist_profile_id' => 42 ),
+					),
+				),
+			),
+		);
+
+		extrachill_artist_platform_register_abilities();
+	}
+
+	public function test_ability_schema_preserves_legacy_range_and_adds_exact_dates(): void {
+		$properties = wp_get_ability( 'extrachill/artist-get-analytics' )
+			->get_input_schema()['properties'];
+
+		$this->assertSame( 90, $properties['date_range']['maximum'] );
+		$this->assertSame( '^\\d{4}-\\d{2}-\\d{2}$', $properties['start_date']['pattern'] );
+		$this->assertSame( '^\\d{4}-\\d{2}-\\d{2}$', $properties['end_date']['pattern'] );
+	}
+
+	public function test_legacy_date_range_is_clamped_and_forwarded(): void {
+		$result = extrachill_artist_platform_ability_artist_get_analytics(
+			array( 'id' => 42, 'date_range' => 120 )
+		);
+
+		$this->assertSame( $GLOBALS['ec_test']['analytics_result'], $result );
+		$this->assertSame(
+			array( 142, 90, '', '' ),
+			$GLOBALS['ec_test']['analytics_filter_args'][0]
+		);
+	}
+
+	public function test_exact_dates_are_forwarded_with_the_legacy_fallback(): void {
+		extrachill_artist_platform_ability_artist_get_analytics(
+			array(
+				'id'         => 42,
+				'date_range' => 7,
+				'start_date' => '2026-06-01',
+				'end_date'   => '2026-06-30',
+			)
+		);
+
+		$this->assertSame(
+			array( 142, 7, '2026-06-01', '2026-06-30' ),
+			$GLOBALS['ec_test']['analytics_filter_args'][0]
+		);
+	}
+
+	public function test_analytics_assets_use_shared_script_and_style_handles(): void {
+		$render  = file_get_contents( dirname( __DIR__ ) . '/src/blocks/artist-analytics/render.php' );
+		$webpack = file_get_contents( dirname( __DIR__ ) . '/webpack.config.js' );
+
+		$this->assertStringContainsString( "'extrachill-analytics-date-range'", $render );
+		$this->assertStringContainsString( "wp_enqueue_style( 'extrachill-analytics-date-range' )", $render );
+		$this->assertStringNotContainsString( 'flatpickr', strtolower( $webpack ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1023,6 +1023,10 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		$producer = (string) ( $args[0] ?? '' );
 		return in_array( $producer, $GLOBALS['ec_test']['authorized_local_support_producers'] ?? array(), true );
 	}
+	if ( 'extrachill_get_link_page_analytics' === $hook_name ) {
+		$GLOBALS['ec_test']['analytics_filter_args'][] = $args;
+		return $GLOBALS['ec_test']['analytics_result'] ?? $value;
+	}
 	return $value;
 }
 

--- a/tests/js/artist-analytics-client.test.js
+++ b/tests/js/artist-analytics-client.test.js
@@ -1,0 +1,24 @@
+import apiFetch from '@wordpress/api-fetch';
+import { getAnalytics } from '../../src/blocks/shared/api/client';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'Artist Analytics API client', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( { summary: {} } );
+	} );
+
+	it( 'serializes exact dates through the released shared client', async () => {
+		await getAnalytics( 42, {
+			start_date: '2026-06-01',
+			end_date: '2026-06-30',
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: 'extrachill/v1/artists/42/analytics?start_date=2026-06-01&end_date=2026-06-30',
+			} )
+		);
+	} );
+} );

--- a/tests/js/artist-analytics-date-range.test.js
+++ b/tests/js/artist-analytics-date-range.test.js
@@ -1,0 +1,113 @@
+// React's test-only act helper is supplied transitively by @wordpress/element.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+import { createRoot } from '@wordpress/element';
+import DateRangeControl from '../../src/blocks/artist-analytics/components/DateRangeControl';
+
+describe( 'Artist Analytics date range control', () => {
+	let container;
+	let root;
+	let controller;
+	let options;
+
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+		controller = {
+			reset: jest.fn(),
+			destroy: jest.fn(),
+		};
+		window.ExtraChillAnalyticsDateRange = {
+			create: jest.fn( ( input, createOptions ) => {
+				options = createOptions;
+				return controller;
+			} ),
+		};
+	} );
+
+	afterEach( () => {
+		act( () => root.unmount() );
+		container.remove();
+		delete window.ExtraChillAnalyticsDateRange;
+	} );
+
+	function render( selection, overrides = {} ) {
+		const props = {
+			selection,
+			onSelectPreset: jest.fn(),
+			onSelectCustom: jest.fn(),
+			onSelectExact: jest.fn(),
+			onReset: jest.fn(),
+			...overrides,
+		};
+		act( () => root.render( <DateRangeControl { ...props } /> ) );
+		return props;
+	}
+
+	test( 'initializes only for custom mode and destroys on mode change', () => {
+		render( { mode: 'preset', days: 30 } );
+		expect(
+			window.ExtraChillAnalyticsDateRange.create
+		).not.toHaveBeenCalled();
+
+		render( { mode: 'exact', startDate: null, endDate: null } );
+		expect(
+			window.ExtraChillAnalyticsDateRange.create
+		).toHaveBeenCalledWith(
+			expect.any( window.HTMLInputElement ),
+			expect.objectContaining( { maxDays: 90 } )
+		);
+
+		render( { mode: 'preset', days: 7 } );
+		expect( controller.destroy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'delivers exact ranges and resets through the shared controller', () => {
+		const onSelectExact = jest.fn();
+		const onReset = jest.fn();
+		render(
+			{ mode: 'exact', startDate: null, endDate: null },
+			{ onSelectExact, onReset }
+		);
+
+		act( () =>
+			options.onChange( {
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+			} )
+		);
+		expect( onSelectExact ).toHaveBeenCalledWith( {
+			startDate: '2026-06-01',
+			endDate: '2026-06-30',
+		} );
+
+		act( () =>
+			container
+				.querySelector( 'button' )
+				.dispatchEvent(
+					new window.MouseEvent( 'click', { bubbles: true } )
+				)
+		);
+		expect( controller.reset ).toHaveBeenCalledTimes( 1 );
+		expect( onReset ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'shows shared runtime validation failures accessibly', () => {
+		render( { mode: 'exact', startDate: null, endDate: null } );
+
+		act( () => options.onError( new RangeError( 'Maximum 90 days.' ) ) );
+
+		expect( container.querySelector( '[role="alert"]' ).textContent ).toBe(
+			'Maximum 90 days.'
+		);
+	} );
+} );

--- a/tests/js/use-analytics.test.js
+++ b/tests/js/use-analytics.test.js
@@ -78,7 +78,12 @@ describe( 'useAnalytics', () => {
 		await act( async () => current.selectCustom() );
 
 		expect( getAnalytics ).not.toHaveBeenCalled();
+		expect( current.analytics ).toBeNull();
 		expect( current.isLoading ).toBe( false );
+
+		await act( async () => root.render( <Harness artistId={ 43 } /> ) );
+		expect( getAnalytics ).not.toHaveBeenCalled();
+		expect( current.analytics ).toBeNull();
 	} );
 
 	test( 'prevents stale requests from overwriting the current range', async () => {

--- a/tests/js/use-analytics.test.js
+++ b/tests/js/use-analytics.test.js
@@ -1,0 +1,104 @@
+// React's test-only act helper is supplied transitively by @wordpress/element.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { act } from 'react';
+import { createRoot } from '@wordpress/element';
+import useAnalytics from '../../src/blocks/artist-analytics/hooks/useAnalytics';
+import { getAnalytics } from '../../src/blocks/shared/api/client';
+
+jest.mock( '../../src/blocks/shared/api/client', () => ( {
+	getAnalytics: jest.fn(),
+} ) );
+
+const deferred = () => {
+	let resolve;
+	let reject;
+	const promise = new Promise( ( promiseResolve, promiseReject ) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	} );
+	return { promise, resolve, reject };
+};
+
+describe( 'useAnalytics', () => {
+	let container;
+	let root;
+	let current;
+
+	beforeAll( () => {
+		global.IS_REACT_ACT_ENVIRONMENT = true;
+	} );
+
+	afterAll( () => {
+		delete global.IS_REACT_ACT_ENVIRONMENT;
+	} );
+
+	function Harness( { artistId = 42 } ) {
+		current = useAnalytics( artistId );
+		return null;
+	}
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+		getAnalytics.mockReset();
+	} );
+
+	afterEach( () => {
+		act( () => root.unmount() );
+		container.remove();
+	} );
+
+	test( 'preserves numeric presets and sends exact object requests', async () => {
+		getAnalytics.mockResolvedValue( { summary: {} } );
+		await act( async () => root.render( <Harness /> ) );
+
+		expect( getAnalytics ).toHaveBeenLastCalledWith( 42, 30 );
+
+		await act( async () => current.selectPreset( 7 ) );
+		expect( getAnalytics ).toHaveBeenLastCalledWith( 42, 7 );
+
+		await act( async () =>
+			current.selectExact( {
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+			} )
+		);
+		expect( getAnalytics ).toHaveBeenLastCalledWith( 42, {
+			start_date: '2026-06-01',
+			end_date: '2026-06-30',
+		} );
+	} );
+
+	test( 'does not request an incomplete custom range', async () => {
+		getAnalytics.mockResolvedValue( { summary: {} } );
+		await act( async () => root.render( <Harness /> ) );
+		getAnalytics.mockClear();
+
+		await act( async () => current.selectCustom() );
+
+		expect( getAnalytics ).not.toHaveBeenCalled();
+		expect( current.isLoading ).toBe( false );
+	} );
+
+	test( 'prevents stale requests from overwriting the current range', async () => {
+		const presetRequest = deferred();
+		const exactRequest = deferred();
+		getAnalytics
+			.mockReturnValueOnce( presetRequest.promise )
+			.mockReturnValueOnce( exactRequest.promise );
+		act( () => root.render( <Harness /> ) );
+
+		act( () =>
+			current.selectExact( {
+				startDate: '2026-06-01',
+				endDate: '2026-06-30',
+			} )
+		);
+		await act( async () => exactRequest.resolve( { range: 'exact' } ) );
+		expect( current.analytics ).toEqual( { range: 'exact' } );
+
+		await act( async () => presetRequest.resolve( { range: 'stale' } ) );
+		expect( current.analytics ).toEqual( { range: 'exact' } );
+	} );
+} );


### PR DESCRIPTION
## Summary
- preserve the 7/30/90-day presets while adding explicit custom exact-date selection through Analytics' shared date-range controller
- forward `start_date` and `end_date` through the Artist ability/filter contract while retaining the legacy 90-day `date_range` path
- prevent stale analytics requests from replacing current data and cover controller lifecycle, request shape/races, ability schema/forwarding, and shared asset dependencies

## Dependency Chain
- Depends on Extra-Chill/extrachill-analytics#236 for exact link-page backend windows and the five-argument `extrachill_get_link_page_analytics` provider contract.
- Depends on Extra-Chill/extrachill-api#149 for REST forwarding.
- Depends on Extra-Chill/extrachill-api-client#18 and a subsequent npm release for the typed `getAnalytics(artistId, { date_range?, start_date?, end_date? })` contract.
- npm latest remains `@extrachill/api-client@0.8.0`, which does not contain #18, so this PR intentionally leaves the canonical dependency unchanged and does not bypass it with raw `apiFetch`. Update that dependency only after the supporting release exists.

## Compatibility
- Numeric `7`, `30`, and `90` requests remain unchanged.
- `date_range` remains available in the ability schema and is clamped to 90 days.
- Exact ranges are explicit state, capped at 90 days by the shared runtime, and forwarded alongside the legacy fallback so the Analytics-owned provider can give exact dates precedence.
- The frontend declares both `extrachill-analytics-date-range` script and style handles. The generated Artist Analytics bundle contains the shared global reference and no bundled Flatpickr code or CSS.
- Reset returns to the default 30-day preset; custom controller instances are destroyed on mode change/unmount.

## Verification
- `npm run test:js` (11 tests)
- `vendor/bin/phpunit --do-not-cache-result` (213 tests, 1186 assertions)
- scoped `wp-scripts lint-js` for changed JS and tests
- `wp-scripts lint-style src/blocks/artist-analytics/style.scss`
- `npm run build`
- PHP syntax checks for changed PHP files
- `git diff --check`
- static mobile/error/generated-asset review

PHPCS was not runnable because the repository's declared Composer dependencies do not install the configured `WordPress` coding standard. PHPStan is not configured.

Closes #175