### PR TITLE
refactor: consume Analytics link-page aggregates

### DIFF
--- a/inc/abilities/handlers/get-artist-platform-stats.php
+++ b/inc/abilities/handlers/get-artist-platform-stats.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/get-artist-platform-stats
  *
@@ -17,18 +16,18 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Return point-in-time artist platform aggregates.
  *
- * @param array $input {
- *     @type int $days Window (in days) for the "recent" aggregates. Default 28.
- * }
+ * @param array $input Input arguments containing the optional recent-metrics window.
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_get_artist_platform_stats( array $input ): array|WP_Error {
-	$days = isset( $input['days'] ) ? max( 0, (int) $input['days'] ) : 28;
+	$days = isset( $input['days'] ) ? min( 90, max( 0, (int) $input['days'] ) ) : 28;
 
 	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? ec_get_blog_id( 'artist' ) : null;
 	if ( ! $artist_blog_id ) {
@@ -40,8 +39,6 @@ function extrachill_artist_platform_ability_get_artist_platform_stats( array $in
 		switch_to_blog( $artist_blog_id );
 		$did_switch = true;
 	}
-
-	global $wpdb;
 
 	// Total published artist profiles (reuse the artists-list ability so the
 	// count stays canonical and is never duplicated here). Fall back to a
@@ -78,12 +75,13 @@ function extrachill_artist_platform_ability_get_artist_platform_stats( array $in
 		array(
 			'post_type'      => 'artist_link_page',
 			'post_status'    => 'publish',
-			'posts_per_page' => 1,
+			'posts_per_page' => -1,
 			'fields'         => 'ids',
 			'no_found_rows'  => false,
 		)
 	);
 	$total_link_pages = (int) $link_page_query->found_posts;
+	$link_page_ids    = array_map( 'intval', $link_page_query->posts );
 
 	// Artist profiles created in the last N days.
 	$profiles_created_recent = 0;
@@ -107,34 +105,82 @@ function extrachill_artist_platform_ability_get_artist_platform_stats( array $in
 		$profiles_created_recent = (int) $created_query->found_posts;
 	}
 
-	// Link pages with at least one view or click in the last N days.
-	$views_table  = $wpdb->prefix . 'extrch_link_page_daily_views';
-	$clicks_table = $wpdb->prefix . 'extrch_link_page_daily_link_clicks';
-	$since        = $days > 0 ? gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) : '1970-01-01';
+	$active_link_pages_recent   = 0;
+	$link_page_analytics_status = 'disabled';
+	$link_page_analytics_error  = null;
+	$authorization_error        = null;
 
-	// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-	$active_link_page_ids = $wpdb->get_col(
-		$wpdb->prepare(
-			"SELECT link_page_id FROM {$views_table} WHERE stat_date >= %s AND view_count > 0
-			 UNION
-			 SELECT link_page_id FROM {$clicks_table} WHERE stat_date >= %s AND click_count > 0",
-			$since,
-			$since
-		)
-	);
-	// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	if ( $days > 0 ) {
+		$analytics_ability = wp_get_ability( 'extrachill/get-link-page-analytics' );
+		if ( ! $analytics_ability ) {
+			$active_link_pages_recent   = null;
+			$link_page_analytics_status = 'unavailable';
+		} elseif ( empty( $link_page_ids ) ) {
+			$link_page_analytics_status = 'no_data';
+		} else {
+			foreach ( $link_page_ids as $link_page_id ) {
+				$analytics_result = $analytics_ability->execute(
+					array(
+						'link_page_id' => $link_page_id,
+						'date_range'   => $days,
+					)
+				);
 
-	$active_link_pages_recent = is_array( $active_link_page_ids ) ? count( $active_link_page_ids ) : 0;
+				if ( is_wp_error( $analytics_result ) ) {
+					$error_code = $analytics_result->get_error_code();
+					if ( in_array( $error_code, array( 'ability_permission_denied', 'permission_denied' ), true ) ) {
+						$authorization_error = $analytics_result;
+						break;
+					}
+
+					$active_link_pages_recent   = null;
+					$link_page_analytics_status = 'error';
+					$link_page_analytics_error  = $error_code;
+					break;
+				}
+
+				$summary = is_array( $analytics_result ) && isset( $analytics_result['summary'] ) && is_array( $analytics_result['summary'] )
+					? $analytics_result['summary']
+					: null;
+				if (
+					null === $summary
+					|| ! isset( $summary['total_views'], $summary['total_clicks'] )
+					|| ! is_int( $summary['total_views'] )
+					|| ! is_int( $summary['total_clicks'] )
+					|| $summary['total_views'] < 0
+					|| $summary['total_clicks'] < 0
+				) {
+					$active_link_pages_recent   = null;
+					$link_page_analytics_status = 'malformed_response';
+					$link_page_analytics_error  = 'invalid_analytics_response';
+					break;
+				}
+
+				if ( $summary['total_views'] > 0 || $summary['total_clicks'] > 0 ) {
+					++$active_link_pages_recent;
+				}
+			}
+
+			if ( null !== $active_link_pages_recent ) {
+				$link_page_analytics_status = $active_link_pages_recent > 0 ? 'available' : 'no_data';
+			}
+		}
+	}
 
 	if ( $did_switch ) {
 		restore_current_blog();
 	}
