### PR TITLE
fix: provision artist analytics page

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -19,6 +19,8 @@ define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
 
+require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-pages.php';
+
 if ( ! defined( 'EXTRCH_LINKPAGE_DEV' ) ) {
     define( 'EXTRCH_LINKPAGE_DEV', false );
 }
@@ -140,6 +142,7 @@ class ExtraChillArtistPlatform {
     public static function activate() {
         // Link-page analytics tables are owned and created by extrachill-analytics
         // (ECA) as of extrachill-artist-platform#89 / extrachill-analytics#94.
+        extrachill_artist_platform_create_pages();
         flush_rewrite_rules();
         // Persist the rewrite-rules version so the version-gated flush on init
         // does not immediately re-run after activation. The constant is defined
@@ -184,82 +187,6 @@ function extrachill_artist_platform_register_blocks() {
     register_block_type( __DIR__ . '/build/blocks/artist-creator' );
     register_block_type( __DIR__ . '/build/blocks/artist-shop-manager' );
 }
-
-/**
- * Migrate old page slugs to new naming convention.
- *
- * Renames manage-artist-profiles -> manage-artist and updates block content.
- * Safe to run multiple times - checks if migration already complete.
- */
-function extrachill_artist_platform_migrate_pages() {
-    // Migrate manage-artist-profiles -> manage-artist
-    $old_page = get_page_by_path( 'manage-artist-profiles' );
-    if ( $old_page ) {
-        wp_update_post( array(
-            'ID'           => $old_page->ID,
-            'post_name'    => 'manage-artist',
-            'post_title'   => 'Manage Artist',
-            'post_content' => '<!-- wp:extrachill/artist-manager /-->',
-        ) );
-    }
-}
-
-/**
- * Create required pages for the artist platform
- *
- * Creates pages with appropriate blocks if they don't already exist.
- * Called on plugin activation and admin_init with version check.
- */
-function extrachill_artist_platform_create_pages() {
-    $pages = array(
-        'create-artist' => array(
-            'title'   => 'Create Artist',
-            'content' => '<!-- wp:extrachill/artist-creator /-->',
-        ),
-        'manage-artist' => array(
-            'title'   => 'Manage Artist',
-            'content' => '<!-- wp:extrachill/artist-manager /-->',
-        ),
-        'manage-link-page' => array(
-            'title'   => 'Manage Link Page',
-            'content' => '<!-- wp:extrachill/link-page-editor /-->',
-        ),
-        'manage-shop' => array(
-            'title'   => 'Manage Shop',
-            'content' => '<!-- wp:extrachill/artist-shop-manager /-->',
-        ),
-    );
-
-    foreach ( $pages as $slug => $page_data ) {
-        $existing_page = get_page_by_path( $slug );
-        if ( ! $existing_page ) {
-            wp_insert_post( array(
-                'post_title'   => $page_data['title'],
-                'post_name'    => $slug,
-                'post_content' => $page_data['content'],
-                'post_status'  => 'publish',
-                'post_type'    => 'page',
-            ) );
-        }
-    }
-}
-
-/**
- * Run page migration and creation on admin_init with version check
- *
- * Ensures pages are migrated/created on plugin upgrades, not just fresh activations.
- */
-function extrachill_artist_platform_maybe_create_pages() {
-    $current_version = EXTRACHILL_ARTIST_PLATFORM_VERSION;
-    $stored_version = get_option( 'extrachill_artist_platform_pages_version', '0' );
-
-    if ( version_compare( $stored_version, $current_version, '<' ) ) {
-        extrachill_artist_platform_migrate_pages();
-        extrachill_artist_platform_create_pages();
-        update_option( 'extrachill_artist_platform_pages_version', $current_version );
-    }
-}
-add_action( 'admin_init', 'extrachill_artist_platform_maybe_create_pages' );
 
 /**
  * Self-heal posts whose post_modified_gmt is the MySQL zero date.

--- a/inc/core/platform-pages.php
+++ b/inc/core/platform-pages.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Required Artist Platform pages.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Migrate old page slugs to new naming convention.
+ *
+ * Renames manage-artist-profiles -> manage-artist and updates block content.
+ * Safe to run multiple times - checks if migration already complete.
+ */
+function extrachill_artist_platform_migrate_pages() {
+	$old_page = get_page_by_path( 'manage-artist-profiles' );
+	if ( $old_page ) {
+		wp_update_post(
+			array(
+				'ID'           => $old_page->ID,
+				'post_name'    => 'manage-artist',
+				'post_title'   => 'Manage Artist',
+				'post_content' => '<!-- wp:extrachill/artist-manager /-->',
+			)
+		);
+	}
+}
+
+/**
+ * Create required pages for the artist platform.
+ *
+ * Creates pages with appropriate blocks if they don't already exist.
+ * Called on plugin activation and admin_init with version check.
+ */
+function extrachill_artist_platform_create_pages() {
+	$pages = array(
+		'create-artist'    => array(
+			'title'   => 'Create Artist',
+			'content' => '<!-- wp:extrachill/artist-creator /-->',
+		),
+		'manage-artist'    => array(
+			'title'   => 'Manage Artist',
+			'content' => '<!-- wp:extrachill/artist-manager /-->',
+		),
+		'manage-link-page' => array(
+			'title'   => 'Manage Link Page',
+			'content' => '<!-- wp:extrachill/link-page-editor /-->',
+		),
+		'manage-shop'      => array(
+			'title'   => 'Manage Shop',
+			'content' => '<!-- wp:extrachill/artist-shop-manager /-->',
+		),
+		'analytics'        => array(
+			'title'   => 'Analytics',
+			'content' => '<!-- wp:extrachill/artist-analytics /-->',
+		),
+	);
+
+	foreach ( $pages as $slug => $page_data ) {
+		$existing_page = get_page_by_path( $slug );
+		if ( ! $existing_page ) {
+			wp_insert_post(
+				array(
+					'post_title'   => $page_data['title'],
+					'post_name'    => $slug,
+					'post_content' => $page_data['content'],
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				)
+			);
+		}
+	}
+}
+
+/**
+ * Run page migration and creation on admin_init with version check.
+ *
+ * Ensures pages are migrated/created on plugin upgrades, not just fresh activations.
+ */
+function extrachill_artist_platform_maybe_create_pages() {
+	$current_version = EXTRACHILL_ARTIST_PLATFORM_VERSION;
+	$stored_version  = get_option( 'extrachill_artist_platform_pages_version', '0' );
+
+	if ( version_compare( $stored_version, $current_version, '<' ) ) {
+		extrachill_artist_platform_migrate_pages();
+		extrachill_artist_platform_create_pages();
+		update_option( 'extrachill_artist_platform_pages_version', $current_version );
+	}
+}
+add_action( 'admin_init', 'extrachill_artist_platform_maybe_create_pages' );

--- a/tests/PlatformPagesTest.php
+++ b/tests/PlatformPagesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname( __DIR__ ) . '/inc/core/platform-pages.php';
+
+final class PlatformPagesTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['ec_test'] = array(
+			'current_blog_id' => 4,
+			'blog_stack'      => array(),
+			'blogs'           => array(
+				4 => array(
+					'posts' => array(),
+				),
+			),
+		);
+	}
+
+	public function test_fresh_install_provisions_canonical_analytics_page_with_block(): void {
+		extrachill_artist_platform_create_pages();
+
+		$page = get_page_by_path( 'analytics' );
+
+		$this->assertNotNull( $page );
+		$this->assertSame( 'publish', $page->post_status );
+		$this->assertSame( '<!-- wp:extrachill/artist-analytics /-->', $page->post_content );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -929,7 +929,12 @@ function wp_generate_uuid4() {
 	return '00000000-0000-4000-8000-' . str_pad( (string) $GLOBALS['ec_test']['uuid_sequence'], 12, '0', STR_PAD_LEFT );
 }
 
-function get_page_by_path() {
+function get_page_by_path( $path ) {
+	foreach ( ec_test_blog_store( 'posts' ) as $post ) {
+		if ( 'page' === $post->post_type && $path === $post->post_name ) {
+			return $post;
+		}
+	}
 	return null;
 }
 


### PR DESCRIPTION
## Summary
- provision the canonical `/analytics/` WordPress page with the existing `extrachill/artist-analytics` dynamic block
- run required-page provisioning directly during activation while retaining the version-gated upgrade path
- isolate page provisioning for fresh-install regression coverage without adding a parallel route or changing block authorization

## Root Cause
The authenticated secondary navigation already linked to `/analytics/`, and the analytics block was registered and functional, but the required-page manifest omitted an Analytics page. Activation also did not call the page creator despite its documented contract, leaving native WordPress routing with no page to resolve on a fresh install.

## Behavior
Fresh activation now creates a published page at the canonical `analytics` slug before rewrites are flushed. Existing installs receive the same page through the existing version-gated `admin_init` provisioning path when Homeboy advances the plugin version. Rendering and authorization remain owned by the existing dynamic block.

## Tests
- `vendor/bin/phpunit --filter PlatformPagesTest` (1 test, 3 assertions)
- `composer test` (250 tests, 1,338 assertions)
- `npm run test:js` (5 suites, 12 tests)
- `npm run build`
- `php -l inc/core/platform-pages.php`
- `php -l extrachill-artist-platform.php`
- `php -l tests/PlatformPagesTest.php`
- `git diff --check`

## Fixture And Lint Caveats
The regression uses the repository's in-memory WordPress fixture to prove that a fresh page store resolves `analytics` to a published page containing `<!-- wp:extrachill/artist-analytics /-->`; it does not boot an HTTP server. Repository-wide `npm run lint:js` and `npm run lint:css` remain blocked by the existing baselines tracked in #159 (1,994 JS findings and 1,561 CSS findings). The declared WordPress PHP standard is not installed by this repository's Composer dependencies, already tracked in #141, so targeted PHP validation used syntax checks.

Closes #192