### PR TITLE
fix: guard artist capability argument handling

### DIFF
--- a/inc/core/filters/permissions.php
+++ b/inc/core/filters/permissions.php
@@ -179,14 +179,24 @@ function ec_filter_user_capabilities( $allcaps, $caps, $args, $user ) {
 		'edit_private_artist_profiles',
 		'edit_published_artist_profiles',
 	);
-	$cap         = $args[0] ?? '';
-	$object_id   = isset( $args[2] ) ? absint( $args[2] ) : 0;
+
+	$cap = $args[0] ?? '';
 	if ( in_array( $cap, $admin_caps, true ) && user_can( $user->ID, 'manage_options' ) ) {
 		$allcaps[ $cap ] = true;
 		return $allcaps;
 	}
 
-	if ( ! $object_id || ! in_array( $cap, $object_caps, true ) ) {
+	if ( ! in_array( $cap, $object_caps, true ) ) {
+		return $allcaps;
+	}
+
+	$object_id_arg = $args[2] ?? null;
+	if ( ! is_int( $object_id_arg ) && ( ! is_string( $object_id_arg ) || ! ctype_digit( $object_id_arg ) ) ) {
+		return $allcaps;
+	}
+
+	$object_id = absint( $object_id_arg );
+	if ( ! $object_id ) {
 		return $allcaps;
 	}
 

--- a/tests/ArtistObjectCapabilitiesTest.php
+++ b/tests/ArtistObjectCapabilitiesTest.php
@@ -212,4 +212,53 @@ final class ArtistObjectCapabilitiesTest extends TestCase {
 			ec_map_artist_object_capabilities( array( 'do_not_allow' ), 'delete_post', 7, array( 40 ) )
 		);
 	}
+
+	/**
+	 * Unrelated object arguments must not be interpreted as artist IDs.
+	 */
+	public function test_unrelated_capabilities_with_object_arguments_are_untouched_without_warnings(): void {
+		$allcaps  = array( 'edit_posts' => true );
+		$warnings = array();
+		$contexts = array(
+			(object) array(
+				'name' => 'core/edit-post',
+				'post' => (object) array( 'post_type' => 'topic' ),
+			),
+			new stdClass(),
+		);
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Captures the regression warning.
+		set_error_handler(
+			static function ( $severity, $message ) use ( &$warnings ) {
+				$warnings[] = $message;
+				return true;
+			},
+			E_WARNING
+		);
+
+		try {
+			foreach ( $contexts as $context ) {
+				$this->assertSame(
+					$allcaps,
+					ec_filter_user_capabilities( $allcaps, array( 'edit_block_bindings' ), array( 'edit_block_binding', 7, $context ), (object) array( 'ID' => 7 ) )
+				);
+			}
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( array(), $warnings );
+	}
+
+	/**
+	 * Owned object capabilities require a numeric object ID.
+	 */
+	public function test_owned_capability_requires_an_object_id_argument(): void {
+		$allcaps = array( 'edit_posts' => true );
+
+		$this->assertSame(
+			$allcaps,
+			ec_filter_user_capabilities( $allcaps, array( 'edit_others_artist_profiles' ), array( 'edit_post', 7, new stdClass() ), (object) array( 'ID' => 7 ) )
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- Return from the global `user_has_cap` filter before interpreting arguments for capabilities Artist Platform does not own.
- Validate owned object-capability arguments as integer or digit-string object IDs before normalizing them.
- Preserve existing administrator and reciprocal artist membership grants while leaving unrelated capability arrays unchanged.

## Root cause

WordPress defines the third and subsequent `user_has_cap` arguments as mixed. `ec_filter_user_capabilities()` nevertheless called `absint()` on `$args[2]` before checking whether the requested capability was one of Artist Platform's capabilities. Gutenberg passes a `WP_Block_Editor_Context` object there for `edit_block_binding`, causing PHP 8.4's object-to-integer warning and corrupting the Community composer response.

## Capability boundary

The filter now handles object arguments only after the requested capability matches Artist Platform's object-capability allowlist. Owned capabilities require a positive integer or digit-string object ID; unrelated capabilities and malformed owned-capability arguments return the original capability map untouched.

## Tests

- `vendor/bin/phpunit --do-not-cache-result tests/ArtistObjectCapabilitiesTest.php` (12 tests, 56 assertions)
- `vendor/bin/phpunit --do-not-cache-result` (248 tests, 1,334 assertions)
- `php -l inc/core/filters/permissions.php`
- `php -l tests/ArtistObjectCapabilitiesTest.php`
- `git diff --check`
- `vendor/bin/phpcs --standard=WordPress inc/core/filters/permissions.php tests/ArtistObjectCapabilitiesTest.php` (repository baseline remains non-green: `permissions.php` improves from 27 errors/7 warnings to 27 errors/5 warnings; the test file remains at 14 errors/2 warnings, with no new findings)

Fixes #188

PR only. No release or deploy performed.