### PR TITLE
docs: restore Artist Preferences source

### DIFF
--- a/docs/user/artist-preferences.md
+++ b/docs/user/artist-preferences.md
@@ -1,0 +1,27 @@
+# Artist Preferences
+
+Artist preferences let you choose whether Extra Chill sends account notifications about an artist. Following an artist does not share the email address on your Extra Chill account or add you to a mailing list.
+
+## Artist notifications
+
+Turn on artist notifications to get an Extra Chill account notification when new coverage of that artist is published.
+
+Turning this off stops those notifications.
+
+## Direct artist subscriptions
+
+An email form on an artist's Link Page or public artist profile is separate from artist notifications. When you submit that form, you subscribe directly to that artist and the artist's team manages that subscriber list.
+
+Extra Chill does not add your account email to an artist's subscriber list. Turning artist notifications on or off does not change a direct artist subscription.
+
+## Extra Chill newsletters
+
+A newsletter form from Extra Chill subscribes you to Extra Chill, not to an artist. Extra Chill newsletter subscriptions, direct artist subscriptions, and artist account notifications are separate choices.
+
+## Change your preferences
+
+1. Log in to Extra Chill.
+2. Open the artist's page.
+3. Use the controls under **Artist preferences**.
+
+You can turn artist notifications on or off at any time.


### PR DESCRIPTION
## Summary
- restore the canonical Artist Preferences Markdown in the Artist Platform-owned `docs/user` directory
- allow the GitHub-to-Docs sync to update the existing `artist-preferences` page instead of leaving it stranded on legacy content

The file is byte-identical to the updated legacy source. No WordPress content was modified by this PR.

Closes #194.