+	if ( $authorization_error ) {
+		return $authorization_error;
+	}
 
 	return array(
-		'total_artist_profiles'    => $total_artist_profiles,
-		'total_link_pages'         => $total_link_pages,
-		'profiles_created_recent'  => $profiles_created_recent,
-		'active_link_pages_recent' => $active_link_pages_recent,
-		'days'                     => $days,
+		'total_artist_profiles'      => $total_artist_profiles,
+		'total_link_pages'           => $total_link_pages,
+		'profiles_created_recent'    => $profiles_created_recent,
+		'active_link_pages_recent'   => $active_link_pages_recent,
+		'link_page_analytics_status' => $link_page_analytics_status,
+		'link_page_analytics_error'  => $link_page_analytics_error,
+		'days'                       => $days,
 	);
 }

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -631,6 +631,7 @@ function extrachill_artist_platform_register_abilities() {
 					'days' => array(
 						'type'        => 'integer',
 						'minimum'     => 0,
+						'maximum'     => 90,
 						'description' => __( 'Window in days for the recent aggregates. 0 disables the recent metrics window. Default 28.', 'extrachill-artist-platform' ),
 					),
 				),
@@ -639,11 +640,16 @@ function extrachill_artist_platform_register_abilities() {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'total_artist_profiles'    => array( 'type' => 'integer' ),
-					'total_link_pages'         => array( 'type' => 'integer' ),
-					'profiles_created_recent'  => array( 'type' => 'integer' ),
-					'active_link_pages_recent' => array( 'type' => 'integer' ),
-					'days'                     => array( 'type' => 'integer' ),
+					'total_artist_profiles'      => array( 'type' => 'integer' ),
+					'total_link_pages'           => array( 'type' => 'integer' ),
+					'profiles_created_recent'    => array( 'type' => 'integer' ),
+					'active_link_pages_recent'   => array( 'type' => array( 'integer', 'null' ) ),
+					'link_page_analytics_status' => array(
+						'type' => 'string',
+						'enum' => array( 'available', 'no_data', 'disabled', 'unavailable', 'error', 'malformed_response' ),
+					),
+					'link_page_analytics_error'  => array( 'type' => array( 'string', 'null' ) ),
+					'days'                       => array( 'type' => 'integer' ),
 				),
 			),
 			'execute_callback'    => 'extrachill_artist_platform_ability_get_artist_platform_stats',

