### PR TITLE
fix: serialize canonical artist bindings

### DIFF
--- a/.github/workflows/artist-binding-mysql.yml
+++ b/.github/workflows/artist-binding-mysql.yml
@@ -1,0 +1,59 @@
+name: Artist binding MySQL proof
+
+on:
+  pull_request:
+    paths:
+      - 'inc/core/artist-term-binding.php'
+      - 'tests/MySQLIntegration/**'
+      - 'phpunit-binding-mysql.xml.dist'
+      - '.github/workflows/artist-binding-mysql.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mysql-84:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: artist_binding_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    env:
+      MYSQL_HOST: 127.0.0.1
+      MYSQL_PORT: 3306
+      MYSQL_USER: root
+      MYSQL_PASSWORD: root
+      MYSQL_DATABASE: artist_binding_test
+      WP_INTEGRATION_PATH: /tmp/artist-binding-wordpress
+      ARTIST_BINDING_SOURCE: ${{ github.workspace }}/inc/core/artist-term-binding.php
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mysqli
+          coverage: none
+      - run: composer install --no-interaction --prefer-dist
+      - name: Install real WordPress multisite
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /tmp/wp
+          chmod +x /tmp/wp
+          mkdir -p "$WP_INTEGRATION_PATH"
+          /tmp/wp core download --path="$WP_INTEGRATION_PATH" --quiet
+          /tmp/wp config create --path="$WP_INTEGRATION_PATH" --dbname="$MYSQL_DATABASE" --dbuser="$MYSQL_USER" --dbpass="$MYSQL_PASSWORD" --dbhost="$MYSQL_HOST:$MYSQL_PORT" --skip-check --quiet
+          /tmp/wp core multisite-install --path="$WP_INTEGRATION_PATH" --url=artist-binding.test --title="Artist Binding Test" --admin_user=admin --admin_password=password --admin_email=test@example.com --skip-email --quiet
+          /tmp/wp site create --path="$WP_INTEGRATION_PATH" --slug=site-two --title="Site Two" --email=test@example.com --quiet
+          /tmp/wp site create --path="$WP_INTEGRATION_PATH" --slug=site-three --title="Site Three" --email=test@example.com --quiet
+          /tmp/wp site create --path="$WP_INTEGRATION_PATH" --slug=artist --title="Artist" --email=test@example.com --quiet
+          test "$(/tmp/wp site list --path="$WP_INTEGRATION_PATH" --field=blog_id | tr '\n' ' ')" = "1 2 3 4 "
+      - run: vendor/bin/phpunit -c phpunit-binding-mysql.xml.dist

