### PR TITLE
feat: expose public artist projections

### DIFF
--- a/inc/abilities/abilities.php
+++ b/inc/abilities/abilities.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/handlers/save-social-links.php';
 // Artist-domain ability handlers (issue #27).
 require_once __DIR__ . '/handlers/artists-list.php';
 require_once __DIR__ . '/handlers/artist-get.php';
+require_once __DIR__ . '/handlers/artist-public-projections.php';
 require_once __DIR__ . '/handlers/artist-get-links.php';
 require_once __DIR__ . '/handlers/artist-update-links.php';
 require_once __DIR__ . '/handlers/artist-get-permissions.php';

--- a/inc/abilities/handlers/artist-public-projections.php
+++ b/inc/abilities/handlers/artist-public-projections.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Handler: extrachill/artist-public-projections
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+declare(strict_types=1);
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Resolve public artist presentation from canonical subscription slugs.
+ *
+ * @param array $input Validated ability input.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_artist_public_projections( array $input ): array|WP_Error {
+	$blog_ids = ec_artist_binding_blog_ids();
+	if ( empty( $blog_ids ) ) {
+		return new WP_Error( 'artist_projection_owner_unavailable', __( 'Artist projection owner sites are unavailable.', 'extrachill-artist-platform' ) );
+	}
+
+	$items = array();
+	foreach ( $input['slugs'] as $slug ) {
+		$item = array(
+			'slug'   => $slug,
+			'status' => 'not_found',
+			'name'   => '',
+			'url'    => '',
+		);
+
+		switch_to_blog( $blog_ids['main'] );
+		try {
+			$term = get_term_by( 'slug', $slug, 'artist' );
+		} finally {
+			restore_current_blog();
+		}
+
+		if ( is_wp_error( $term ) ) {
+			return $term;
+		}
+		if ( ! $term ) {
+			$items[] = $item;
+			continue;
+		}
+
+		$binding = ec_artist_binding_read_term( (int) $term->term_id, $blog_ids['main'] );
+		if ( empty( $binding['profile_id'] ) ) {
+			$items[] = $item;
+			continue;
+		}
+
+		$profile = ec_artist_binding_read_profile( $binding['profile_id'], $blog_ids['artist'] );
+		if ( empty( $profile ) || 'publish' !== $profile['status'] || '' === $profile['title'] || (int) $profile['term_id'] !== (int) $binding['id'] ) {
+			$items[] = $item;
+			continue;
+		}
+
+		switch_to_blog( $blog_ids['artist'] );
+		try {
+			$url = get_permalink( $profile['id'] );
+		} finally {
+			restore_current_blog();
+		}
+
+		if ( ! is_string( $url ) || '' === $url ) {
+			return new WP_Error( 'artist_projection_permalink_unavailable', __( 'The canonical artist profile URL is unavailable.', 'extrachill-artist-platform' ) );
+		}
+
+		$item['status'] = 'resolved';
+		$item['name']   = $profile['title'];
+		$item['url']    = $url;
+		$items[]        = $item;
+	}
+
+	return array(
+		'schema_version' => '1',
+		'items'          => $items,
+	);
+}

--- a/inc/abilities/registry.php
+++ b/inc/abilities/registry.php
@@ -85,6 +85,78 @@ function extrachill_artist_platform_register_abilities() {
 		)
 	);
 