--- a/tests/ArtistPlatformStatsContractTest.php
+++ b/tests/ArtistPlatformStatsContractTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! class_exists( 'WP_Query' ) ) {
+	class WP_Query {
+		public $found_posts = 0;
+		public $posts       = array();
+
+		public function __construct( $args ) {
+			$GLOBALS['ec_test']['wp_queries'][] = $args;
+			$result = array_shift( $GLOBALS['ec_test']['wp_query_results'] );
+			$this->found_posts = $result['found_posts'] ?? 0;
+			$this->posts       = $result['posts'] ?? array();
+		}
+	}
+}
+
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/get-artist-platform-stats.php';
+
+final class ArtistPlatformStatsContractTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'wp_query_results' => array(),
+		);
+		extrachill_artist_platform_register_abilities();
+		$this->registerAbility(
+			'extrachill/artists-list',
+			static function () {
+				return array( 'total' => 3 );
+			}
+		);
+	}
+
+	private function registerAbility( string $name, callable $execute, ?callable $permission = null ): void {
+		$GLOBALS['ec_test']['abilities'][ $name ] = new EcTestRegisteredAbility(
+			array(
+				'execute_callback'    => $execute,
+				'permission_callback' => $permission ?? static function () {
+					return true;
+				},
+			)
+		);
+	}
+
+	private function setQueryResults( array $link_page_ids ): void {
+		$GLOBALS['ec_test']['wp_query_results'] = array(
+			array(
+				'found_posts' => count( $link_page_ids ),
+				'posts'       => $link_page_ids,
+			),
+			array( 'found_posts' => 1 ),
+		);
+	}
+
+	public function test_provider_data_maps_to_active_link_page_count(): void {
+		$this->setQueryResults( array( 10, 20 ) );
+		$this->registerAbility(
+			'extrachill/get-link-page-analytics',
+			static function ( $input ) {
+				$GLOBALS['ec_test']['analytics_inputs'][] = $input;
+				return array(
+					'summary' => array(
+						'total_views'  => 10 === $input['link_page_id'] ? 4 : 0,
+						'total_clicks' => 0,
+					),
+				);
+			}
+		);
+
+		$result = extrachill_artist_platform_ability_get_artist_platform_stats( array( 'days' => 28 ) );
+
+		$this->assertSame( 1, $result['active_link_pages_recent'] );
+		$this->assertSame( 'available', $result['link_page_analytics_status'] );
+		$this->assertNull( $result['link_page_analytics_error'] );
+		$this->assertSame(
+			array(
+				array( 'link_page_id' => 10, 'date_range' => 28 ),
+				array( 'link_page_id' => 20, 'date_range' => 28 ),
+			),
+			$GLOBALS['ec_test']['analytics_inputs']
+		);
+	}
+
+	public function test_available_provider_distinguishes_genuine_no_data(): void {
+		$this->setQueryResults( array( 10 ) );
+		$this->registerAbility(
+			'extrachill/get-link-page-analytics',
+			static function () {
+				return array(
+					'summary' => array(
+						'total_views'  => 0,
+						'total_clicks' => 0,
+					),
+				);
+			}
+		);
+
+		$result = extrachill_artist_platform_ability_get_artist_platform_stats( array( 'days' => 28 ) );
+
+		$this->assertSame( 0, $result['active_link_pages_recent'] );
+		$this->assertSame( 'no_data', $result['link_page_analytics_status'] );
+		$this->assertNull( $result['link_page_analytics_error'] );
+	}
+
+	public function test_absent_provider_is_not_reported_as_zero_activity(): void {
+		$this->setQueryResults( array( 10 ) );
+		unset( $GLOBALS['ec_test']['abilities']['extrachill/get-link-page-analytics'] );
+
+		$result = extrachill_artist_platform_ability_get_artist_platform_stats( array( 'days' => 28 ) );
+
+		$this->assertNull( $result['active_link_pages_recent'] );
+		$this->assertSame( 'unavailable', $result['link_page_analytics_status'] );
+		$this->assertNull( $result['link_page_analytics_error'] );
+	}
+
+	public function test_provider_error_is_not_reported_as_zero_activity(): void {
+		$this->setQueryResults( array( 10 ) );
+		$this->registerAbility(
+			'extrachill/get-link-page-analytics',
+			static function () {
+				return new WP_Error( 'analytics_unavailable', 'Analytics unavailable.' );
+			}
+		);
+
+		$result = extrachill_artist_platform_ability_get_artist_platform_stats( array( 'days' => 28 ) );
+
+		$this->assertNull( $result['active_link_pages_recent'] );
+		$this->assertSame( 'error', $result['link_page_analytics_status'] );
+		$this->assertSame( 'analytics_unavailable', $result['link_page_analytics_error'] );
+	}
+
+	public function test_malformed_provider_response_is_explicit(): void {
+		$this->setQueryResults( array( 10 ) );
+		$this->registerAbility(
+			'extrachill/get-link-page-analytics',
+			static function () {
+				return array( 'summary' => array( 'total_views' => 1 ) );
+			}
+		);
+
+		$result = extrachill_artist_platform_ability_get_artist_platform_stats( array( 'days' => 28 ) );
+
+		$this->assertNull( $result['active_link_pages_recent'] );
+		$this->assertSame( 'malformed_response', $result['link_page_analytics_status'] );
+		$this->assertSame( 'invalid_analytics_response', $result['link_page_analytics_error'] );
+	}
+
+	public function test_owner_ability_authorization_failure_is_preserved(): void {
+		$GLOBALS['ec_test']['current_blog_id']                 = 1;
+		$GLOBALS['ec_test']['current_user_id']                 = 7;
+		$GLOBALS['ec_test']['capabilities']['manage_options'] = true;
+		$this->setQueryResults( array( 10 ) );
+		$this->registerAbility(
+			'extrachill/get-link-page-analytics',
+			static function () {
+				return array();
+			},
+			static function () {
+				return false;
+			}
+		);
+
+		$result = wp_get_ability( 'extrachill/get-artist-platform-stats' )->execute( array( 'days' => 28 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'ability_permission_denied', $result->get_error_code() );
+		$this->assertSame( 1, get_current_blog_id() );
+	}
+}


