### PR TITLE
fix: guard optional artist creation analytics

### DIFF
--- a/inc/abilities/handlers/create-artist.php
+++ b/inc/abilities/handlers/create-artist.php
@@ -8,19 +8,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-/*
- * Event-name contract (Extra-Chill/extrachill-users#129).
- * -------------------------------------------------------
- * The canonical artist-funnel event_type name is defined ONCE in
- * extrachill-analytics (inc/core/event-types.php) as
- * `EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED`. extrachill-analytics owns
- * the analytics substrate and the `extrachill/track-analytics-event`
- * ability this handler already calls at runtime, and is network-active,
- * so the constant is guaranteed present here — referencing it adds no new
- * coupling. The emit site below references the analytics constant directly
- * (no local copy of the literal), so a rename happens in exactly one place.
- */
-
 /**
  * Create a new artist profile.
  *
@@ -126,13 +113,15 @@ function extrachill_artist_platform_ability_create_artist( $input ) {
 	// the anonymous first-party visitor_id is passed so this completion step
 	// stitches to the upstream artist_signup_started / user_registration rows
 	// for the same member (Extra-Chill/extrachill-users#145 stitching).
-	ec_artist_platform_emit_funnel_event(
-		EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
-		array(
-			'user_id'   => $user_id,
-			'artist_id' => (int) $artist_id,
-		)
-	);
+	if ( defined( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED' ) ) {
+		ec_artist_platform_emit_funnel_event(
+			EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED,
+			array(
+				'user_id'   => $user_id,
+				'artist_id' => (int) $artist_id,
+			)
+		);
+	}
 
 	restore_current_blog();
 

--- a/tests/CreateArtistOptionalAnalyticsTest.php
+++ b/tests/CreateArtistOptionalAnalyticsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class CreateArtistOptionalAnalyticsTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 1,
+			'blog_stack'      => array(),
+			'current_user_id' => 7,
+			'blogs'           => array(
+				4 => array(
+					'posts'     => array(),
+					'post_meta' => array(),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_creation_succeeds_without_analytics(): void {
+		$result = extrachill_artist_platform_ability_create_artist( array( 'name' => 'No Analytics Band' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['id'] );
+		$this->assertSame( 'No Analytics Band', $result['name'] );
+		$this->assertSame( array( 7 ), $GLOBALS['ec_test']['blogs'][4]['post_meta'][1]['_artist_member_ids'] );
+		$this->assertSame( array( 1 ), $GLOBALS['ec_test']['user_meta'][7]['_artist_profile_ids'] );
+		$this->assertArrayNotHasKey( 'funnel_events', $GLOBALS['ec_test'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_creation_emits_event_when_analytics_is_available(): void {
+		define( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED', 'artist_profile_created' );
+
+		$result = extrachill_artist_platform_ability_create_artist( array( 'name' => 'Analytics Band' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['id'] );
+		$this->assertSame(
+			array(
+				array(
+					'artist_profile_created',
+					array(
+						'user_id'   => 7,
+						'artist_id' => 1,
+					),
+				),
+			),
+			$GLOBALS['ec_test']['funnel_events']
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,6 @@ define( 'ABSPATH', __DIR__ . '/' );
 define( 'OBJECT', 'OBJECT' );
 define( 'MINUTE_IN_SECONDS', 60 );
 define( 'DAY_IN_SECONDS', 86400 );
-define( 'EC_ANALYTICS_EVENT_ARTIST_PROFILE_CREATED', 'artist_profile_created' );
 define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
 
 function plugin_dir_path( $file ) {
@@ -1043,7 +1042,8 @@ function do_action() {
 	return true;
 }
 
-function ec_artist_platform_emit_funnel_event() {
+function ec_artist_platform_emit_funnel_event( ...$args ) {
+	$GLOBALS['ec_test']['funnel_events'][] = $args;
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- guard the Analytics-owned artist creation event constant before emission, matching the existing first-publish path
- preserve successful artist creation and membership writes when Analytics is inactive
- cover Analytics-absent success and Analytics-present event emission in isolated regression tests

## Testing
- `vendor/bin/phpunit tests/CreateArtistOptionalAnalyticsTest.php` (2 tests, 9 assertions)
- `vendor/bin/phpunit` (215 tests, 1195 assertions)
- `npm run test:js` (5 suites, 12 tests)
- `php -l` on all changed PHP files
- `git diff --check`

## Known Repository Lint Baseline
- `composer run lint:php` cannot load the configured WordPress standard because it is not declared/installed by the repository's Composer dependencies
- `npm run lint:js` and `npm run lint:css` report existing repository-wide violations in unrelated files; this PHP-only change adds no JS or CSS

Closes #179