+	wp_register_ability(
+		'extrachill/artist-public-projections',
+		array(
+			'label'               => __( 'Resolve Public Artist Projections', 'extrachill-artist-platform' ),
+			'description'         => __( 'Resolve canonical public artist names and profile URLs from subscription slugs.', 'extrachill-artist-platform' ),
+			'category'            => 'extrachill-artist-platform',
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'schema_version', 'slugs' ),
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( '1' ),
+					),
+					'slugs'          => array(
+						'type'        => 'array',
+						'minItems'    => 1,
+						'maxItems'    => 100,
+						'uniqueItems' => true,
+						'items'       => array(
+							'type'      => 'string',
+							'minLength' => 1,
+							'maxLength' => 200,
+							'pattern'   => '^[a-z0-9]+(?:-[a-z0-9]+)*$',
+						),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'                 => 'object',
+				'required'             => array( 'schema_version', 'items' ),
+				'properties'           => array(
+					'schema_version' => array(
+						'type' => 'string',
+						'enum' => array( '1' ),
+					),
+					'items'          => array(
+						'type'     => 'array',
+						'minItems' => 1,
+						'maxItems' => 100,
+						'items'    => array(
+							'type'                 => 'object',
+							'required'             => array( 'slug', 'status', 'name', 'url' ),
+							'properties'           => array(
+								'slug'   => array( 'type' => 'string' ),
+								'status' => array(
+									'type' => 'string',
+									'enum' => array( 'resolved', 'not_found' ),
+								),
+								'name'   => array( 'type' => 'string' ),
+								'url'    => array( 'type' => 'string' ),
+							),
+							'additionalProperties' => false,
+						),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'execute_callback'    => 'extrachill_artist_platform_ability_artist_public_projections',
+			'permission_callback' => '__return_true',
+			'meta'                => array(
+				'show_in_rest' => true,
+				'annotations'  => array(
+					'readonly'    => true,
+					'idempotent'  => true,
+					'destructive' => false,
+				),
+			),
+		)
+	);
+
 	// --- Write abilities ---
 
 	wp_register_ability(

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -34,7 +34,7 @@ function ec_artist_binding_blog_ids() {
  *
  * @param int $profile_id    Artist profile post ID.
  * @param int $artist_blog_id Artist blog ID.
- * @return array{id:int,term_id:int,slug:string,title:string}|array{}
+ * @return array{id:int,term_id:int,slug:string,title:string,status:string}|array{}
  */
 function ec_artist_binding_read_profile( $profile_id, $artist_blog_id ) {
 	$profile = array();
@@ -47,6 +47,7 @@ function ec_artist_binding_read_profile( $profile_id, $artist_blog_id ) {
 				'term_id' => (int) get_post_meta( $profile_id, '_artist_term_id', true ),
 				'slug'    => (string) $post->post_name,
 				'title'   => (string) $post->post_title,
+				'status'  => (string) $post->post_status,
 			);
 		}
 	} finally {

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -60,6 +60,7 @@ final class AbilityAuthorizationTest extends TestCase {
 			'extrachill/artist-invitation',
 			'extrachill/artists-list',
 			'extrachill/artist-get',
+			'extrachill/artist-public-projections',
 			'extrachill/artist-get-permissions',
 			'extrachill/artist-subscribe',
 			'extrachill/artist-query-local-support-candidates',
@@ -231,6 +232,7 @@ final class AbilityAuthorizationTest extends TestCase {
 		$abilities = array(
 			'extrachill/artists-list'          => array(),
 			'extrachill/artist-get'            => array( 'id' => 42 ),
+			'extrachill/artist-public-projections' => array( 'schema_version' => '1', 'slugs' => array( 'test-artist' ) ),
 			'extrachill/artist-get-permissions' => array( 'id' => 42 ),
 			'extrachill/artist-subscribe'      => array( 'id' => 42, 'email' => 'fan@example.com' ),
 		);

--- a/tests/ArtistPublicProjectionsTest.php
+++ b/tests/ArtistPublicProjectionsTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class ArtistPublicProjectionsTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'blogs'           => array(
+				1 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+				4 => array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() ),
+			),
+		);
+		extrachill_artist_platform_register_abilities();
+	}
+
+	private function addTerm( int $id, string $slug, int $profile_id = 0 ): void {
+		$GLOBALS['ec_test']['blogs'][1]['terms'][ $id ] = (object) array(
+			'term_id'  => $id,
+			'taxonomy' => 'artist',
+			'slug'     => $slug,
+		);
+		if ( $profile_id > 0 ) {
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][ $id ]['_artist_profile_id'] = $profile_id;
+		}
+	}
+
+	private function addProfile( int $id, string $slug, string $name, int $term_id, string $status = 'publish' ): void {
+		$GLOBALS['ec_test']['blogs'][4]['posts'][ $id ] = (object) array(
+			'ID'          => $id,
+			'post_type'   => 'artist_profile',
+			'post_status' => $status,
+			'post_title'  => $name,
+			'post_name'   => $slug,
+		);
+		$GLOBALS['ec_test']['blogs'][4]['post_meta'][ $id ]['_artist_term_id'] = $term_id;
+	}
+
+	public function test_registration_exposes_an_exact_public_read_contract(): void {
+		$ability = wp_get_ability( 'extrachill/artist-public-projections' );
+		$input   = $ability->get_input_schema();
+		$output  = $ability->get_output_schema();
+		$item    = $output['properties']['items']['items'];
+
+		$this->assertTrue( $ability->check_permissions( array( 'schema_version' => '1', 'slugs' => array( 'kid-lake' ) ) ) );
+		$this->assertTrue( $ability->get_meta()['show_in_rest'] );
+		$this->assertSame( array( 'readonly' => true, 'idempotent' => true, 'destructive' => false ), $ability->get_meta()['annotations'] );
+		$this->assertSame( array( 'schema_version', 'slugs' ), $input['required'] );
+		$this->assertFalse( $input['additionalProperties'] );
+		$this->assertSame( array( '1' ), $input['properties']['schema_version']['enum'] );
+		$this->assertSame( 1, $input['properties']['slugs']['minItems'] );
+		$this->assertSame( 100, $input['properties']['slugs']['maxItems'] );
+		$this->assertTrue( $input['properties']['slugs']['uniqueItems'] );
+		$this->assertSame( 1, $input['properties']['slugs']['items']['minLength'] );
+		$this->assertSame( 200, $input['properties']['slugs']['items']['maxLength'] );
+		$this->assertSame( '^[a-z0-9]+(?:-[a-z0-9]+)*$', $input['properties']['slugs']['items']['pattern'] );
+		$this->assertSame( array( 'schema_version', 'items' ), $output['required'] );
+		$this->assertFalse( $output['additionalProperties'] );
+		$this->assertSame( 100, $output['properties']['items']['maxItems'] );
+		$this->assertSame( array( 'slug', 'status', 'name', 'url' ), $item['required'] );
+		$this->assertFalse( $item['additionalProperties'] );
+		$this->assertSame( array( 'resolved', 'not_found' ), $item['properties']['status']['enum'] );
+	}
+
+	public function test_schema_rejects_duplicate_bounds_and_noncanonical_slugs(): void {
+		$slugs_schema = wp_get_ability( 'extrachill/artist-public-projections' )->get_input_schema()['properties']['slugs'];
+		$valid_slug   = static function ( string $slug ) use ( $slugs_schema ): bool {
+			$item = $slugs_schema['items'];
+			return strlen( $slug ) >= $item['minLength']
+				&& strlen( $slug ) <= $item['maxLength']
+				&& 1 === preg_match( '/' . $item['pattern'] . '/', $slug );
+		};
+
+		$this->assertLessThan( $slugs_schema['minItems'], count( array() ) );
+		$this->assertGreaterThan( $slugs_schema['maxItems'], count( range( 1, 101 ) ) );
+		$this->assertNotSame( array( 'kid-lake', 'kid-lake' ), array_values( array_unique( array( 'kid-lake', 'kid-lake' ) ) ) );
+		$this->assertTrue( $slugs_schema['uniqueItems'] );
+		$this->assertTrue( $valid_slug( 'kid-lake' ) );
+		$this->assertFalse( $valid_slug( '' ) );
+		$this->assertFalse( $valid_slug( 'Kid-Lake' ) );
+		$this->assertFalse( $valid_slug( '-kid-lake' ) );
+		$this->assertFalse( $valid_slug( 'kid--lake' ) );
+		$this->assertFalse( $valid_slug( str_repeat( 'a', 201 ) ) );
+	}
+
+	public function test_resolved_and_missing_artists_preserve_order_and_exact_shape(): void {
+		$this->addTerm( 10, 'kid-lake', 20 );
+		$this->addProfile( 20, 'kid-lake', 'Kid Lake', 10 );
+
+		$result = extrachill_artist_platform_ability_artist_public_projections(
+			array( 'schema_version' => '1', 'slugs' => array( 'missing-artist', 'kid-lake' ) )
+		);
+
+		$this->assertSame(
+			array(
+				'schema_version' => '1',
+				'items'          => array(
+					array( 'slug' => 'missing-artist', 'status' => 'not_found', 'name' => '', 'url' => '' ),
+					array( 'slug' => 'kid-lake', 'status' => 'resolved', 'name' => 'Kid Lake', 'url' => 'https://artist.example/artists/kid-lake/' ),
+				),
+			),
+			$result
+		);
+		$this->assertSame( 4, get_current_blog_id() );
+		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );
+	}
+
+	public function test_missing_and_stale_bindings_do_not_fall_back_by_slug(): void {
+		$this->addTerm( 10, 'unbound-artist' );
+		$this->addProfile( 20, 'unbound-artist', 'Unbound Artist', 10 );
+		$this->addTerm( 11, 'stale-artist', 21 );
+		$this->addProfile( 21, 'stale-artist', 'Stale Artist', 99 );
+
+		$result = extrachill_artist_platform_ability_artist_public_projections(
+			array( 'schema_version' => '1', 'slugs' => array( 'unbound-artist', 'stale-artist' ) )
+		);
+
+		$this->assertSame( array( 'not_found', 'not_found' ), array_column( $result['items'], 'status' ) );
+		$this->assertSame( array( '', '' ), array_column( $result['items'], 'name' ) );
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][10] ?? array() );
+	}
+
+	public function test_deleted_and_unpublished_profiles_are_not_found(): void {
+		$this->addTerm( 10, 'deleted-artist', 20 );
+		$this->addTerm( 11, 'draft-artist', 21 );
+		$this->addProfile( 21, 'draft-artist', 'Draft Artist', 11, 'draft' );
+
+		$result = extrachill_artist_platform_ability_artist_public_projections(
+			array( 'schema_version' => '1', 'slugs' => array( 'deleted-artist', 'draft-artist' ) )
+		);
+
+		$this->assertSame( array( 'not_found', 'not_found' ), array_column( $result['items'], 'status' ) );
+		$this->assertSame( array( '', '' ), array_column( $result['items'], 'url' ) );
+	}
+
+	public function test_owner_site_failure_remains_an_error(): void {
+		$GLOBALS['ec_test']['artist_blog_unavailable'] = true;
+
+		$result = extrachill_artist_platform_ability_artist_public_projections(
+			array( 'schema_version' => '1', 'slugs' => array( 'kid-lake' ) )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'artist_projection_owner_unavailable', $result->get_error_code() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1114,6 +1114,7 @@ require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/permissions.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-platform-post-types.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
+require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-public-projections.php';
 require_once dirname( __DIR__ ) . '/inc/local-support/availability.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/helpers.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-term-binding.php';


### PR DESCRIPTION
## Summary
- add the public, read-only `extrachill/artist-public-projections` owner ability for canonical subscription slug presentation
- resolve only reciprocal Main artist-term to Artist Platform profile bindings, requiring a published profile and canonical Artist Platform permalink
- preserve input order and exact per-slug output while returning `not_found` for absent, stale, deleted, or unpublished bindings and `WP_Error` for owner infrastructure failures

## Owner Lookup And Visibility
Artist Platform remains the sole owner of the Main term binding lookup, reciprocal profile validation, publication visibility, display name, and canonical URL. The handler uses the existing binding readers and does not expose metadata keys, accept profile IDs, add a registry, duplicate state, or fall back to same-slug profiles when a binding is missing.

The ability is intentionally public and REST-visible. Its annotations mark it read-only, idempotent, and non-destructive.

## Schema
- requires exact `schema_version: "1"`
- accepts 1-100 unique canonical slugs matching `^[a-z0-9]+(?:-[a-z0-9]+)*$`
- rejects additional input properties
- returns exact `schema_version` and ordered `items`
- returns exactly `slug`, `status`, `name`, and `url` per item with no additional properties
- uses `resolved|not_found`; unresolved items always have empty `name` and `url`

## Tests
- `vendor/bin/phpunit` (227 tests, 1,254 assertions)
- `npm run test:js -- --runInBand` (5 suites, 12 tests)
- changed production PHP: WordPress PHPCS (pass)
- changed implementation: PHPStan level 0 with test bootstrap (pass; repository has no PHPStan dependency/config)
- `npm run build` (pass)
- `npm run lint:js` (existing unrelated baseline: 1,994 findings)
- `npm run lint:css` (existing unrelated baseline: 1,561 findings)

Closes #182.
Unblocks Extra-Chill/extrachill-community#266.