### PR DESCRIPTION
## Summary
- replace Artist Platform's direct Analytics table queries with the Analytics-owned `extrachill/get-link-page-analytics` public ability
- map the owner response's integer `summary.total_views` and `summary.total_clicks` values into the existing active-link-page count while preserving the owner's date-window and ownership checks
- expose `active_link_pages_recent: null` plus explicit status/error fields when the provider is absent, errors, or returns a malformed response; a successful all-zero response remains `0` with `no_data`

## Owner ability and response mapping
Analytics owns validation, authorization, date-range handling, and the `summary`, `chart_data`, and `top_links` aggregates. Artist Platform now enumerates its published link pages, executes the owner ability with `link_page_id` and `date_range`, and consumes only the documented integer summary totals needed by the platform response.

The stats response preserves its existing aggregate fields. `active_link_pages_recent` stays an integer when Analytics produced a valid result, and is nullable only when no trustworthy aggregate is available. `link_page_analytics_status` distinguishes `available`, `no_data`, `disabled`, `unavailable`, `error`, and `malformed_response`; `link_page_analytics_error` carries the provider/error contract code when applicable. Owner authorization failures remain `WP_Error` and are not masked as provider downtime.

## Verification
- `composer test` (221 tests, 1,214 assertions)
- `npm run test:js` (12 tests)
- focused WordPressCS on changed production PHP (pass)
- focused PHPStan level 0 on changed PHP and contract test (pass)
- `npm run build` (pass)
- final source grep for Analytics table names, table helpers, and removed SQL patterns (no matches)
- repository-wide `npm run lint:js` and `npm run lint:css` remain red on existing baseline debt tracked by #159
- declared `composer lint:php` cannot load its configured WordPress standard, tracked by #141; the changed production files pass the shared installed WordPressCS standard
- repository-wide PHPStan restoration remains tracked by #166

Closes #180