### PR TITLE
Prevent roster source from breaking response headers

### DIFF
--- a/inc/artist-profiles/roster/manage-roster-ui.php
+++ b/inc/artist-profiles/roster/manage-roster-ui.php
@@ -146,5 +146,3 @@ function ec_display_manage_members_section( $artist_id, $current_user_id ) {
     <?php
 }
 } // Close the function_exists check
-
-?> 

--- a/tests/PluginSourceOutputTest.php
+++ b/tests/PluginSourceOutputTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class PluginSourceOutputTest extends TestCase {
+	public function test_roster_ui_source_does_not_emit_output_when_loaded(): void {
+		ob_start();
+		include dirname( __DIR__ ) . '/inc/artist-profiles/roster/manage-roster-ui.php';
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}


### PR DESCRIPTION
## Summary
- remove trailing PHP output from the legacy roster UI source so plugin loading cannot preempt response headers
- add a regression test that requires the source to emit zero bytes when included

## Verification
- `composer test` (249 tests, 1,335 assertions)
- `php -l inc/artist-profiles/roster/manage-roster-ui.php`
- `php -l tests/PluginSourceOutputTest.php`
- WP Codebox run 15 completed all 87 auth assertions with clean stdout and no header warnings; browser navigation later timed out under host load
- Focused PHPCS was unavailable because the repository's Composer dependencies do not install WordPress Coding Standards

Fixes #190