--- a/inc/artist-profiles/admin/membership.php
+++ b/inc/artist-profiles/admin/membership.php
@@ -255,7 +255,10 @@ function ec_get_artist_membership_failure() {
 }
 
 /**
- * Acquire the relationship-wide lock.
+ * Acquire the relationship-wide membership lock.
+ *
+ * When an operation also locks canonical profile/term binding authority, it
+ * must acquire the Artist Platform binding lock before this distinct lock.
  *
  * @param int $user_id   User ID.
  * @param int $artist_id Artist ID.

--- a/inc/core/artist-term-binding.php
+++ b/inc/core/artist-term-binding.php
@@ -8,6 +8,173 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Acquire the network-wide canonical binding lock.
+ *
+ * The lock covers every profile/term pair, including absent metadata rows.
+ * This lock is always first. Transactions, domain locks, profile/term locks,
+ * and the distinct artist membership lock are subordinate and are released
+ * before this lock. Consumers acquire outside a transaction, start and finish
+ * subordinate transaction/domain/member work, then release this lock.
+ * REPEATABLE READ is the intentional isolation level for that subordinate
+ * transaction, not merely a transaction-state probe.
+ *
+ * @return string|WP_Error Opaque lock token or a stable failure.
+ */
+function ec_acquire_artist_binding_lock() {
+	global $wpdb;
+	$lock_name = 'ec_artist_binding_v1';
+	if ( ! empty( $GLOBALS['ec_artist_binding_lock'] ) || ! empty( $GLOBALS['ec_artist_binding_lock_pending'] ) || preg_match( '/sqlite|pgsql|postgres/', strtolower( get_class( $wpdb ) ) ) ) {
+		return new WP_Error( 'artist_binding_lock_unsupported', __( 'Canonical artist binding serialization is unavailable.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+	}
+	$GLOBALS['ec_artist_binding_lock_pending'] = true;
+	try {
+		$result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, %d)', $lock_name, 5 ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One network-wide lock covers both multisite metadata tables and absent rows.
+	} finally {
+		unset( $GLOBALS['ec_artist_binding_lock_pending'] );
+	}
+	if ( '1' !== (string) $result ) {
+		$code = '0' === (string) $result ? 'artist_binding_busy' : 'artist_binding_lock_failed';
+		return new WP_Error( $code, __( 'Canonical artist binding is temporarily unavailable.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+	}
+	$GLOBALS['ec_artist_binding_lock'] = $lock_name;
+	$handed_off                        = false;
+	try {
+		$boundary = ec_artist_binding_prepare_mutation_boundary();
+		if ( is_wp_error( $boundary ) ) {
+			ec_artist_binding_defer_lock_release( 'boundary', $lock_name );
+			$handed_off = true;
+			return $boundary;
+		}
+		$handed_off = true;
+		return $lock_name;
+	} finally {
+		if ( ! $handed_off ) {
+			$release = ec_release_artist_binding_lock( $lock_name );
+			if ( is_wp_error( $release ) ) {
+				ec_set_artist_binding_release_failure( $release );
+			}
+		}
+	}
+}
+
+/**
+ * Release the canonical binding lock.
+ *
+ * Failed releases remain tracked so the connection is never treated as clean.
+ *
+ * @param string $lock_token Opaque lock token.
+ * @return true|WP_Error True on release or a stable failure.
+ */
+function ec_release_artist_binding_lock( $lock_token ) {
+	global $wpdb;
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) || $GLOBALS['ec_artist_binding_lock'] !== $lock_token ) {
+		return new WP_Error( 'artist_binding_lock_invalid', __( 'Canonical artist binding lock ownership is invalid.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	$boundary = ec_artist_binding_prepare_mutation_boundary();
+	if ( is_wp_error( $boundary ) ) {
+		return new WP_Error( 'artist_binding_release_transaction_active', __( 'Canonical artist binding cannot be released before subordinate transaction work finishes.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	$released = $wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_token ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Releases the exact connection-owned lock acquired above.
+	if ( '1' !== (string) $released ) {
+		return new WP_Error( 'artist_binding_release_failed', __( 'Canonical artist binding lock cleanup failed.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+	}
+	unset( $GLOBALS['ec_artist_binding_lock'] );
+	foreach ( (array) ( $GLOBALS['ec_artist_binding_deferred_locks'] ?? array() ) as $key => $deferred_lock ) {
+		if ( $deferred_lock === $lock_token ) {
+			unset( $GLOBALS['ec_artist_binding_deferred_locks'][ $key ] );
+		}
+	}
+	return true;
+}
+
+/**
+ * Set the intentional isolation level and prove the connection boundary.
+ *
+ * MySQL 8.4 and MariaDB 10.11 both reject this statement inside an active
+ * transaction. On success it configures the next transaction as REPEATABLE
+ * READ. Error display is restored exactly to its previous state.
+ *
+ * @return true|WP_Error True outside a transaction or a stable failure.
+ */
+function ec_artist_binding_prepare_mutation_boundary() {
+	global $wpdb;
+	if ( preg_match( '/sqlite|pgsql|postgres/', strtolower( get_class( $wpdb ) ) ) ) {
+		return new WP_Error( 'artist_binding_transaction_state_unsupported', __( 'Canonical artist binding transaction state is unavailable.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	$previous_suppression = $wpdb->suppress_errors( true );
+	try {
+		$accepted = $wpdb->query( 'SET TRANSACTION ISOLATION LEVEL REPEATABLE READ' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Portable MySQL/MariaDB transaction-boundary probe.
+	} finally {
+		$wpdb->suppress_errors( $previous_suppression );
+	}
+	return false === $accepted
+		? new WP_Error( 'artist_binding_nested_transaction', __( 'Canonical artist binding cannot inherit a caller-owned transaction.', 'extrachill-artist-platform' ), array( 'retryable' => false ) )
+		: true;
+}
+
+/**
+ * Retain a lock until shutdown when transaction ownership prevents release.
+ *
+ * @param string $key        Deferred lock context key.
+ * @param string $lock_token Opaque lock token.
+ * @return void
+ */
+function ec_artist_binding_defer_lock_release( $key, $lock_token ) {
+	$GLOBALS['ec_artist_binding_deferred_locks'][ $key ] = $lock_token;
+	if ( empty( $GLOBALS['ec_artist_binding_shutdown_registered'] ) ) {
+		register_shutdown_function( 'ec_artist_binding_release_deferred_locks' );
+		$GLOBALS['ec_artist_binding_shutdown_registered'] = true;
+	}
+}
+
+/** Release locks whose caller-owned transaction has ended by shutdown. */
+function ec_artist_binding_release_deferred_locks() {
+	foreach ( (array) ( $GLOBALS['ec_artist_binding_deferred_locks'] ?? array() ) as $key => $lock ) {
+		if ( ec_finish_artist_binding_lock( $lock ) ) {
+			unset( $GLOBALS['ec_artist_binding_deferred_locks'][ $key ] );
+		}
+	}
+}
+
+/**
+ * Store a release failure without replacing the primary failure.
+ *
+ * @param WP_Error|null $failure Release failure or null to clear.
+ * @return void
+ */
+function ec_set_artist_binding_release_failure( $failure = null ) {
+	$GLOBALS['ec_artist_binding_release_failure'] = $failure instanceof WP_Error ? $failure : null;
+}
+
+/**
+ * Return the last canonical binding release failure.
+ *
+ * @return WP_Error|null Last canonical binding release failure.
+ */
+function ec_get_artist_binding_release_failure() {
+	$failure = $GLOBALS['ec_artist_binding_release_failure'] ?? null;
+	return $failure instanceof WP_Error ? $failure : null;
+}
+
+/**
+ * Record release outcome while retaining any primary operation failure.
+ *
+ * @param string $lock_token Opaque lock token.
+ * @return bool Whether release succeeded.
+ */
+function ec_finish_artist_binding_lock( $lock_token ) {
+	$release = ec_release_artist_binding_lock( $lock_token );
+	if ( ! is_wp_error( $release ) ) {
+		return true;
+	}
+	ec_set_artist_binding_release_failure( $release );
+	if ( ! ec_get_artist_binding_failure() ) {
+		ec_set_artist_binding_failure( $release );
+	}
+	return false;
+}
+
+/**
  * Resolve the blogs that own each side of the binding.
  *
  * @return array{artist:int,main:int}|array{}
@@ -30,6 +197,66 @@ function ec_artist_binding_blog_ids() {
 }
 
 /**
+ * Invalidate profile caches before an authoritative locked read.
+ *
+ * @param int $profile_id    Artist profile post ID.
+ * @param int $artist_blog_id Artist blog ID.
+ * @return void
+ */
+function ec_artist_binding_invalidate_profile_cache( $profile_id, $artist_blog_id ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+		return;
+	}
+	switch_to_blog( $artist_blog_id );
+	try {
+		clean_post_cache( (int) $profile_id );
+		wp_cache_delete( (int) $profile_id, 'post_meta' );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
+ * Invalidate term caches before an authoritative locked read.
+ *
+ * @param int $term_id      Artist term ID.
+ * @param int $main_blog_id Main blog ID.
+ * @return void
+ */
+function ec_artist_binding_invalidate_term_cache( $term_id, $main_blog_id ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+		return;
+	}
+	switch_to_blog( $main_blog_id );
+	try {
+		clean_term_cache( (int) $term_id, 'artist' );
+		wp_cache_delete( (int) $term_id, 'term_meta' );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/** Invalidate slug lookup caches while the global binding lock is held. */
+function ec_artist_binding_invalidate_slug_caches() {
+	$blog_ids = ec_artist_binding_blog_ids();
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) || empty( $blog_ids ) ) {
+		return;
+	}
+	switch_to_blog( $blog_ids['main'] );
+	try {
+		clean_taxonomy_cache( 'artist' );
+	} finally {
+		restore_current_blog();
+	}
+	switch_to_blog( $blog_ids['artist'] );
+	try {
+		wp_cache_delete( 'last_changed', 'posts' );
+	} finally {
+		restore_current_blog();
+	}
+}
+
+/**
  * Read and validate an artist profile from its owning blog.
  *
  * @param int $profile_id    Artist profile post ID.
@@ -38,6 +265,7 @@ function ec_artist_binding_blog_ids() {
  */
 function ec_artist_binding_read_profile( $profile_id, $artist_blog_id ) {
 	$profile = array();
+	ec_artist_binding_invalidate_profile_cache( $profile_id, $artist_blog_id );
 	switch_to_blog( $artist_blog_id );
 	try {
 		$post = get_post( $profile_id );
@@ -66,6 +294,7 @@ function ec_artist_binding_read_profile( $profile_id, $artist_blog_id ) {
  */
 function ec_artist_binding_read_term( $term_id, $main_blog_id ) {
 	$artist_term = array();
+	ec_artist_binding_invalidate_term_cache( $term_id, $main_blog_id );
 	switch_to_blog( $main_blog_id );
 	try {
 		$term = get_term( $term_id, 'artist' );
@@ -151,8 +380,33 @@ function ec_artist_binding_delete_term_meta( $term_id, $profile_id, $main_blog_i
  * @return bool Whether the pair is reciprocal or was safely completed.
  */
 function ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $main_blog_id = null ) {
+	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		ec_set_artist_binding_failure( $lock );
+		return false;
+	}
+	$result = false;
+	try {
+		$result = ec_reconcile_artist_profile_term_pair_locked( $profile_id, $term_id, $main_blog_id );
+	} finally {
+		$released = ec_finish_artist_binding_lock( $lock );
+	}
+	return $result && $released;
+}
+
+/**
+ * Fill only a missing side of the current pair while holding the binding lock.
+ *
+ * @param int      $profile_id   Artist profile post ID.
+ * @param int      $term_id      Main-blog artist term ID.
+ * @param int|null $main_blog_id Optional resolved main blog ID.
+ * @return bool Whether the pair is reciprocal or was safely completed.
+ */
+function ec_reconcile_artist_profile_term_pair_locked( $profile_id, $term_id, $main_blog_id = null ) {
 	$blog_ids = ec_artist_binding_blog_ids();
-	if ( empty( $blog_ids ) ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) || empty( $blog_ids ) ) {
 		return false;
 	}
 
@@ -174,7 +428,73 @@ function ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $main_blo
 		return false;
 	}
 
-	return ec_bind_artist_profile_to_term( (int) $profile_id, (int) $term_id, $main_blog_id );
+	$wrote_profile = false;
+	$wrote_term    = false;
+	if ( 0 === $profile['term_id'] ) {
+		switch_to_blog( $blog_ids['artist'] );
+		try {
+			update_post_meta( (int) $profile_id, '_artist_term_id', (int) $term_id );
+		} finally {
+			restore_current_blog();
+		}
+		$current_profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
+		$wrote_profile   = ! empty( $current_profile ) && (int) $current_profile['term_id'] === (int) $term_id;
+	}
+	if ( 0 === $term['profile_id'] ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			update_term_meta( (int) $term_id, '_artist_profile_id', (int) $profile_id );
+		} finally {
+			restore_current_blog();
+		}
+		$current_term = ec_artist_binding_read_term( (int) $term_id, $main_blog_id );
+		$wrote_term   = ! empty( $current_term ) && (int) $current_term['profile_id'] === (int) $profile_id;
+	}
+	$profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
+	$term    = ec_artist_binding_read_term( (int) $term_id, $main_blog_id );
+	if ( ! empty( $profile ) && ! empty( $term ) && (int) $profile['term_id'] === (int) $term_id && (int) $term['profile_id'] === (int) $profile_id ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			delete_term_meta( (int) $term_id, '_ec_artist_binding_recoverable' );
+		} finally {
+			restore_current_blog();
+		}
+		return true;
+	}
+	if ( $wrote_profile ) {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			ec_artist_binding_delete_profile_meta( (int) $profile_id, (int) $term_id, $blog_ids['artist'] );
+			$current_profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
+			if ( empty( $current_profile ) || (int) $current_profile['term_id'] !== (int) $term_id ) {
+				break;
+			}
+		}
+	}
+	if ( $wrote_term ) {
+		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+			ec_artist_binding_delete_term_meta( (int) $term_id, (int) $profile_id, $main_blog_id );
+			$current_term = ec_artist_binding_read_term( (int) $term_id, $main_blog_id );
+			if ( empty( $current_term ) || (int) $current_term['profile_id'] !== (int) $profile_id ) {
+				break;
+			}
+		}
+	}
+	$current_profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
+	$current_term    = ec_artist_binding_read_term( (int) $term_id, $main_blog_id );
+	if ( ( $wrote_profile && ! empty( $current_profile ) && (int) $current_profile['term_id'] === (int) $term_id ) || ( $wrote_term && ! empty( $current_term ) && (int) $current_term['profile_id'] === (int) $profile_id ) ) {
+		ec_set_artist_binding_failure(
+			new WP_Error(
+				'artist_binding_compensation_failed',
+				__( 'Canonical artist binding compensation failed. Manual reconciliation is required.', 'extrachill-artist-platform' ),
+				array(
+					'profile_id' => (int) $profile_id,
+					'term_id'    => (int) $term_id,
+					'retryable'  => false,
+				)
+			)
+		);
+	}
+	return false;
 }
 
 /**
@@ -198,6 +518,89 @@ function ec_get_artist_binding_failure() {
 }
 
 /**
+ * Read one reciprocal pair while the caller owns the canonical binding lock.
+ *
+ * This is the downstream consumer contract. It does not repair state and is
+ * safe to call inside a consumer-owned transaction after acquiring the lock.
+ *
+ * @param int $profile_id Artist profile post ID.
+ * @param int $term_id    Main-blog artist term ID.
+ * @return array{profile_id:int,term_id:int}|WP_Error Valid reciprocal pair.
+ */
+function ec_read_locked_artist_binding( $profile_id, $term_id ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+		return new WP_Error( 'artist_binding_lock_required', __( 'Canonical artist binding must be locked before it is read.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	$blog_ids = ec_artist_binding_blog_ids();
+	$profile  = empty( $blog_ids ) ? array() : ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
+	$term     = empty( $blog_ids ) ? array() : ec_artist_binding_read_term( (int) $term_id, $blog_ids['main'] );
+	if ( empty( $profile ) || empty( $term ) || (int) $profile['term_id'] !== (int) $term_id || (int) $term['profile_id'] !== (int) $profile_id ) {
+		return new WP_Error( 'artist_binding_invalid', __( 'The canonical artist binding is missing or invalid.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	return array(
+		'profile_id' => (int) $profile_id,
+		'term_id'    => (int) $term_id,
+	);
+}
+
+/**
+ * Remove one stale reciprocal reference under canonical serialization.
+ *
+ * @param string $side        Metadata side: profile or term.
+ * @param int    $object_id   Profile or term ID.
+ * @param int    $expected_id Expected reciprocal ID.
+ * @return bool Whether the stale value is absent afterward.
+ */
+function ec_remove_stale_artist_binding_reference( $side, $object_id, $expected_id ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) || ( 'profile' !== $side && 'term' !== $side ) ) {
+		return false;
+	}
+	$blog_ids = ec_artist_binding_blog_ids();
+	if ( 'profile' === $side ) {
+		$current = ec_artist_binding_read_profile( $object_id, $blog_ids['artist'] );
+		if ( ! empty( $current ) && (int) $current['term_id'] === (int) $expected_id ) {
+			ec_artist_binding_delete_profile_meta( $object_id, $expected_id, $blog_ids['artist'] );
+		}
+		$current = ec_artist_binding_read_profile( $object_id, $blog_ids['artist'] );
+		$clean   = empty( $current ) || (int) $current['term_id'] !== (int) $expected_id;
+	} else {
+		$current = ec_artist_binding_read_term( $object_id, $blog_ids['main'] );
+		if ( ! empty( $current ) && (int) $current['profile_id'] === (int) $expected_id ) {
+			ec_artist_binding_delete_term_meta( $object_id, $expected_id, $blog_ids['main'] );
+		}
+		$current = ec_artist_binding_read_term( $object_id, $blog_ids['main'] );
+		$clean   = empty( $current ) || (int) $current['profile_id'] !== (int) $expected_id;
+	}
+	return $clean;
+}
+
+/**
+ * Run the canonical binding writer outside caller-owned transactions.
+ *
+ * @param int      $profile_id   Artist profile post ID.
+ * @param int      $term_id      Main-blog artist term ID.
+ * @param int|null $main_blog_id Optional resolved main blog ID.
+ * @return bool Whether the requested binding was persisted and unlocked.
+ */
+function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = null ) {
+	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		ec_set_artist_binding_failure( $lock );
+		return false;
+	}
+
+	$result = false;
+	try {
+		$result = ec_bind_artist_profile_to_term_locked( $profile_id, $term_id, $main_blog_id );
+	} finally {
+		$released = ec_finish_artist_binding_lock( $lock );
+	}
+	return $result && $released;
+}
+
+/**
  * Persist a validated one-to-one profile <-> term binding.
  *
  * One-sided stale references are replaced. A reciprocal binding owned by a
@@ -208,8 +611,12 @@ function ec_get_artist_binding_failure() {
  * @param int|null $main_blog_id Optional resolved main blog ID.
  * @return bool Whether the requested binding is valid and persisted.
  */
-function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = null ) {
+function ec_bind_artist_profile_to_term_locked( $profile_id, $term_id, $main_blog_id = null ) {
 	ec_set_artist_binding_failure();
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+		ec_set_artist_binding_failure( new WP_Error( 'artist_binding_lock_required', __( 'Canonical artist binding must be locked before it is changed.', 'extrachill-artist-platform' ), array( 'retryable' => false ) ) );
+		return false;
+	}
 	$profile_id = (int) $profile_id;
 	$term_id    = (int) $term_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
@@ -315,6 +722,15 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 		return true;
 	}
 
+	// Compensation preserves the mutation order: old term, profile, new term.
+	if ( $old_reciprocal_term_id > 0 ) {
+		switch_to_blog( $main_blog_id );
+		try {
+			update_term_meta( $old_reciprocal_term_id, '_artist_profile_id', $profile_id );
+		} finally {
+			restore_current_blog();
+		}
+	}
 	if ( ec_artist_binding_entity_exists( $bound_profile ) && $bound_profile['term_id'] === $term_id ) {
 		for ( $attempt = 0; $attempt < 3; ++$attempt ) {
 			switch_to_blog( $artist_blog_id );
@@ -351,16 +767,6 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
 			}
 		}
 	}
-	$rolled_profile = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
-	if ( $old_reciprocal_term_id > 0 && ec_artist_binding_entity_exists( $rolled_profile ) && $rolled_profile['term_id'] === $old_reciprocal_term_id ) {
-		switch_to_blog( $main_blog_id );
-		try {
-			update_term_meta( $old_reciprocal_term_id, '_artist_profile_id', $profile_id );
-		} finally {
-			restore_current_blog();
-		}
-	}
-
 	$final_profile     = ec_artist_binding_read_profile( $profile_id, $artist_blog_id );
 	$final_term        = ec_artist_binding_read_term( $term_id, $main_blog_id );
 	$final_old_term    = $old_reciprocal_term_id > 0 ? ec_artist_binding_read_term( $old_reciprocal_term_id, $main_blog_id ) : array();
@@ -393,6 +799,29 @@ function ec_bind_artist_profile_to_term( $profile_id, $term_id, $main_blog_id = 
  */
 function ec_get_artist_term_id( $profile_id ) {
 	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		ec_set_artist_binding_failure( $lock );
+		return 0;
+	}
+	$result = 0;
+	try {
+		$result = ec_get_artist_term_id_locked( $profile_id );
+	} finally {
+		$released = ec_finish_artist_binding_lock( $lock );
+	}
+	return $released ? $result : 0;
+}
+
+/**
+ * Resolve or fill a profile binding while the canonical lock is held.
+ *
+ * @param int $profile_id Artist profile post ID.
+ * @return int Canonical artist term ID or 0.
+ */
+function ec_get_artist_term_id_locked( $profile_id ) {
+	ec_set_artist_binding_failure();
 	$profile_id = (int) $profile_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
 	if ( $profile_id <= 0 || empty( $blog_ids ) ) {
@@ -405,13 +834,13 @@ function ec_get_artist_term_id( $profile_id ) {
 	}
 
 	if ( $profile['term_id'] > 0 ) {
-		if ( ec_reconcile_artist_profile_term_pair( $profile_id, $profile['term_id'], $blog_ids['main'] ) ) {
+		if ( ec_reconcile_artist_profile_term_pair_locked( $profile_id, $profile['term_id'], $blog_ids['main'] ) ) {
 			return $profile['term_id'];
 		}
 		if ( ec_get_artist_binding_failure() ) {
 			return 0;
 		}
-		ec_artist_binding_delete_profile_meta( $profile_id, $profile['term_id'], $blog_ids['artist'] );
+		ec_remove_stale_artist_binding_reference( 'profile', $profile_id, $profile['term_id'] );
 	}
 
 	if ( '' === $profile['slug'] ) {
@@ -419,6 +848,7 @@ function ec_get_artist_term_id( $profile_id ) {
 	}
 
 	$term_id = 0;
+	ec_artist_binding_invalidate_slug_caches();
 	switch_to_blog( $blog_ids['main'] );
 	try {
 		$term = get_term_by( 'slug', $profile['slug'], 'artist' );
@@ -429,7 +859,7 @@ function ec_get_artist_term_id( $profile_id ) {
 		restore_current_blog();
 	}
 
-	if ( $term_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ) {
+	if ( $term_id > 0 && ec_reconcile_artist_profile_term_pair_locked( $profile_id, $term_id, $blog_ids['main'] ) ) {
 		return $term_id;
 	}
 	return 0;
@@ -443,6 +873,29 @@ function ec_get_artist_term_id( $profile_id ) {
  */
 function ec_get_artist_profile_id( $term_id ) {
 	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		ec_set_artist_binding_failure( $lock );
+		return 0;
+	}
+	$result = 0;
+	try {
+		$result = ec_get_artist_profile_id_locked( $term_id );
+	} finally {
+		$released = ec_finish_artist_binding_lock( $lock );
+	}
+	return $released ? $result : 0;
+}
+
+/**
+ * Resolve or fill a term binding while the canonical lock is held.
+ *
+ * @param int $term_id Canonical artist term ID.
+ * @return int Artist profile post ID or 0.
+ */
+function ec_get_artist_profile_id_locked( $term_id ) {
+	ec_set_artist_binding_failure();
 	$term_id  = (int) $term_id;
 	$blog_ids = ec_artist_binding_blog_ids();
 	if ( $term_id <= 0 || empty( $blog_ids ) ) {
@@ -455,13 +908,13 @@ function ec_get_artist_profile_id( $term_id ) {
 	}
 
 	if ( $term['profile_id'] > 0 ) {
-		if ( ec_reconcile_artist_profile_term_pair( $term['profile_id'], $term_id, $blog_ids['main'] ) ) {
+		if ( ec_reconcile_artist_profile_term_pair_locked( $term['profile_id'], $term_id, $blog_ids['main'] ) ) {
 			return $term['profile_id'];
 		}
 		if ( ec_get_artist_binding_failure() ) {
 			return 0;
 		}
-		ec_artist_binding_delete_term_meta( $term_id, $term['profile_id'], $blog_ids['main'] );
+		ec_remove_stale_artist_binding_reference( 'term', $term_id, $term['profile_id'] );
 	}
 
 	if ( '' === $term['slug'] ) {
@@ -469,6 +922,7 @@ function ec_get_artist_profile_id( $term_id ) {
 	}
 
 	$profile_id = 0;
+	ec_artist_binding_invalidate_slug_caches();
 	switch_to_blog( $blog_ids['artist'] );
 	try {
 		$found = get_posts(
@@ -488,7 +942,7 @@ function ec_get_artist_profile_id( $term_id ) {
 		restore_current_blog();
 	}
 
-	if ( $profile_id > 0 && ec_reconcile_artist_profile_term_pair( $profile_id, $term_id, $blog_ids['main'] ) ) {
+	if ( $profile_id > 0 && ec_reconcile_artist_profile_term_pair_locked( $profile_id, $term_id, $blog_ids['main'] ) ) {
 		return $profile_id;
 	}
 	return 0;
@@ -501,6 +955,31 @@ function ec_get_artist_profile_id( $term_id ) {
  * @return int|WP_Error Bound artist term ID, or an actionable failure.
  */
 function ec_sync_artist_profile_term_binding( $profile_id ) {
+	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		return $lock;
+	}
+	$result = new WP_Error( 'artist_term_binding_failed', __( 'The artist profile could not be bound to its canonical artist term.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
+	try {
+		$result = ec_sync_artist_profile_term_binding_locked( $profile_id );
+	} finally {
+		$released = ec_finish_artist_binding_lock( $lock );
+	}
+	if ( $released || is_wp_error( $result ) ) {
+		return $result;
+	}
+	return ec_get_artist_binding_release_failure();
+}
+
+/**
+ * Ensure a profile binding while holding one lock through term lifecycle.
+ *
+ * @param int $profile_id Artist profile post ID.
+ * @return int|WP_Error Bound artist term ID or failure.
+ */
+function ec_sync_artist_profile_term_binding_locked( $profile_id ) {
 	$profile_id = (int) $profile_id;
 	$blog_ids   = ec_artist_binding_blog_ids();
 	if ( $profile_id <= 0 || empty( $blog_ids ) ) {
@@ -511,7 +990,7 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 	if ( empty( $profile ) ) {
 		return new WP_Error( 'invalid_artist_profile', __( 'The artist profile is unavailable.', 'extrachill-artist-platform' ) );
 	}
-	$existing_term_id = ec_get_artist_term_id( $profile_id );
+	$existing_term_id = ec_get_artist_term_id_locked( $profile_id );
 	$binding_failure  = ec_get_artist_binding_failure();
 	if ( $binding_failure ) {
 		return $binding_failure;
@@ -526,6 +1005,7 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 
 	$new_term_id  = 0;
 	$term_created = false;
+	ec_artist_binding_invalidate_slug_caches();
 	switch_to_blog( $blog_ids['main'] );
 	try {
 		$existing = get_term_by( 'slug', $profile['slug'], 'artist' );
@@ -545,10 +1025,10 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 	if ( $new_term_id <= 0 ) {
 		return new WP_Error( 'artist_term_creation_failed', __( 'The canonical artist term could not be created.', 'extrachill-artist-platform' ), array( 'retryable' => true ) );
 	}
-	if ( ec_bind_artist_profile_to_term( $profile_id, $new_term_id, $blog_ids['main'] ) ) {
+	if ( ec_bind_artist_profile_to_term_locked( $profile_id, $new_term_id, $blog_ids['main'] ) ) {
 		return $new_term_id;
 	}
-	/** @var WP_Error|null $binding_failure A failed metadata write can require manual compensation. */
+	/* @var WP_Error|null $binding_failure A failed metadata write can require manual compensation. */
 	$binding_failure = ec_get_artist_binding_failure();
 	if ( $binding_failure instanceof WP_Error ) {
 		return $binding_failure;
@@ -560,17 +1040,20 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 		$delete_state_mismatch = false;
 		switch_to_blog( $blog_ids['main'] );
 		try {
+			ec_artist_binding_invalidate_term_cache( $new_term_id, $blog_ids['main'] );
 			$created_term     = get_term( $new_term_id, 'artist' );
 			$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
 			if ( $created_term && ! is_wp_error( $created_term ) && 0 === ec_artist_binding_term_count( $created_term ) && 0 === $bound_profile_id ) {
 				$delete_result   = wp_delete_term( $new_term_id, 'artist' );
 				$delete_reported = ! is_wp_error( $delete_result ) && (bool) $delete_result;
-				/** @var mixed $deleted_term The term may disappear after deletion. */
+				/* @var mixed $deleted_term The term may disappear after deletion. */
+				ec_artist_binding_invalidate_term_cache( $new_term_id, $blog_ids['main'] );
 				$deleted_term          = get_term( $new_term_id, 'artist' );
 				$deleted               = $delete_reported && ( ! $deleted_term || is_wp_error( $deleted_term ) );
 				$delete_state_mismatch = $delete_reported && ! $deleted;
 				if ( ! $deleted && ! $delete_state_mismatch ) {
-					/** @var mixed $created_term Re-read because deletion may have changed term state. */
+					/* @var mixed $created_term Re-read because deletion may have changed term state. */
+					ec_artist_binding_invalidate_term_cache( $new_term_id, $blog_ids['main'] );
 					$created_term     = get_term( $new_term_id, 'artist' );
 					$bound_profile_id = (int) get_term_meta( $new_term_id, '_artist_profile_id', true );
 					if ( $created_term && ! is_wp_error( $created_term ) && 0 === ec_artist_binding_term_count( $created_term ) && 0 === $bound_profile_id ) {
@@ -608,23 +1091,193 @@ function ec_sync_artist_profile_term_binding( $profile_id ) {
 }
 add_action( 'ec_artist_profile_save', 'ec_sync_artist_profile_term_binding', 5, 1 );
 
+// phpcs:disable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by the WordPress filter contract.
 /**
- * Remove all term references before an artist profile is deleted.
+ * Acquire and retain canonical serialization through core post deletion.
  *
- * @param int $profile_id Post ID being deleted.
- * @return void
+ * @param mixed   $check        Earlier deletion veto value.
+ * @param WP_Post $post         Post being deleted.
+ * @param bool    $force_delete Whether deletion bypasses trash.
+ * @return mixed Null to continue or false to veto safely.
  */
-function ec_delete_artist_profile_term_binding( $profile_id ) {
+function ec_artist_binding_pre_delete_post( $check, $post, $force_delete ) {
+	// phpcs:enable Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+	ec_set_artist_binding_failure();
+	ec_set_artist_binding_release_failure();
+	if ( null !== $check || ! is_object( $post ) || 'artist_profile' !== $post->post_type ) {
+		return $check;
+	}
 	$blog_ids = ec_artist_binding_blog_ids();
 	if ( empty( $blog_ids ) || get_current_blog_id() !== $blog_ids['artist'] ) {
+		return $check;
+	}
+	$lock = ec_acquire_artist_binding_lock();
+	if ( is_wp_error( $lock ) ) {
+		ec_set_artist_binding_failure( $lock );
+		return false;
+	}
+	$retained = false;
+	try {
+		$cleanup = ec_delete_artist_profile_term_binding_locked( (int) $post->ID );
+		if ( is_wp_error( $cleanup ) ) {
+			ec_set_artist_binding_failure( $cleanup );
+			return false;
+		}
+		$key = get_current_blog_id() . ':' . (int) $post->ID;
+		$GLOBALS['ec_artist_binding_delete_locks'][ $key ] = $lock;
+		if ( empty( $GLOBALS['ec_artist_binding_delete_shutdown_registered'] ) ) {
+			register_shutdown_function( 'ec_artist_binding_release_delete_locks' );
+			$GLOBALS['ec_artist_binding_delete_shutdown_registered'] = true;
+		}
+		$retained = true;
+		return null;
+	} finally {
+		if ( ! $retained ) {
+			ec_finish_artist_binding_lock( $lock );
+		}
+	}
+}
+
+/**
+ * Release a retained delete lock after core deletion has completed.
+ *
+ * @param int     $profile_id Deleted artist profile ID.
+ * @param WP_Post $post       Deleted artist profile.
+ * @return void
+ */
+function ec_artist_binding_after_delete_post( $profile_id, $post ) {
+	if ( ! is_object( $post ) || 'artist_profile' !== $post->post_type ) {
 		return;
+	}
+	$key = get_current_blog_id() . ':' . (int) $profile_id;
+	if ( empty( $GLOBALS['ec_artist_binding_delete_locks'][ $key ] ) ) {
+		return;
+	}
+	$lock = $GLOBALS['ec_artist_binding_delete_locks'][ $key ];
+	if ( ec_finish_artist_binding_lock( $lock ) ) {
+		unset( $GLOBALS['ec_artist_binding_delete_locks'][ $key ] );
+	}
+}
+
+/** Release delete locks retained by vetoes, failed deletes, or throwables. */
+function ec_artist_binding_release_delete_locks() {
+	foreach ( (array) ( $GLOBALS['ec_artist_binding_delete_locks'] ?? array() ) as $key => $lock ) {
+		if ( ec_finish_artist_binding_lock( $lock ) ) {
+			unset( $GLOBALS['ec_artist_binding_delete_locks'][ $key ] );
+		}
+	}
+}
+
+/**
+ * Compare metadata value collections without coercing scalar types or order.
+ *
+ * @param array $left  First metadata value collection.
+ * @param array $right Second metadata value collection.
+ * @return bool Whether both collections contain the same exact values.
+ */
+function ec_artist_binding_meta_values_match( $left, $right ) {
+	$normalize = static function ( $value ) {
+		return gettype( $value ) . ':' . serialize( $value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Exact scalar type comparison prevents unsafe compensation.
+	};
+	$left      = array_map( $normalize, (array) $left );
+	$right     = array_map( $normalize, (array) $right );
+	sort( $left, SORT_STRING );
+	sort( $right, SORT_STRING );
+	return $left === $right;
+}
+
+/**
+ * Restore inverse values removed before a later deletion cleanup failure.
+ *
+ * @param array    $journal      Successful inverse removals in mutation order.
+ * @param int      $main_blog_id Main blog ID.
+ * @param WP_Error $primary      Primary cleanup failure.
+ * @return WP_Error Primary failure, or non-retryable compensation failure.
+ */
+function ec_compensate_artist_binding_delete_cleanup( $journal, $main_blog_id, $primary ) {
+	$failed_term_ids = array();
+	$failure_stage   = '';
+	switch_to_blog( $main_blog_id );
+	try {
+		foreach ( array_reverse( $journal ) as $entry ) {
+			$target   = array_merge( $entry['expected_after'], $entry['values'] );
+			$restored = false;
+			for ( $attempt = 0; $attempt < 3; ++$attempt ) {
+				ec_artist_binding_invalidate_term_cache( $entry['term_id'], $main_blog_id );
+				$current = get_term_meta( $entry['term_id'], '_artist_profile_id', false );
+				if ( ec_artist_binding_meta_values_match( $current, $target ) ) {
+					$restored = true;
+					break;
+				}
+				if ( ! ec_artist_binding_meta_values_match( $current, $entry['expected_after'] ) ) {
+					$failure_stage = 'state_changed';
+					break;
+				}
+
+				$writes_succeeded = true;
+				foreach ( $entry['values'] as $value ) {
+					$writes_succeeded = add_term_meta( $entry['term_id'], '_artist_profile_id', $value, false ) && $writes_succeeded;
+				}
+				ec_artist_binding_invalidate_term_cache( $entry['term_id'], $main_blog_id );
+				$verified = get_term_meta( $entry['term_id'], '_artist_profile_id', false );
+				if ( ec_artist_binding_meta_values_match( $verified, $target ) ) {
+					$restored = true;
+					break;
+				}
+				$failure_stage = $writes_succeeded ? 'verification' : 'write';
+			}
+			if ( ! $restored ) {
+				$failed_term_ids[] = (int) $entry['term_id'];
+			}
+		}
+	} finally {
+		restore_current_blog();
+	}
+
+	if ( empty( $failed_term_ids ) ) {
+		return $primary;
+	}
+	return new WP_Error(
+		'artist_binding_delete_compensation_failed',
+		__( 'Canonical artist inverse cleanup compensation failed. Manual reconciliation is required.', 'extrachill-artist-platform' ),
+		array(
+			'primary_code'      => $primary->get_error_code(),
+			'affected_term_ids' => array_values( array_unique( $failed_term_ids ) ),
+			'failure_stage'     => $failure_stage,
+			'retryable'         => false,
+		)
+	);
+}
+
+/**
+ * Remove all term references while the canonical binding lock is held.
+ *
+ * @param int $profile_id Post ID being deleted.
+ * @return true|WP_Error True when every valid inverse claim is absent.
+ */
+function ec_delete_artist_profile_term_binding_locked( $profile_id ) {
+	if ( empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+		return new WP_Error( 'artist_binding_lock_required', __( 'Canonical artist binding must be locked before it is changed.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
+	}
+	$blog_ids = ec_artist_binding_blog_ids();
+	if ( empty( $blog_ids ) || get_current_blog_id() !== $blog_ids['artist'] ) {
+		return new WP_Error( 'artist_binding_delete_context_invalid', __( 'Canonical artist binding deletion is unavailable in this site context.', 'extrachill-artist-platform' ), array( 'retryable' => false ) );
 	}
 
 	$profile = ec_artist_binding_read_profile( (int) $profile_id, $blog_ids['artist'] );
 	if ( empty( $profile ) ) {
-		return;
+		return new WP_Error(
+			'artist_binding_delete_profile_unavailable',
+			__( 'The artist profile could not be read before deletion.', 'extrachill-artist-platform' ),
+			array(
+				'profile_id' => (int) $profile_id,
+				'retryable'  => true,
+			)
+		);
 	}
 
+	$failure = null;
+	$journal = array();
 	switch_to_blog( $blog_ids['main'] );
 	try {
 		$batch_size        = 100;
@@ -653,17 +1306,36 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 					),
 				)
 			);
-			if ( is_wp_error( $term_ids ) || empty( $term_ids ) ) {
+			if ( is_wp_error( $term_ids ) ) {
+				$failure = new WP_Error(
+					'artist_binding_delete_query_failed',
+					__( 'Canonical artist inverse references could not be read before deletion.', 'extrachill-artist-platform' ),
+					array(
+						'profile_id' => (int) $profile_id,
+						'retryable'  => true,
+					)
+				);
+				break;
+			}
+			if ( empty( $term_ids ) ) {
 				break;
 			}
 
 			$deleted = false;
 			foreach ( $term_ids as $term_id ) {
-				$stored_values = get_term_meta( (int) $term_id, '_artist_profile_id', false );
+				ec_artist_binding_invalidate_term_cache( (int) $term_id, $blog_ids['main'] );
+				$stored_values    = get_term_meta( (int) $term_id, '_artist_profile_id', false );
+				$processed_values = array();
 				foreach ( $stored_values as $stored_value ) {
 					if ( ! is_int( $stored_value ) && ! is_string( $stored_value ) ) {
 						continue;
 					}
+					$value_key = gettype( $stored_value ) . ':' . serialize( $stored_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- Exact scalar type identity avoids duplicate compensation records.
+					if ( isset( $processed_values[ $value_key ] ) ) {
+						continue;
+					}
+					$processed_values[ $value_key ] = true;
+
 					$stored_value_string = (string) $stored_value;
 					if ( 1 !== preg_match( '/^\+?\d+$/D', $stored_value_string ) ) {
 						continue;
@@ -671,9 +1343,65 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 					$normalized_value = ltrim( ltrim( $stored_value_string, '+' ), '0' );
 					$normalized_value = '' === $normalized_value ? '0' : $normalized_value;
 					if ( $normalized_value === $profile_id_string ) {
-						$deleted = delete_term_meta( (int) $term_id, '_artist_profile_id', $stored_value ) || $deleted;
+						$before_count  = count(
+							array_filter(
+								$stored_values,
+								static function ( $value ) use ( $stored_value ) {
+									return $value === $stored_value;
+								}
+							)
+						);
+						$delete_result = delete_term_meta( (int) $term_id, '_artist_profile_id', $stored_value );
+						ec_artist_binding_invalidate_term_cache( (int) $term_id, $blog_ids['main'] );
+						$remaining     = get_term_meta( (int) $term_id, '_artist_profile_id', false );
+						$after_count   = count(
+							array_filter(
+								$remaining,
+								static function ( $value ) use ( $stored_value ) {
+									return $value === $stored_value;
+								}
+							)
+						);
+						$removed_count = max( 0, $before_count - $after_count );
+						if ( $removed_count > 0 ) {
+							$journal[] = array(
+								'term_id'        => (int) $term_id,
+								'values'         => array_fill( 0, $removed_count, $stored_value ),
+								'expected_after' => $remaining,
+							);
+						}
+						if ( ! $delete_result && in_array( $stored_value, $remaining, true ) ) {
+							$failure = new WP_Error(
+								'artist_binding_delete_inverse_failed',
+								__( 'A canonical artist inverse reference could not be removed.', 'extrachill-artist-platform' ),
+								array(
+									'profile_id' => (int) $profile_id,
+									'term_id'    => (int) $term_id,
+									'retryable'  => false,
+								)
+							);
+							break 2;
+						}
+						foreach ( $remaining as $remaining_value ) {
+							if ( ( is_int( $remaining_value ) || is_string( $remaining_value ) ) && (string) $remaining_value === $stored_value_string ) {
+								$failure = new WP_Error(
+									'artist_binding_delete_inverse_remaining',
+									__( 'A canonical artist inverse reference remained after deletion.', 'extrachill-artist-platform' ),
+									array(
+										'profile_id' => (int) $profile_id,
+										'term_id'    => (int) $term_id,
+										'retryable'  => false,
+									)
+								);
+								break 3;
+							}
+						}
+						$deleted = $removed_count > 0 || $deleted;
 					}
 				}
+			}
+			if ( $failure instanceof WP_Error ) {
+				break;
 			}
 
 			if ( ! $deleted ) {
@@ -683,8 +1411,13 @@ function ec_delete_artist_profile_term_binding( $profile_id ) {
 	} finally {
 		restore_current_blog();
 	}
+	if ( $failure instanceof WP_Error && ! empty( $journal ) ) {
+		return ec_compensate_artist_binding_delete_cleanup( $journal, $blog_ids['main'], $failure );
+	}
+	return $failure instanceof WP_Error ? $failure : true;
 }
-add_action( 'before_delete_post', 'ec_delete_artist_profile_term_binding', 10, 1 );
+add_filter( 'pre_delete_post', 'ec_artist_binding_pre_delete_post', PHP_INT_MAX, 3 );
+add_action( 'after_delete_post', 'ec_artist_binding_after_delete_post', PHP_INT_MAX, 2 );
 
 // Main-site term deletion is owned by the network-active runtime; see
 // Extra-Chill/extrachill-network#143. Resolvers remain fail-closed meanwhile.

--- a/phpunit-binding-mysql.xml.dist
+++ b/phpunit-binding-mysql.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/MySQLIntegration/bootstrap.php" colors="true">
+	<testsuites>
+		<testsuite name="Artist binding MySQL concurrency">
+			<directory suffix="Proof.php">tests/MySQLIntegration</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/ArtistMembershipContractTest.php
+++ b/tests/ArtistMembershipContractTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 final class ArtistMembershipContractTest extends TestCase {
 	protected function setUp(): void {
 		unset( $GLOBALS['ec_artist_membership_locks'] );
+		unset( $GLOBALS['ec_artist_binding_lock'], $GLOBALS['ec_artist_binding_lock_pending'], $GLOBALS['ec_artist_binding_delete_locks'], $GLOBALS['ec_artist_binding_deferred_locks'], $GLOBALS['ec_artist_binding_release_failure'] );
 		$GLOBALS['wpdb'] = new EcTestWpdb();
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 1,

--- a/tests/ArtistTermBindingTest.php
+++ b/tests/ArtistTermBindingTest.php
@@ -4,6 +4,8 @@ use PHPUnit\Framework\TestCase;
 
 final class ArtistTermBindingTest extends TestCase {
 	protected function setUp(): void {
+		unset( $GLOBALS['ec_artist_binding_lock'], $GLOBALS['ec_artist_binding_lock_pending'], $GLOBALS['ec_artist_binding_delete_locks'], $GLOBALS['ec_artist_binding_deferred_locks'], $GLOBALS['ec_artist_binding_release_failure'] );
+		$GLOBALS['wpdb'] = new EcTestWpdb();
 		$GLOBALS['ec_test'] = array(
 			'current_blog_id' => 4,
 			'blog_stack'      => array(),
@@ -119,6 +121,169 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
 
+	public function test_create_uses_and_releases_the_canonical_lock(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+
+		$this->assertTrue( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertSame( array( 'ec_artist_binding_v1' ), $GLOBALS['ec_test']['db_lock_order'] );
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+	}
+
+	public function test_boundary_probe_restores_existing_error_suppression(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['wpdb']->suppress_errors = true;
+
+		$this->assertTrue( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertTrue( $GLOBALS['wpdb']->suppress_errors );
+	}
+
+	public function test_sync_holds_one_lock_across_term_creation_and_binding(): void {
+		$this->addProfile( 12, 'the-band' );
+
+		$this->assertSame( 1, ec_sync_artist_profile_term_binding( 12 ) );
+		$this->assertSame( array( 'ec_artist_binding_v1' ), $GLOBALS['ec_test']['db_lock_order'] );
+		$this->assertSame( 1, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][1]['_artist_profile_id'] );
+	}
+
+	public function test_writer_rejects_a_caller_owned_transaction_without_locking(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['ec_test']['in_transaction'] = true;
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertSame( 'artist_binding_nested_transaction', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( array( 'ec_artist_binding_v1' ), $GLOBALS['ec_test']['db_lock_order'] );
+		$this->assertSame( array( true, false ), $GLOBALS['ec_test']['error_suppression'] );
+		$this->assertArrayHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+		$this->assertArrayNotHasKey( '_artist_term_id', $GLOBALS['ec_test']['blogs'][4]['post_meta'][12] ?? array() );
+		$GLOBALS['ec_test']['in_transaction'] = false;
+		ec_artist_binding_release_deferred_locks();
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+	}
+
+	public function test_release_failure_fails_closed_and_retains_lock_tracking(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['ec_test']['advisory_release_result'] = 'error';
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertSame( 'artist_binding_release_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( 'ec_artist_binding_v1', $GLOBALS['ec_artist_binding_lock'] );
+	}
+
+	public function test_locked_read_is_the_consumer_revalidation_contract(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->assertSame( 'artist_binding_lock_required', ec_read_locked_artist_binding( 12, 101 )->get_error_code() );
+
+		$lock = ec_acquire_artist_binding_lock();
+		$GLOBALS['ec_test']['in_transaction'] = true;
+		$this->assertSame( array( 'profile_id' => 12, 'term_id' => 101 ), ec_read_locked_artist_binding( 12, 101 ) );
+		$this->assertContains( array( 4, 12 ), $GLOBALS['ec_test']['clean_post_cache_calls'] );
+		$this->assertContains( array( 1, 101, 'artist' ), $GLOBALS['ec_test']['clean_term_cache_calls'] );
+		$this->assertSame( 'artist_binding_release_transaction_active', ec_release_artist_binding_lock( $lock )->get_error_code() );
+		$GLOBALS['ec_test']['in_transaction'] = false;
+		$this->assertTrue( ec_release_artist_binding_lock( $lock ) );
+	}
+
+	public function test_consumer_cannot_acquire_binding_lock_after_starting_transaction(): void {
+		$GLOBALS['ec_test']['in_transaction'] = true;
+
+		$result = ec_acquire_artist_binding_lock();
+		$this->assertSame( 'artist_binding_nested_transaction', $result->get_error_code() );
+		$this->assertArrayHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+		$GLOBALS['ec_test']['in_transaction'] = false;
+		ec_artist_binding_release_deferred_locks();
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+	}
+
+	public function test_resolver_revalidates_after_waiting_and_never_undoes_the_winner(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$this->addTerm( 102, 'winning-band' );
+		$GLOBALS['ec_test']['after_external_artist_lock'] = static function () {
+			$GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id']      = 102;
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] = 12;
+		};
+
+		$this->assertFalse( ec_reconcile_artist_profile_term_pair( 12, 101 ) );
+		$this->assertSame( 102, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
+		$this->assertArrayNotHasKey( 101, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
+	public function test_concurrent_rebind_has_one_winner(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'old-name', 12 );
+		$this->addTerm( 102, 'first-name' );
+		$this->addTerm( 103, 'second-name' );
+		$GLOBALS['ec_test']['after_external_artist_lock'] = static function () {
+			$GLOBALS['ec_test']['competing_rebind'] = ec_bind_artist_profile_to_term( 12, 103 );
+		};
+
+		$this->assertTrue( ec_bind_artist_profile_to_term( 12, 102 ) );
+		$this->assertFalse( $GLOBALS['ec_test']['competing_rebind'] );
+		$this->assertSame( 102, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
+		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+		$this->assertArrayNotHasKey( 103, $GLOBALS['ec_test']['blogs'][1]['term_meta'] );
+	}
+
+	public function test_consumer_acquires_binding_before_distinct_membership_lock(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$binding_lock = ec_acquire_artist_binding_lock();
+		$this->assertSame( array( 'profile_id' => 12, 'term_id' => 101 ), ec_read_locked_artist_binding( 12, 101 ) );
+		$this->assertTrue( ec_acquire_artist_membership_lock( 7, 12 ) );
+
+		$this->assertSame( array( 'ec_artist_binding_v1', 'ec_artist_membership_7_12' ), $GLOBALS['ec_test']['db_lock_order'] );
+		ec_release_artist_membership_lock( 7, 12 );
+		$this->assertTrue( ec_release_artist_binding_lock( $binding_lock ) );
+	}
+
+	public function test_unsupported_database_fails_closed_without_raw_database_errors(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['wpdb'] = new EcTestSqliteWpdb();
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertSame( 'artist_binding_lock_unsupported', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( array( 'retryable' => true ), ec_get_artist_binding_failure()->get_error_data() );
+	}
+
+	public function test_primary_boundary_failure_survives_release_failure(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['ec_test']['in_transaction']          = true;
+		$GLOBALS['ec_test']['advisory_release_result'] = 'error';
+
+		$this->assertFalse( ec_bind_artist_profile_to_term( 12, 101 ) );
+		$this->assertSame( 'artist_binding_nested_transaction', ec_get_artist_binding_failure()->get_error_code() );
+		$GLOBALS['ec_test']['in_transaction'] = false;
+		ec_artist_binding_release_deferred_locks();
+		$this->assertSame( 'artist_binding_release_failed', ec_get_artist_binding_release_failure()->get_error_code() );
+	}
+
+	public function test_throwable_releases_the_binding_lock(): void {
+		$this->addProfile( 12, 'the-band' );
+		$this->addTerm( 101, 'the-band' );
+		$GLOBALS['ec_test']['after_post_meta_update'] = static function () {
+			throw new RuntimeException( 'Injected writer failure.' );
+		};
+
+		try {
+			ec_bind_artist_profile_to_term( 12, 101 );
+			$this->fail( 'Expected injected writer failure.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Injected writer failure.', $exception->getMessage() );
+		}
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+		$this->assertArrayNotHasKey( 'ec_artist_binding_lock', $GLOBALS );
+	}
+
 	public function test_failed_rebinding_restores_the_previous_reciprocal_pair(): void {
 		$this->addProfile( 12, 'the-band', 101 );
 		$this->addTerm( 101, 'old-name', 12 );
@@ -180,7 +345,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->assertSame( 'artist_binding_compensation_failed', ec_get_artist_binding_failure()->get_error_code() );
 		$this->assertFalse( ec_get_artist_binding_failure()->get_error_data()['retryable'] );
 		$this->assertSame( 102, $GLOBALS['ec_test']['blogs'][4]['post_meta'][12]['_artist_term_id'] );
-		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 	}
 
 	public function test_sync_propagates_resolver_compensation_failure_without_cleanup(): void {
@@ -202,7 +367,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addTerm( 101, 'the-band', 12 );
 		$GLOBALS['ec_test']['current_blog_id'] = 1;
 
-		ec_delete_artist_profile_term_binding( 12 );
+		$this->assertNull( ec_artist_binding_pre_delete_post( null, $GLOBALS['ec_test']['blogs'][4]['posts'][12], true ) );
 
 		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 	}
@@ -212,16 +377,146 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addTerm( 101, 'the-band', 12 );
 		$this->addTerm( 102, 'stale-band', 12 );
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
+		$this->assertSame( array( 'ec_artist_binding_v1' ), $GLOBALS['ec_test']['db_lock_order'] );
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][102] );
+	}
+
+	public function test_delete_holds_binding_lock_until_core_finishes(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'replacement' );
+		$GLOBALS['ec_test']['before_post_delete'] = static function () {
+			$GLOBALS['ec_test']['delete_competing_bind'] = ec_bind_artist_profile_to_term( 12, 102 );
+			$GLOBALS['ec_test']['delete_lock_held']      = isset( $GLOBALS['ec_test']['db_locks']['ec_artist_binding_v1'] );
+		};
+
+		$this->assertNotFalse( wp_delete_post( 12, true ) );
+		$this->assertFalse( $GLOBALS['ec_test']['delete_competing_bind'] );
+		$this->assertTrue( $GLOBALS['ec_test']['delete_lock_held'] );
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+	}
+
+	public function test_failed_core_delete_retains_lock_until_shutdown_cleanup(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['fail_post_delete'] = true;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertArrayHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+		ec_artist_binding_release_delete_locks();
+		$this->assertArrayNotHasKey( 'ec_artist_binding_v1', $GLOBALS['ec_test']['db_locks'] );
+	}
+
+	public function test_delete_vetoes_when_inverse_query_fails(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['fail_get_terms'] = true;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertSame( 'artist_binding_delete_query_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertArrayHasKey( 12, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+	}
+
+	public function test_delete_vetoes_when_inverse_delete_fails(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['fail_term_meta_delete_keys']['_artist_profile_id'] = 1;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertSame( 'artist_binding_delete_inverse_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertArrayHasKey( 12, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+	}
+
+	public function test_delete_vetoes_when_inverse_claim_remains_after_reported_success(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['term_meta_delete_reports_success_without_delete'] = true;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertSame( 'artist_binding_delete_inverse_remaining', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertArrayHasKey( 12, $GLOBALS['ec_test']['blogs'][4]['posts'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+	}
+
+	public function test_delete_compensates_a_successful_removal_before_later_query_failure(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['fail_get_terms_on_call'] = 2;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertSame( 'artist_binding_delete_query_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+		$this->assertSame( 1, $GLOBALS['ec_test']['term_meta_add_calls']['_artist_profile_id'] );
+	}
+
+	public function test_delete_compensates_earlier_removals_when_later_delete_fails(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'stale-band', 12 );
+		$GLOBALS['ec_test']['fail_term_meta_delete_on_call']['_artist_profile_id'] = 2;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$this->assertSame( 'artist_binding_delete_inverse_failed', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
+		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
+	}
+
+	public function test_delete_reports_nonretryable_compensation_write_failure(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'stale-band', 12 );
+		$GLOBALS['ec_test']['fail_term_meta_delete_on_call']['_artist_profile_id'] = 2;
+		$GLOBALS['ec_test']['fail_term_meta_add_keys']['_artist_profile_id']       = 3;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$failure = ec_get_artist_binding_failure();
+		$this->assertSame( 'artist_binding_delete_compensation_failed', $failure->get_error_code() );
+		$this->assertSame( 'artist_binding_delete_inverse_failed', $failure->get_error_data()['primary_code'] );
+		$this->assertSame( array( 101 ), $failure->get_error_data()['affected_term_ids'] );
+		$this->assertSame( 'write', $failure->get_error_data()['failure_stage'] );
+		$this->assertFalse( $failure->get_error_data()['retryable'] );
+	}
+
+	public function test_delete_reports_nonretryable_compensation_verification_failure(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$this->addTerm( 102, 'stale-band', 12 );
+		$GLOBALS['ec_test']['fail_term_meta_delete_on_call']['_artist_profile_id'] = 2;
+		$GLOBALS['ec_test']['term_meta_add_reports_success_without_add']           = true;
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$failure = ec_get_artist_binding_failure();
+		$this->assertSame( 'artist_binding_delete_compensation_failed', $failure->get_error_code() );
+		$this->assertSame( 'artist_binding_delete_inverse_failed', $failure->get_error_data()['primary_code'] );
+		$this->assertSame( array( 101 ), $failure->get_error_data()['affected_term_ids'] );
+		$this->assertSame( 'verification', $failure->get_error_data()['failure_stage'] );
+		$this->assertFalse( $failure->get_error_data()['retryable'] );
+	}
+
+	public function test_delete_compensation_never_overwrites_changed_term_state(): void {
+		$this->addProfile( 12, 'the-band', 101 );
+		$this->addTerm( 101, 'the-band', 12 );
+		$GLOBALS['ec_test']['fail_get_terms_on_call'] = 2;
+		$GLOBALS['ec_test']['before_get_terms_failure'] = static function () {
+			$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = 99;
+		};
+
+		$this->assertFalse( wp_delete_post( 12, true ) );
+		$failure = ec_get_artist_binding_failure();
+		$this->assertSame( 'artist_binding_delete_compensation_failed', $failure->get_error_code() );
+		$this->assertSame( 'state_changed', $failure->get_error_data()['failure_stage'] );
+		$this->assertSame( 99, $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 	}
 
 	public function test_profile_deletion_cleans_term_references_without_profile_metadata(): void {
 		$this->addProfile( 12, 'the-band' );
 		$this->addTerm( 101, 'stale-band', 12 );
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
@@ -231,7 +526,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addTerm( 101, 'stale-band', 12 );
 		$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = '012';
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 	}
@@ -246,7 +541,7 @@ final class ArtistTermBindingTest extends TestCase {
 			$this->addTerm( $term_id, 'stale-band-' . $term_id, 12 );
 		}
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1000]['_artist_profile_id'] );
 		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][1099]['_artist_profile_id'] );
@@ -272,7 +567,7 @@ final class ArtistTermBindingTest extends TestCase {
 			'9007199254740992',
 		);
 
-		ec_delete_artist_profile_term_binding( $profile_id );
+		wp_delete_post( $profile_id, true );
 
 		$this->assertSame(
 			array( '9007199254740992' ),
@@ -288,7 +583,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] = '12broken';
 		$GLOBALS['ec_test']['blogs'][1]['term_meta'][103]['_artist_profile_id'] = '12.5';
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertSame( '12broken', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101]['_artist_profile_id'] );
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][102] );
@@ -303,7 +598,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addTerm( 102, 'genre-term', 12, 'genre' );
 		$this->addTerm( 103, 'other-band', 13 );
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 		$this->assertSame( 12, $GLOBALS['ec_test']['blogs'][1]['term_meta'][102]['_artist_profile_id'] );
@@ -322,7 +617,7 @@ final class ArtistTermBindingTest extends TestCase {
 		);
 		$GLOBALS['ec_test']['blogs'][1]['post_meta'][12]['_artist_profile_id'] = 'unchanged';
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertArrayNotHasKey( '_artist_profile_id', $GLOBALS['ec_test']['blogs'][1]['term_meta'][101] );
 		$this->assertSame( 'unchanged', $GLOBALS['ec_test']['blogs'][1]['post_meta'][12]['_artist_profile_id'] );
@@ -332,7 +627,7 @@ final class ArtistTermBindingTest extends TestCase {
 		$this->addProfile( 12, 'the-band' );
 		$this->addTerm( 101, 'the-band', 12 );
 
-		ec_delete_artist_profile_term_binding( 12 );
+		wp_delete_post( 12, true );
 
 		$this->assertSame( 4, $GLOBALS['ec_test']['current_blog_id'] );
 		$this->assertSame( array(), $GLOBALS['ec_test']['blog_stack'] );

--- a/tests/MySQLIntegration/ArtistBindingProductionMySQLProof.php
+++ b/tests/MySQLIntegration/ArtistBindingProductionMySQLProof.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Production WordPress two-session MySQL proof for artist bindings.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/** Exercises production binding functions, metadata, caches, and delete hooks. */
+final class ArtistBindingProductionMySQLProof extends TestCase {
+	/** @var mysqli Independent advisory-lock contender. */
+	private $contender;
+
+	/** @var int Disposable artist profile ID. */
+	private $profile_id = 0;
+
+	/** @var int[] Disposable canonical term IDs. */
+	private $term_ids = array();
+
+	protected function setUp(): void {
+		global $wpdb;
+		// phpcs:disable WordPress.DB.RestrictedFunctions.mysql_mysqli_report,WordPress.DB.RestrictedFunctions.mysql_mysqli_init,WordPress.DB.RestrictedFunctions.mysql_mysqli_real_connect,WordPress.DB.RestrictedFunctions.mysql_mysqli_connect_error -- Independent contention is required.
+		mysqli_report( MYSQLI_REPORT_OFF );
+		$this->contender  = mysqli_init();
+		$connected        = mysqli_real_connect( $this->contender, DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
+		$connection_error = mysqli_connect_error();
+		// phpcs:enable WordPress.DB.RestrictedFunctions.mysql_mysqli_report,WordPress.DB.RestrictedFunctions.mysql_mysqli_init,WordPress.DB.RestrictedFunctions.mysql_mysqli_real_connect,WordPress.DB.RestrictedFunctions.mysql_mysqli_connect_error
+		$this->assertTrue( $connected, $connection_error ? $connection_error : 'MySQL connection failed.' );
+		$version         = $this->contender->query( 'SELECT VERSION()' )->fetch_row()[0];
+		$version_pattern = getenv( 'MYSQL_EXPECT_VERSION_PATTERN' );
+		$version_pattern = $version_pattern ? $version_pattern : '/^8\.4\./';
+		$this->assertMatchesRegularExpression( $version_pattern, $version, 'Unexpected integration database version.' );
+		$this->assertSame( '', (string) $wpdb->last_error );
+
+		switch_to_blog( 4 );
+		$this->profile_id = wp_insert_post(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+				'post_title'  => 'Binding Proof ' . wp_generate_uuid4(),
+				'post_name'   => 'binding-proof-' . wp_generate_uuid4(),
+			),
+			true
+		);
+		restore_current_blog();
+		$this->assertIsInt( $this->profile_id );
+		$this->term_ids = array( $this->createTerm(), $this->createTerm(), $this->createTerm() );
+	}
+
+	protected function tearDown(): void {
+		if ( ! empty( $GLOBALS['ec_artist_binding_lock'] ) ) {
+			global $wpdb;
+			$wpdb->query( 'ROLLBACK' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+			ec_release_artist_binding_lock( $GLOBALS['ec_artist_binding_lock'] );
+		}
+		if ( $this->profile_id > 0 ) {
+			switch_to_blog( 4 );
+			wp_delete_post( $this->profile_id, true );
+			restore_current_blog();
+		}
+		switch_to_blog( 1 );
+		foreach ( $this->term_ids as $term_id ) {
+			wp_delete_term( $term_id, 'artist' );
+		}
+		restore_current_blog();
+		if ( $this->contender instanceof mysqli ) {
+			$this->contender->close();
+		}
+	}
+
+	public function test_production_protocol_serializes_all_boundaries(): void {
+		global $wpdb;
+		list( $first_term, $second_term, $third_term ) = $this->term_ids;
+
+		// Two actual writers serialize; exactly one reciprocal final winner remains.
+		$first         = $this->startWorker( $first_term );
+		$second        = $this->startWorker( $second_term );
+		$first_result  = $this->finishWorker( $first );
+		$second_result = $this->finishWorker( $second );
+		$this->assertTrue( $first_result['result'] );
+		$this->assertTrue( $second_result['result'] );
+		$winner = ec_get_artist_term_id( $this->profile_id );
+		$this->assertContains( $winner, array( $first_term, $second_term ) );
+		$this->assertSame( $this->profile_id, ec_get_artist_profile_id( $winner ) );
+		$loser = $winner === $first_term ? $second_term : $first_term;
+		$this->assertSame( 0, ec_get_artist_profile_id( $loser ) );
+
+		// A consumer starts its transaction only after acquiring the global lock.
+		$lock = ec_acquire_artist_binding_lock();
+		$this->assertIsString( $lock );
+		$this->assertNotFalse( $wpdb->query( 'START TRANSACTION' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Production consumer ordering proof.
+		$this->assertSame(
+			array(
+				'profile_id' => $this->profile_id,
+				'term_id'    => $winner,
+			),
+			ec_read_locked_artist_binding( $this->profile_id, $winner )
+		);
+		$worker = $this->startWorker( $third_term );
+		$this->assertSame( 'artist_binding_release_transaction_active', ec_release_artist_binding_lock( $lock )->get_error_code() );
+		$this->assertNotFalse( $wpdb->query( 'COMMIT' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Subordinate transaction must finish first.
+		$this->assertTrue( ec_release_artist_binding_lock( $lock ) );
+		$this->assertTrue( $this->finishWorker( $worker )['result'] );
+		$this->assertSame( $third_term, ec_get_artist_term_id( $this->profile_id ) );
+
+		// A real contender forces the production timeout path, then release permits entry.
+		$this->assertSame( 1, $this->contenderLock( 1 ) );
+		$this->assertFalse( ec_bind_artist_profile_to_term( $this->profile_id, $first_term ) );
+		$this->assertSame( 'artist_binding_busy', ec_get_artist_binding_failure()->get_error_code() );
+		$this->assertSame( 1, $this->contenderRelease() );
+		$this->assertTrue( ec_bind_artist_profile_to_term( $this->profile_id, $first_term ) );
+
+		// Core deletion retains the production lock while a real writer waits.
+		$delete_worker = null;
+		add_action(
+			'before_delete_post',
+			function ( $post_id ) use ( &$delete_worker, $second_term ) {
+				if ( $post_id === $this->profile_id ) {
+					$delete_worker = $this->startWorker( $second_term );
+				}
+			},
+			PHP_INT_MAX,
+			1
+		);
+		switch_to_blog( 4 );
+		$this->assertNotFalse( wp_delete_post( $this->profile_id, true ) );
+		restore_current_blog();
+		$this->profile_id = 0;
+		$this->assertIsArray( $delete_worker );
+		$this->assertFalse( $this->finishWorker( $delete_worker )['result'] );
+
+		// Acquisition from an existing transaction is rejected and deferred safely.
+		$this->profile_id = $this->createProfile();
+		$this->assertNotFalse( $wpdb->query( 'START TRANSACTION' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Boundary rejection proof.
+		$rejected = ec_acquire_artist_binding_lock();
+		$this->assertSame( 'artist_binding_nested_transaction', $rejected->get_error_code() );
+		$this->assertNotFalse( $wpdb->query( 'ROLLBACK' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- End caller transaction before deferred release.
+		ec_artist_binding_release_deferred_locks();
+		$this->assertEmpty( $GLOBALS['ec_artist_binding_lock'] ?? null );
+	}
+
+	private function createProfile(): int {
+		switch_to_blog( 4 );
+		$profile_id = wp_insert_post(
+			array(
+				'post_type'   => 'artist_profile',
+				'post_status' => 'publish',
+				'post_title'  => 'Boundary Proof ' . wp_generate_uuid4(),
+			),
+			true
+		);
+		restore_current_blog();
+		$this->assertIsInt( $profile_id );
+		return $profile_id;
+	}
+
+	private function createTerm(): int {
+		switch_to_blog( 1 );
+		$inserted = wp_insert_term( 'Binding Proof ' . wp_generate_uuid4(), 'artist' );
+		restore_current_blog();
+		$this->assertIsArray( $inserted );
+		return (int) $inserted['term_id'];
+	}
+
+	private function startWorker( int $term_id ): array {
+		$marker = tempnam( sys_get_temp_dir(), 'ec-binding-' );
+		unlink( $marker );
+		$command = array( PHP_BINARY, __DIR__ . '/artist-binding-worker.php', 'bind', (string) $this->profile_id, (string) $term_id, $marker );
+		$pipes   = array();
+		$process = proc_open(
+			$command,
+			array(
+				1 => array( 'pipe', 'w' ),
+				2 => array( 'pipe', 'w' ),
+			),
+			$pipes
+		);
+		$this->assertIsResource( $process );
+		$deadline = microtime( true ) + 5;
+		while ( ! file_exists( $marker ) && microtime( true ) < $deadline ) {
+			usleep( 10000 );
+		}
+		$this->assertFileExists( $marker );
+		unlink( $marker );
+		return array( $process, $pipes );
+	}
+
+	private function finishWorker( array $worker ): array {
+		list( $process, $pipes ) = $worker;
+
+		$stdout = stream_get_contents( $pipes[1] );
+		$stderr = stream_get_contents( $pipes[2] );
+		fclose( $pipes[1] );
+		fclose( $pipes[2] );
+		$status  = proc_close( $process );
+		$result  = json_decode( $stdout, true );
+		$message = $stderr ? $stderr : $stdout;
+		$this->assertIsArray( $result, $message );
+		$this->assertContains( $status, array( 0, 1 ), $stderr );
+		return $result;
+	}
+
+	private function contenderLock( int $timeout ): int {
+		$name      = 'ec_artist_binding_v1';
+		$statement = $this->contender->prepare( 'SELECT GET_LOCK(?, ?)' );
+		$statement->bind_param( 'si', $name, $timeout );
+		$statement->execute();
+		return (int) $statement->get_result()->fetch_row()[0];
+	}
+
+	private function contenderRelease(): int {
+		$name      = 'ec_artist_binding_v1';
+		$statement = $this->contender->prepare( 'SELECT RELEASE_LOCK(?)' );
+		$statement->bind_param( 's', $name );
+		$statement->execute();
+		return (int) $statement->get_result()->fetch_row()[0];
+	}
+}

--- a/tests/MySQLIntegration/artist-binding-worker.php
+++ b/tests/MySQLIntegration/artist-binding-worker.php
@@ -1,0 +1,27 @@
+<?php
+/** Execute one production binding operation in an independent process. */
+
+require_once __DIR__ . '/bootstrap.php';
+
+$action     = $argv[1] ?? '';
+$profile_id = (int) ( $argv[2] ?? 0 );
+$term_id    = (int) ( $argv[3] ?? 0 );
+$marker     = $argv[4] ?? '';
+if ( '' !== $marker ) {
+	file_put_contents( $marker, 'ready' );
+}
+
+if ( 'bind' !== $action ) {
+	fwrite( STDERR, 'Unsupported worker action.' );
+	exit( 2 );
+}
+
+$result = ec_bind_artist_profile_to_term( $profile_id, $term_id );
+$error  = ec_get_artist_binding_failure();
+echo wp_json_encode(
+	array(
+		'result' => $result,
+		'error'  => $error instanceof WP_Error ? $error->get_error_code() : null,
+	)
+);
+exit( $result ? 0 : 1 );

--- a/tests/MySQLIntegration/bootstrap.php
+++ b/tests/MySQLIntegration/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+/** Bootstrap real WordPress multisite for binding integration tests. */
+
+$wordpress_path = getenv( 'WP_INTEGRATION_PATH' );
+if ( ! is_string( $wordpress_path ) || '' === $wordpress_path || ! file_exists( $wordpress_path . '/wp-load.php' ) ) {
+	throw new RuntimeException( 'WP_INTEGRATION_PATH must reference an installed WordPress multisite.' );
+}
+
+require_once $wordpress_path . '/wp-load.php';
+
+if ( ! is_multisite() ) {
+	throw new RuntimeException( 'Artist binding integration requires WordPress multisite.' );
+}
+
+if ( ! function_exists( 'ec_get_blog_id' ) ) {
+	function ec_get_blog_id( $site ) {
+		return 'main' === $site ? 1 : ( 'artist' === $site ? 4 : 0 );
+	}
+}
+
+switch_to_blog( 1 );
+register_taxonomy( 'artist', 'post', array( 'public' => true ) );
+restore_current_blog();
+switch_to_blog( 4 );
+register_post_type( 'artist_profile', array( 'public' => true ) );
+restore_current_blog();
+
+$binding_source = getenv( 'ARTIST_BINDING_SOURCE' );
+if ( ! is_string( $binding_source ) || ! file_exists( $binding_source ) ) {
+	throw new RuntimeException( 'ARTIST_BINDING_SOURCE must reference the production binding file.' );
+}
+require_once $binding_source;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,6 +42,7 @@ class WP_Term {
 class EcTestWpdb {
 	public $last_error = '';
 	public $options    = 'wp_options';
+	public $suppress_errors = false;
 
 	public function prepare( $query, ...$args ) {
 		return array( 'query' => $query, 'args' => $args );
@@ -52,6 +53,7 @@ class EcTestWpdb {
 		$query = $prepared['query'];
 		$name  = (string) ( $prepared['args'][0] ?? '' );
 		if ( str_contains( $query, 'GET_LOCK' ) ) {
+			$GLOBALS['ec_test']['db_lock_order'][] = $name;
 			$GLOBALS['ec_test']['db_lock_get_calls'][ $name ] = ( $GLOBALS['ec_test']['db_lock_get_calls'][ $name ] ?? 0 ) + 1;
 			if ( 'contention' === ( $GLOBALS['ec_test']['advisory_lock_result'] ?? '' ) ) {
 				return '0';
@@ -86,6 +88,17 @@ class EcTestWpdb {
 
 	public function query( $prepared ) {
 		$this->last_error = '';
+		if ( is_string( $prepared ) ) {
+			$GLOBALS['ec_test']['raw_queries'][] = $prepared;
+			if ( str_starts_with( $prepared, 'SET TRANSACTION ISOLATION LEVEL' ) ) {
+				if ( ! empty( $GLOBALS['ec_test']['in_transaction'] ) || ! empty( $GLOBALS['ec_test']['boundary_query_error'] ) ) {
+					$this->last_error = 'Transaction characteristics cannot be changed.';
+					return false;
+				}
+				return 0;
+			}
+			return false;
+		}
 		if ( ! empty( $GLOBALS['ec_test']['fallback_lock_query_error'] ) ) {
 			$this->last_error = 'Network lock query failed.';
 			return false;
@@ -112,6 +125,13 @@ class EcTestWpdb {
 			return 1;
 		}
 		return false;
+	}
+
+	public function suppress_errors( $suppress = true ) {
+		$previous             = $this->suppress_errors;
+		$this->suppress_errors = (bool) $suppress;
+		$GLOBALS['ec_test']['error_suppression'][] = $this->suppress_errors;
+		return $previous;
 	}
 }
 
@@ -657,22 +677,41 @@ function wp_insert_post( $post_data, $return_error = false ) {
 }
 
 function wp_delete_post( $post_id, $force_delete = false ) {
-	if ( ! empty( $GLOBALS['ec_test']['fail_post_delete'] ) ) {
-		return false;
-	}
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
 	$post    = $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ] ?? null;
+	if ( $post && function_exists( 'ec_artist_binding_pre_delete_post' ) ) {
+		$check = ec_artist_binding_pre_delete_post( null, $post, $force_delete );
+		if ( null !== $check ) {
+			return $check;
+		}
+	}
 	if ( isset( $GLOBALS['ec_test']['before_post_delete'] ) ) {
 		$callback = $GLOBALS['ec_test']['before_post_delete'];
 		unset( $GLOBALS['ec_test']['before_post_delete'] );
 		$callback( $post_id, $post );
 	}
-	if ( $post && 'artist_profile' === $post->post_type && function_exists( 'ec_delete_artist_profile_term_binding' ) ) {
-		ec_delete_artist_profile_term_binding( $post_id );
+	if ( ! empty( $GLOBALS['ec_test']['fail_post_delete'] ) ) {
+		return false;
 	}
 	unset( $GLOBALS['ec_test']['blogs'][ $blog_id ]['posts'][ $post_id ], $GLOBALS['ec_test']['blogs'][ $blog_id ]['post_meta'][ $post_id ] );
 	$GLOBALS['ec_test']['deleted_posts'][] = $post_id;
+	if ( $post && function_exists( 'ec_artist_binding_after_delete_post' ) ) {
+		ec_artist_binding_after_delete_post( $post_id, $post );
+	}
 	return $post;
+}
+
+function clean_post_cache( $post_id ) {
+	$post_id = is_object( $post_id ) ? $post_id->ID : $post_id;
+	$GLOBALS['ec_test']['clean_post_cache_calls'][] = array( get_current_blog_id(), (int) $post_id );
+}
+
+function clean_term_cache( $term_id, $taxonomy = '' ) {
+	$GLOBALS['ec_test']['clean_term_cache_calls'][] = array( get_current_blog_id(), (int) $term_id, $taxonomy );
+}
+
+function clean_taxonomy_cache( $taxonomy ) {
+	$GLOBALS['ec_test']['clean_taxonomy_cache_calls'][] = array( get_current_blog_id(), $taxonomy );
 }
 
 function delete_post_meta( $post_id, $key, $value = '' ) {
@@ -728,6 +767,14 @@ function get_term_by( $field, $value, $taxonomy ) {
 
 function get_terms( $args = array() ) {
 	$GLOBALS['ec_test']['get_terms_calls'][] = $args;
+	if ( ! empty( $GLOBALS['ec_test']['fail_get_terms'] ) || (int) ( $GLOBALS['ec_test']['fail_get_terms_on_call'] ?? 0 ) === count( $GLOBALS['ec_test']['get_terms_calls'] ) ) {
+		if ( isset( $GLOBALS['ec_test']['before_get_terms_failure'] ) ) {
+			$callback = $GLOBALS['ec_test']['before_get_terms_failure'];
+			unset( $GLOBALS['ec_test']['before_get_terms_failure'] );
+			$callback();
+		}
+		return new WP_Error( 'term_query_failed', 'Term query failed.' );
+	}
 	$term_ids   = array();
 	$meta_query = $args['meta_query'][0] ?? array();
 	foreach ( ec_test_blog_store( 'terms' ) as $term_id => $term ) {
@@ -780,11 +827,42 @@ function update_term_meta( $term_id, $key, $value ) {
 	return true;
 }
 
+function add_term_meta( $term_id, $key, $value, $unique = false ) {
+	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	$GLOBALS['ec_test']['term_meta_add_calls'][ $key ] = ( $GLOBALS['ec_test']['term_meta_add_calls'][ $key ] ?? 0 ) + 1;
+	if ( ! empty( $GLOBALS['ec_test']['fail_term_meta_add_keys'][ $key ] ) ) {
+		--$GLOBALS['ec_test']['fail_term_meta_add_keys'][ $key ];
+		return false;
+	}
+	if ( ! empty( $GLOBALS['ec_test']['term_meta_add_reports_success_without_add'] ) ) {
+		return true;
+	}
+	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] ?? null;
+	if ( $unique && null !== $current ) {
+		return false;
+	}
+	if ( null === $current ) {
+		$GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] = $value;
+	} else {
+		$values = is_array( $current ) ? $current : array( $current );
+		$values[] = $value;
+		$GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] = $values;
+	}
+	return true;
+}
+
 function delete_term_meta( $term_id, $key, $value = '' ) {
 	$blog_id = $GLOBALS['ec_test']['current_blog_id'];
+	$GLOBALS['ec_test']['term_meta_delete_calls'][ $key ] = ( $GLOBALS['ec_test']['term_meta_delete_calls'][ $key ] ?? 0 ) + 1;
+	if ( (int) ( $GLOBALS['ec_test']['fail_term_meta_delete_on_call'][ $key ] ?? 0 ) === $GLOBALS['ec_test']['term_meta_delete_calls'][ $key ] ) {
+		return false;
+	}
 	if ( ! empty( $GLOBALS['ec_test']['fail_term_meta_delete_keys'][ $key ] ) ) {
 		--$GLOBALS['ec_test']['fail_term_meta_delete_keys'][ $key ];
 		return false;
+	}
+	if ( ! empty( $GLOBALS['ec_test']['term_meta_delete_reports_success_without_delete'] ) ) {
+		return true;
 	}
 	$current = $GLOBALS['ec_test']['blogs'][ $blog_id ]['term_meta'][ $term_id ][ $key ] ?? null;
 	if ( is_array( $current ) && '' !== $value ) {
@@ -920,7 +998,8 @@ function get_main_site_id() {
 	return 1;
 }
 
-function wp_cache_delete() {
+function wp_cache_delete( $key = '', $group = '' ) {
+	$GLOBALS['ec_test']['cache_delete_calls'][] = array( get_current_blog_id(), $key, $group );
 	return true;
 }
 


### PR DESCRIPTION
## Summary
- serialize every canonical artist profile/term create, rebind, delete, compensation, and locked consumer read behind one Artist Platform-owned protocol
- enforce binding-first ordering, cache-current reciprocal reads, portable transaction boundaries, deletion veto/compensation, and release-last semantics
- add a production WordPress multisite MySQL 8.4 concurrency gate using the real binding functions and hooks

## Testing
- full suite: `273 tests, 1,434 assertions`
- focused binding: `47 tests, 401 assertions`
- local production MariaDB integration: `1 test, 51 assertions`
- PHPCS, actionlint, syntax, XML, and diff checks

Closes #196