### PR TITLE
fix: satisfy exact-date release lint

### DIFF
--- a/inc/abilities/handlers/artist-get-analytics.php
+++ b/inc/abilities/handlers/artist-get-analytics.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-get-analytics
  *
@@ -9,20 +8,17 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Get link page analytics for an artist.
  *
- * @param array $input {
- *     @type int    $id         Artist profile post ID.
- *     @type int    $date_range Number of days to query (default 30, max 90).
- *     @type string $start_date Inclusive exact window start in Y-m-d format.
- *     @type string $end_date   Inclusive exact window end in Y-m-d format.
- * }
+ * @param array $input Input parameters.
  * @return array|WP_Error
  */
-function extrachill_artist_platform_ability_artist_get_analytics( array $input ): array|WP_Error {
+function extrachill_artist_platform_ability_artist_get_analytics( array $input ) {
 	$artist_id  = isset( $input['id'] ) ? (int) $input['id'] : 0;
 	$date_range = isset( $input['date_range'] ) ? (int) $input['date_range'] : 30;
 	$start_date = isset( $input['start_date'] ) ? (string) $input['start_date'] : '';

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -57,7 +57,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -97,18 +97,42 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'artist_name', 'source_type', 'source_id' ),
 				'properties'           => array(
-					'submitter_user_id' => array( 'type' => 'integer', 'minimum' => 1 ),
-					'submitter_email'   => array( 'type' => 'string', 'format' => 'email' ),
-					'artist_name'       => array( 'type' => 'string', 'minLength' => 1 ),
-					'artist_term_id'    => array( 'type' => 'integer', 'minimum' => 1 ),
-					'artist_profile_id' => array( 'type' => 'integer', 'minimum' => 1 ),
-					'source_type'       => array( 'type' => 'string', 'minLength' => 1 ),
-					'source_id'         => array( 'type' => 'string', 'minLength' => 1 ),
-					'return_url'        => array( 'type' => 'string', 'format' => 'uri' ),
+					'submitter_user_id' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+					'submitter_email'   => array(
+						'type'   => 'string',
+						'format' => 'email',
+					),
+					'artist_name'       => array(
+						'type'      => 'string',
+						'minLength' => 1,
+					),
+					'artist_term_id'    => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+					'artist_profile_id' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+					'source_type'       => array(
+						'type'      => 'string',
+						'minLength' => 1,
+					),
+					'source_id'         => array(
+						'type'      => 'string',
+						'minLength' => 1,
+					),
+					'return_url'        => array(
+						'type'   => 'string',
+						'format' => 'uri',
+					),
 					'consent'           => array(
 						'type'                 => 'object',
 						'properties'           => array(
-							'profile_creation'  => array( 'type' => 'boolean' ),
+							'profile_creation'   => array( 'type' => 'boolean' ),
 							'link_page'          => array( 'type' => 'boolean' ),
 							'disclosure_version' => array( 'type' => 'string' ),
 						),
@@ -121,13 +145,22 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'outcome', 'user', 'artist', 'membership', 'claim', 'link_page', 'source', 'return_url', 'next_action' ),
 				'properties'           => array(
-					'outcome'     => array( 'type' => 'string', 'enum' => array( 'account_claim_required', 'authentication_required', 'artist_consent_required', 'membership_request_required', 'managed_artist', 'artist_created' ) ),
+					'outcome'     => array(
+						'type' => 'string',
+						'enum' => array( 'account_claim_required', 'authentication_required', 'artist_consent_required', 'membership_request_required', 'managed_artist', 'artist_created' ),
+					),
 					'user'        => array(
 						'type'                 => 'object',
 						'required'             => array( 'id', 'state', 'created' ),
 						'properties'           => array(
-							'id'      => array( 'type' => 'integer', 'minimum' => 1 ),
-							'state'   => array( 'type' => 'string', 'enum' => array( 'unclaimed', 'created', 'existing' ) ),
+							'id'      => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+							),
+							'state'   => array(
+								'type' => 'string',
+								'enum' => array( 'unclaimed', 'created', 'existing' ),
+							),
 							'created' => array( 'type' => 'boolean' ),
 						),
 						'additionalProperties' => false,
@@ -139,7 +172,10 @@ function extrachill_artist_platform_register_abilities() {
 							'name'               => array( 'type' => 'string' ),
 							'profile_id'         => array( 'type' => array( 'integer', 'null' ) ),
 							'term_id'            => array( 'type' => array( 'integer', 'null' ) ),
-							'state'              => array( 'type' => 'string', 'enum' => array( 'existing_profile', 'existing_canonical_identity', 'new_eligible', 'eligible_after_claim_and_consent', 'eligible_after_authentication_and_consent', 'eligible_after_consent', 'created' ) ),
+							'state'              => array(
+								'type' => 'string',
+								'enum' => array( 'existing_profile', 'existing_canonical_identity', 'new_eligible', 'eligible_after_claim_and_consent', 'eligible_after_authentication_and_consent', 'eligible_after_consent', 'created' ),
+							),
 							'disclosure_version' => array( 'type' => 'string' ),
 						),
 						'additionalProperties' => false,
@@ -147,7 +183,12 @@ function extrachill_artist_platform_register_abilities() {
 					'membership'  => array(
 						'type'                 => 'object',
 						'required'             => array( 'state' ),
-						'properties'           => array( 'state' => array( 'type' => 'string', 'enum' => array( 'managed', 'request_required', 'not_applicable' ) ) ),
+						'properties'           => array(
+							'state' => array(
+								'type' => 'string',
+								'enum' => array( 'managed', 'request_required', 'not_applicable' ),
+							),
+						),
 						'additionalProperties' => false,
 					),
 					'claim'       => array(
@@ -155,7 +196,10 @@ function extrachill_artist_platform_register_abilities() {
 						'required'             => array( 'required', 'delivery' ),
 						'properties'           => array(
 							'required' => array( 'type' => 'boolean' ),
-							'delivery' => array( 'type' => 'string', 'enum' => array( 'not_required', 'previously_provisioned', 'sent', 'previously_sent', 'pending', 'busy', 'failed', 'sent_unconfirmed' ) ),
+							'delivery' => array(
+								'type' => 'string',
+								'enum' => array( 'not_required', 'previously_provisioned', 'sent', 'previously_sent', 'pending', 'busy', 'failed', 'sent_unconfirmed' ),
+							),
 						),
 						'additionalProperties' => false,
 					),
@@ -163,7 +207,10 @@ function extrachill_artist_platform_register_abilities() {
 						'type'                 => 'object',
 						'required'             => array( 'state', 'id' ),
 						'properties'           => array(
-							'state' => array( 'type' => 'string', 'enum' => array( 'unavailable', 'offered', 'existing', 'created' ) ),
+							'state' => array(
+								'type' => 'string',
+								'enum' => array( 'unavailable', 'offered', 'existing', 'created' ),
+							),
 							'id'    => array( 'type' => array( 'integer', 'null' ) ),
 						),
 						'additionalProperties' => false,
@@ -178,7 +225,10 @@ function extrachill_artist_platform_register_abilities() {
 						'additionalProperties' => false,
 					),
 					'return_url'  => array( 'type' => 'string' ),
-					'next_action' => array( 'type' => 'string', 'enum' => array( 'none', 'claim_account', 'request_membership', 'authenticate', 'confirm_profile_creation', 'manage_artist' ) ),
+					'next_action' => array(
+						'type' => 'string',
+						'enum' => array( 'none', 'claim_account', 'request_membership', 'authenticate', 'confirm_profile_creation', 'manage_artist' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -205,17 +255,32 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'artist_id', 'email', 'token' ),
 				'properties'           => array(
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1 ),
-					'email'     => array( 'type' => 'string', 'format' => 'email' ),
-					'token'     => array( 'type' => 'string', 'minLength' => 1 ),
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1 ),
+					'artist_id' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+					'email'     => array(
+						'type'   => 'string',
+						'format' => 'email',
+					),
+					'token'     => array(
+						'type'      => 'string',
+						'minLength' => 1,
+					),
+					'user_id'   => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
 				),
 				'additionalProperties' => false,
 			),
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'status'    => array( 'type' => 'string', 'enum' => array( 'valid', 'applied' ) ),
+					'status'    => array(
+						'type' => 'string',
+						'enum' => array( 'valid', 'applied' ),
+					),
 					'artist_id' => array( 'type' => 'integer' ),
 				),
 			),
@@ -241,11 +306,11 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'name' => array(
+					'name'       => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'        => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
@@ -253,11 +318,11 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'      => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
-					'user_id' => array(
+					'user_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'User ID to link as member. Defaults to current user.', 'extrachill-artist-platform' ),
 					),
@@ -290,23 +355,23 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'        => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'name' => array(
+					'name'             => array(
 						'type'        => 'string',
 						'description' => __( 'Artist name.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'              => array(
 						'type'        => 'string',
 						'description' => __( 'Artist bio (HTML allowed).', 'extrachill-artist-platform' ),
 					),
-					'local_city' => array(
+					'local_city'       => array(
 						'type'        => 'string',
 						'description' => __( 'Local city/scene.', 'extrachill-artist-platform' ),
 					),
-					'genre' => array(
+					'genre'            => array(
 						'type'        => 'string',
 						'description' => __( 'Genre.', 'extrachill-artist-platform' ),
 					),
@@ -314,7 +379,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'header_image_id' => array(
+					'header_image_id'  => array(
 						'type'        => 'integer',
 						'description' => __( 'Header image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -351,7 +416,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'links' => array(
+					'links'     => array(
 						'type'        => 'array',
 						'description' => __( 'Array of link sections with nested links.', 'extrachill-artist-platform' ),
 					),
@@ -388,7 +453,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'css_vars' => array(
+					'css_vars'  => array(
 						'type'        => 'object',
 						'description' => __( 'CSS variables to save. Merged with existing.', 'extrachill-artist-platform' ),
 					),
@@ -421,15 +486,15 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'           => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
-					'settings' => array(
+					'settings'            => array(
 						'type'        => 'object',
 						'description' => __( 'Settings to save.', 'extrachill-artist-platform' ),
 					),
-					'bio' => array(
+					'bio'                 => array(
 						'type'        => 'string',
 						'description' => __( 'Short bio displayed on the public link page.', 'extrachill-artist-platform' ),
 					),
@@ -437,7 +502,7 @@ function extrachill_artist_platform_register_abilities() {
 						'type'        => 'integer',
 						'description' => __( 'Background image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
-					'profile_image_id' => array(
+					'profile_image_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Profile image attachment ID. 0 to remove.', 'extrachill-artist-platform' ),
 					),
@@ -470,7 +535,7 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'       => 'object',
 				'properties' => array(
-					'artist_id' => array(
+					'artist_id'    => array(
 						'type'        => 'integer',
 						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
 					),
@@ -512,9 +577,21 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
-					'search'   => array( 'type' => 'string', 'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ) ),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
+					'search'   => array(
+						'type'        => 'string',
+						'description' => __( 'Search by artist name.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -551,7 +628,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'days' => array( 'type' => 'integer', 'minimum' => 0, 'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ) ),
+					'days' => array(
+						'type'        => 'integer',
+						'minimum'     => 0,
+						'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -592,7 +673,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -602,7 +687,10 @@ function extrachill_artist_platform_register_abilities() {
 					'id'                => array( 'type' => 'integer' ),
 					'name'              => array( 'type' => 'string' ),
 					'slug'              => array( 'type' => 'string' ),
-					'permalink'         => array( 'type' => 'string', 'format' => 'uri' ),
+					'permalink'         => array(
+						'type'   => 'string',
+						'format' => 'uri',
+					),
 					'bio'               => array( 'type' => 'string' ),
 					'local_city'        => array( 'type' => array( 'string', 'null' ) ),
 					'genre'             => array( 'type' => array( 'string', 'null' ) ),
@@ -637,7 +725,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -667,7 +759,12 @@ function extrachill_artist_platform_register_abilities() {
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
-				'properties'           => array( 'id' => array( 'type' => 'integer', 'minimum' => 1 ) ),
+				'properties'           => array(
+					'id' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+				),
 				'additionalProperties' => false,
 			),
 			'output_schema'       => array(
@@ -684,7 +781,11 @@ function extrachill_artist_platform_register_abilities() {
 			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
-				'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
 			),
 		)
 	);
@@ -699,7 +800,10 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'available' ),
 				'properties'           => array(
-					'id'         => array( 'type' => 'integer', 'minimum' => 1 ),
+					'id'         => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
 					'available'  => array( 'type' => 'boolean' ),
 					'scene_slug' => array( 'type' => 'string' ),
 				),
@@ -719,7 +823,11 @@ function extrachill_artist_platform_register_abilities() {
 			'permission_callback' => 'extrachill_artist_platform_ability_artist_permission',
 			'meta'                => array(
 				'show_in_rest' => true,
-				'annotations'  => array( 'readonly' => false, 'destructive' => false, 'idempotent' => true ),
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
 			),
 		)
 	);
@@ -737,7 +845,10 @@ function extrachill_artist_platform_register_abilities() {
 					'producer'           => array( 'type' => 'string' ),
 					'scene_slug'         => array( 'type' => 'string' ),
 					'genre'              => array( 'type' => 'string' ),
-					'exclude_artist_ids' => array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+					'exclude_artist_ids' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'integer' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -756,12 +867,18 @@ function extrachill_artist_platform_register_abilities() {
 								'artist_term_id'    => array( 'type' => 'integer' ),
 								'name'              => array( 'type' => 'string' ),
 								'slug'              => array( 'type' => 'string' ),
-								'permalink'         => array( 'type' => 'string', 'format' => 'uri' ),
+								'permalink'         => array(
+									'type'   => 'string',
+									'format' => 'uri',
+								),
 								'genre'             => array( 'type' => array( 'string', 'null' ) ),
 								'local_city'        => array( 'type' => array( 'string', 'null' ) ),
 								'profile_image_url' => array( 'type' => array( 'string', 'null' ) ),
 								'header_image_url'  => array( 'type' => array( 'string', 'null' ) ),
-								'manager_user_ids'  => array( 'type' => 'array', 'items' => array( 'type' => 'integer' ) ),
+								'manager_user_ids'  => array(
+									'type'  => 'array',
+									'items' => array( 'type' => 'integer' ),
+								),
 							),
 							'additionalProperties' => false,
 						),
@@ -773,7 +890,11 @@ function extrachill_artist_platform_register_abilities() {
 			'permission_callback' => 'extrachill_artist_platform_ability_local_support_producer_permission',
 			'meta'                => array(
 				'show_in_rest' => false,
-				'annotations'  => array( 'readonly' => true, 'destructive' => false, 'idempotent' => true ),
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
 			),
 		)
 	);
@@ -788,14 +909,39 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'                 => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'links'              => array( 'type' => 'array', 'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ) ),
-					'css_vars'           => array( 'type' => 'object', 'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ) ),
-					'settings'           => array( 'type' => 'object', 'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ) ),
-					'socials'            => array( 'type' => 'array', 'description' => __( 'Social link objects.', 'extrachill-artist-platform' ) ),
-					'background_image_id' => array( 'type' => 'integer', 'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ) ),
-					'profile_image_id'   => array( 'type' => 'integer', 'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ) ),
-					'bio'                => array( 'type' => 'string', 'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ) ),
+					'id'                  => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'links'               => array(
+						'type'        => 'array',
+						'description' => __( 'Link sections with nested links.', 'extrachill-artist-platform' ),
+					),
+					'css_vars'            => array(
+						'type'        => 'object',
+						'description' => __( 'CSS variables to save.', 'extrachill-artist-platform' ),
+					),
+					'settings'            => array(
+						'type'        => 'object',
+						'description' => __( 'Advanced settings.', 'extrachill-artist-platform' ),
+					),
+					'socials'             => array(
+						'type'        => 'array',
+						'description' => __( 'Social link objects.', 'extrachill-artist-platform' ),
+					),
+					'background_image_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Background image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'profile_image_id'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Profile image attachment ID.', 'extrachill-artist-platform' ),
+					),
+					'bio'                 => array(
+						'type'        => 'string',
+						'description' => __( 'Short bio for the link page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -826,7 +972,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -861,7 +1011,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -895,7 +1049,11 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -928,9 +1086,20 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'type', 'url' ),
 				'properties'           => array(
-					'id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'type' => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'  => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'type' => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'  => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -963,10 +1132,24 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ) ),
-					'type'      => array( 'type' => 'string', 'description' => __( 'Social platform type.', 'extrachill-artist-platform' ) ),
-					'url'       => array( 'type' => 'string', 'format' => 'uri', 'description' => __( 'Social link URL.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to update.', 'extrachill-artist-platform' ),
+					),
+					'type'      => array(
+						'type'        => 'string',
+						'description' => __( 'Social platform type.', 'extrachill-artist-platform' ),
+					),
+					'url'       => array(
+						'type'        => 'string',
+						'format'      => 'uri',
+						'description' => __( 'Social link URL.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -999,8 +1182,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'social_id' ),
 				'properties'           => array(
-					'id'        => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'social_id' => array( 'type' => 'string', 'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ) ),
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'social_id' => array(
+						'type'        => 'string',
+						'description' => __( 'Social link ID to delete.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1035,8 +1225,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id', 'email' ),
 				'properties'           => array(
-					'id'    => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'email' => array( 'type' => 'string', 'format' => 'email', 'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ) ),
+					'id'    => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'email' => array(
+						'type'        => 'string',
+						'format'      => 'email',
+						'description' => __( 'Subscriber email address.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1069,9 +1267,22 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'       => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'page'     => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Page number.', 'extrachill-artist-platform' ) ),
-					'per_page' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 100, 'description' => __( 'Results per page.', 'extrachill-artist-platform' ) ),
+					'id'       => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'page'     => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Page number.', 'extrachill-artist-platform' ),
+					),
+					'per_page' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'description' => __( 'Results per page.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1107,8 +1318,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'               => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'include_exported' => array( 'type' => 'boolean', 'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ) ),
+					'id'               => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'include_exported' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Include already exported subscribers.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1145,10 +1363,27 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'id' ),
 				'properties'           => array(
-					'id'         => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
-					'date_range' => array( 'type' => 'integer', 'minimum' => 1, 'maximum' => 90, 'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ) ),
-					'start_date' => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$', 'description' => __( 'Inclusive exact window start in Y-m-d format.', 'extrachill-artist-platform' ) ),
-					'end_date'   => array( 'type' => 'string', 'pattern' => '^\\d{4}-\\d{2}-\\d{2}$', 'description' => __( 'Inclusive exact window end in Y-m-d format.', 'extrachill-artist-platform' ) ),
+					'id'         => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
+					'date_range' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'description' => __( 'Number of days to query.', 'extrachill-artist-platform' ),
+					),
+					'start_date' => array(
+						'type'        => 'string',
+						'pattern'     => '^\\d{4}-\\d{2}-\\d{2}$',
+						'description' => __( 'Inclusive exact window start in Y-m-d format.', 'extrachill-artist-platform' ),
+					),
+					'end_date'   => array(
+						'type'        => 'string',
+						'pattern'     => '^\\d{4}-\\d{2}-\\d{2}$',
+						'description' => __( 'Inclusive exact window end in Y-m-d format.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1187,8 +1422,15 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array(),
 				'properties'           => array(
-					'view'   => array( 'type' => 'string', 'enum' => array( 'artists', 'users' ), 'description' => __( 'View mode.', 'extrachill-artist-platform' ) ),
-					'search' => array( 'type' => 'string', 'description' => __( 'Search term.', 'extrachill-artist-platform' ) ),
+					'view'   => array(
+						'type'        => 'string',
+						'enum'        => array( 'artists', 'users' ),
+						'description' => __( 'View mode.', 'extrachill-artist-platform' ),
+					),
+					'search' => array(
+						'type'        => 'string',
+						'description' => __( 'Search term.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1221,8 +1463,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1255,8 +1505,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),
@@ -1320,8 +1578,16 @@ function extrachill_artist_platform_register_abilities() {
 				'type'                 => 'object',
 				'required'             => array( 'user_id', 'artist_id' ),
 				'properties'           => array(
-					'user_id'   => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ) ),
-					'artist_id' => array( 'type' => 'integer', 'minimum' => 1, 'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ) ),
+					'user_id'   => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'WordPress user ID.', 'extrachill-artist-platform' ),
+					),
+					'artist_id' => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'Artist profile post ID.', 'extrachill-artist-platform' ),
+					),
 				),
 				'additionalProperties' => false,
 			),

--- a/src/blocks/artist-analytics/components/Analytics.js
+++ b/src/blocks/artist-analytics/components/Analytics.js
@@ -4,8 +4,15 @@
  * Main analytics dashboard with Chart.js visualization.
  */
 
+/**
+ * WordPress dependencies
+ */
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
 import {
 	ActionRow,
 	BlockShell,
@@ -15,6 +22,10 @@ import {
 	PanelHeader,
 	Section,
 } from '@extrachill/components';
+
+/**
+ * Internal dependencies
+ */
 import { useAnalyticsContext } from '../context/AnalyticsContext';
 import useAnalytics from '../hooks/useAnalytics';
 import ArtistSwitcher from '../../shared/components/ArtistSwitcher';
@@ -51,7 +62,7 @@ export default function Analytics() {
 			// scales, and elements already registered). Resolve defensively
 			// across those shapes. The external mapping is why the
 			// extraneous-dependency lint rule is suppressed here.
-			// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
+			// eslint-disable-next-line import/no-unresolved
 			const ChartModule = await import( 'chart.js/auto' );
 			const Chart =
 				ChartModule?.default || ChartModule?.Chart || ChartModule;

--- a/src/blocks/artist-analytics/components/DateRangeControl.js
+++ b/src/blocks/artist-analytics/components/DateRangeControl.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 

--- a/src/blocks/artist-analytics/hooks/useAnalytics.js
+++ b/src/blocks/artist-analytics/hooks/useAnalytics.js
@@ -4,7 +4,14 @@
  * Manages analytics data fetching, date range state, and loading/error states.
  */
 
+/**
+ * WordPress dependencies
+ */
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { getAnalytics } from '../../shared/api/client';
 
 const DEFAULT_SELECTION = { mode: 'preset', days: 30 };

--- a/src/blocks/artist-analytics/render.php
+++ b/src/blocks/artist-analytics/render.php
@@ -4,13 +4,15 @@
  *
  * Renders the artist analytics React app on the frontend.
  * Handles authentication, artist resolution, and data localization.
+ *
+ * @package ExtraChillArtistPlatform
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Authentication check
+// Authentication check.
 if ( ! is_user_logged_in() ) {
 	echo '<div class="notice notice-info">';
 	echo '<p>' . esc_html__( 'Please log in to view your analytics.', 'extrachill-artist-platform' ) . '</p>';
@@ -20,7 +22,7 @@ if ( ! is_user_logged_in() ) {
 
 $current_user_id = get_current_user_id();
 
-// Get user's artists
+// Get user's artists.
 if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
 	echo '<div class="notice notice-error">';
 	echo '<p>' . esc_html__( 'Artist platform is not properly configured.', 'extrachill-artist-platform' ) . '</p>';
@@ -30,7 +32,7 @@ if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
 
 $user_artists = ec_get_artists_for_user( $current_user_id, true );
 
-// No artists - show creation prompt
+// No artists - show creation prompt.
 if ( empty( $user_artists ) ) {
 	if ( function_exists( 'ec_can_create_artist_profiles' ) && ec_can_create_artist_profiles( $current_user_id ) ) {
 		echo '<div class="notice notice-info">';
@@ -45,68 +47,68 @@ if ( empty( $user_artists ) ) {
 	return;
 }
 
-// Build user artists data for switcher (only artists with link pages)
-$user_artists_data = array();
+// Build user artists data for switcher (only artists with link pages).
+$user_artists_data               = array();
 $user_artist_ids_with_link_pages = array();
 
 foreach ( $user_artists as $ua_id ) {
-    $artist_post = get_post( $ua_id );
-    if ( ! $artist_post || $artist_post->post_status !== 'publish' ) {
-        continue;
-    }
+	$artist_post = get_post( $ua_id );
+	if ( ! $artist_post || 'publish' !== $artist_post->post_status ) {
+		continue;
+	}
 
-    $link_page_id = function_exists( 'ec_get_link_page_for_artist' )
-        ? ec_get_link_page_for_artist( $ua_id )
-        : 0;
+	$link_page_id = function_exists( 'ec_get_link_page_for_artist' )
+		? ec_get_link_page_for_artist( $ua_id )
+		: 0;
 
-    if ( $link_page_id && get_post_status( $link_page_id ) === 'publish' ) {
-        $user_artists_data[] = array(
-            'id'   => (int) $ua_id,
-            'name' => $artist_post->post_title,
-            'slug' => $artist_post->post_name,
-        );
-        $user_artist_ids_with_link_pages[] = (int) $ua_id;
-    }
+	if ( $link_page_id && get_post_status( $link_page_id ) === 'publish' ) {
+		$user_artists_data[]               = array(
+			'id'   => (int) $ua_id,
+			'name' => $artist_post->post_title,
+			'slug' => $artist_post->post_name,
+		);
+		$user_artist_ids_with_link_pages[] = (int) $ua_id;
+	}
 }
 
-// No link pages yet for this user
+// No link pages yet for this user.
 if ( empty( $user_artists_data ) ) {
-    echo '<div class="notice notice-info">';
-    echo '<p>' . esc_html__( 'Create a link page to start tracking analytics.', 'extrachill-artist-platform' ) . '</p>';
-    echo '<a href="' . esc_url( site_url( '/manage-link-page/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Create Link Page', 'extrachill-artist-platform' ) . '</a>';
-    echo '</div>';
-    return;
+	echo '<div class="notice notice-info">';
+	echo '<p>' . esc_html__( 'Create a link page to start tracking analytics.', 'extrachill-artist-platform' ) . '</p>';
+	echo '<a href="' . esc_url( site_url( '/manage-link-page/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Create Link Page', 'extrachill-artist-platform' ) . '</a>';
+	echo '</div>';
+	return;
 }
 
-// Get the artist to view (prefer latest with a link page)
+// Get the artist to view (prefer latest with a link page).
 $artist_id = 0;
 if ( function_exists( 'ec_get_latest_artist_for_user' ) ) {
-    $latest_artist_id = ec_get_latest_artist_for_user( $current_user_id );
-    if ( $latest_artist_id && in_array( (int) $latest_artist_id, $user_artist_ids_with_link_pages, true ) ) {
-        $artist_id = (int) $latest_artist_id;
-    }
+	$latest_artist_id = ec_get_latest_artist_for_user( $current_user_id );
+	if ( $latest_artist_id && in_array( (int) $latest_artist_id, $user_artist_ids_with_link_pages, true ) ) {
+		$artist_id = (int) $latest_artist_id;
+	}
 }
 
 if ( ! $artist_id ) {
-    $artist_id = (int) $user_artists_data[0]['id'];
+	$artist_id = (int) $user_artists_data[0]['id'];
 }
 
 if ( ! $artist_id ) {
-    echo '<div class="notice notice-error">';
-    echo '<p>' . esc_html__( 'Could not determine which artist to view.', 'extrachill-artist-platform' ) . '</p>';
-    echo '</div>';
-    return;
+	echo '<div class="notice notice-error">';
+	echo '<p>' . esc_html__( 'Could not determine which artist to view.', 'extrachill-artist-platform' ) . '</p>';
+	echo '</div>';
+	return;
 }
 
-// Localize configuration data
+// Localize configuration data.
 $link_page_id = ec_get_link_page_for_artist( $artist_id );
 
 if ( ! $link_page_id || get_post_status( $link_page_id ) !== 'publish' ) {
-    echo '<div class="notice notice-info">';
-    echo '<p>' . esc_html__( 'Create a link page to start tracking analytics.', 'extrachill-artist-platform' ) . '</p>';
-    echo '<a href="' . esc_url( site_url( '/manage-link-page/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Create Link Page', 'extrachill-artist-platform' ) . '</a>';
-    echo '</div>';
-    return;
+	echo '<div class="notice notice-info">';
+	echo '<p>' . esc_html__( 'Create a link page to start tracking analytics.', 'extrachill-artist-platform' ) . '</p>';
+	echo '<a href="' . esc_url( site_url( '/manage-link-page/' ) ) . '" class="button-1 button-medium">' . esc_html__( 'Create Link Page', 'extrachill-artist-platform' ) . '</a>';
+	echo '</div>';
+	return;
 }
 
 $config = array(
@@ -117,7 +119,7 @@ $config = array(
 	'linkPageBaseUrl' => 'https://extrachill.link',
 );
 
-// Enqueue the frontend script with localized data
+// Enqueue the frontend script with localized data.
 $asset_file = include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'build/blocks/artist-analytics/view.asset.php';
 
 // Analytics owns both shared runtimes. Declare them explicitly so Chart.js and
@@ -141,11 +143,13 @@ wp_enqueue_script(
 
 wp_localize_script( 'ec-artist-analytics-frontend', 'ecArtistAnalyticsConfig', $config );
 
-// Render mount point
-$wrapper_attributes = get_block_wrapper_attributes( array(
-	'class' => 'ec-artist-analytics',
-) );
+// Render mount point.
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => 'ec-artist-analytics',
+	)
+);
 
-echo '<div ' . $wrapper_attributes . '>';
-echo '<div id="ec-artist-analytics-root" data-artist-id="' . esc_attr( $artist_id ) . '"></div>';
+echo '<div ' . $wrapper_attributes . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated by get_block_wrapper_attributes().
+echo '<div id="ec-artist-analytics-root" data-artist-id="' . esc_attr( (string) $artist_id ) . '"></div>';
 echo '</div>';

--- a/src/blocks/shared/api/client.js
+++ b/src/blocks/shared/api/client.js
@@ -9,7 +9,14 @@
  * cross-origin and cannot go through the api-client transport.
  */
 
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * External dependencies
+ */
 import { ExtraChillClient } from '@extrachill/api-client';
 import { WpApiFetchTransport } from '@extrachill/api-client/wordpress';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -187,7 +187,7 @@ function get_current_blog_id() {
 }
 
 function get_site( $blog_id = null ) {
-	$blog_id = $blog_id ?: get_current_blog_id();
+	$blog_id = $blog_id ? $blog_id : get_current_blog_id();
 	if ( ! isset( $GLOBALS['ec_test']['blogs'][ $blog_id ] ) ) {
 		return null;
 	}
@@ -421,7 +421,7 @@ function get_post_status( $post_id ) {
 function get_post_meta( $post_id, $key = '', $single = false ) {
 	$blog_meta = ec_test_blog_store( 'post_meta' );
 	$meta      = $blog_meta[ $post_id ] ?? ( $GLOBALS['ec_test']['meta'][ $post_id ] ?? array() );
-	if ( $key === '' ) {
+	if ( '' === $key ) {
 		return $meta;
 	}
 	$value = $meta[ $key ] ?? ( $single ? '' : array() );


### PR DESCRIPTION
## Summary
- normalize changed PHP files to the release coding standard and PHP 7.4 target
- add dependency-group annotations to exact-date JavaScript
- fix wrapper attribute typing/escaping analysis without changing runtime output

## Verification
- Homeboy release-range PHPCS, ESLint, and PHPStan passed
- 12 JS tests passed
- 213 PHP tests passed with 1,186 assertions
- production build passed

Closes #177