### PR TITLE
refactor: hand off Link Pages runtime ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Extra Chill Artist Platform
 
+## Link Pages runtime handoff
+
+This compatibility build supports a rolling extraction to the standalone
+`extrachill-link-pages` plugin without declaring a hard `Requires Plugins`
+dependency. Deploy this Artist Platform compatibility build first, then install
+and activate the standalone plugin. During that activation request the
+standalone plugin must tolerate the already-loaded fallback symbols; on the next
+request Artist Platform sees the active configuration and fully defers. Artist
+Platform reads WordPress's site and network active plugin configuration for
+`extrachill-link-pages/extrachill-link-pages.php`; when configured, it defers the
+`artist_link_page` CPT and bundled generic owner/operation APIs to that plugin.
+The standalone plugin must expose those APIs by `plugins_loaded` priority 20,
+after which Artist Platform registers its artist adapters. Without the
+standalone plugin, the bundled runtime and current behavior remain active.
+
 Artist profiles, link pages, and shop management for the Extra Chill network.
 
 ## What It Does

--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -17,9 +17,9 @@ define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_FILE', __FILE__ );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
 
 require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/platform-pages.php';
+require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/runtime-handoff.php';
 
 if ( ! defined( 'EXTRCH_LINKPAGE_DEV' ) ) {
     define( 'EXTRCH_LINKPAGE_DEV', false );
@@ -50,6 +50,7 @@ class ExtraChillArtistPlatform {
         add_action( 'init', 'extrachill_artist_platform_register_blocks' );
         add_action( 'init', array( $this, 'init' ), 15 );
         add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
+        add_action( 'plugins_loaded', 'extrachill_artist_platform_boot_link_pages_runtime', 20 );
         register_activation_hook( __FILE__, array( $this, 'activate' ) );
         register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
     }
@@ -70,8 +71,6 @@ class ExtraChillArtistPlatform {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/class-templates.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/owner-reference.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-compatibility.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';
@@ -140,6 +139,11 @@ class ExtraChillArtistPlatform {
     }
 
     public static function activate() {
+        $runtime = extrachill_artist_platform_boot_link_pages_runtime();
+        if ( is_wp_error( $runtime ) ) {
+            wp_die( esc_html( $runtime->get_error_message() ) );
+        }
+
         // Link-page analytics tables are owned and created by extrachill-analytics
         // (ECA) as of extrachill-artist-platform#89 / extrachill-analytics#94.
         extrachill_artist_platform_create_pages();

--- a/inc/core/artist-platform-post-types.php
+++ b/inc/core/artist-platform-post-types.php
@@ -2,8 +2,7 @@
 /**
  * Artist Platform Custom Post Types
  * 
- * Centralized registration of all custom post types for the artist platform.
- * Registers artist_profile and artist_link_page CPTs with appropriate settings.
+ * Registration of Artist Platform custom post types.
  *
  * @package ExtraChillArtistPlatform
  * @since 1.0.0
@@ -76,6 +75,9 @@ function extrachill_register_artist_profile_cpt() {
  * Register artist_link_page Custom Post Type
  */
 function extrachill_register_artist_link_page_cpt() {
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() || post_type_exists( 'artist_link_page' ) ) {
+		return;
+	}
 
     $labels = array(
         'name'                  => _x( 'Link Pages', 'Post Type General Name', 'extrachill-artist-platform' ),
@@ -136,10 +138,8 @@ function extrachill_register_artist_link_page_cpt() {
 /**
  * Initialize post type registration
  */
-function extrachill_init_post_types() {
-    extrachill_register_artist_profile_cpt();
-    extrachill_register_artist_link_page_cpt();
-}
+add_action( 'init', 'extrachill_register_artist_profile_cpt', 5 );
 
-// Hook to init with proper priority for post type registration
-add_action( 'init', 'extrachill_init_post_types', 5 );
+if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+	add_action( 'init', 'extrachill_register_artist_link_page_cpt', 5 );
+}

--- a/inc/link-pages/artist-owner-compatibility.php
+++ b/inc/link-pages/artist-owner-compatibility.php
@@ -72,7 +72,3 @@ function ec_artist_link_page_owner_compatibility_provider( $operation, $context 
 	}
 	return $claims;
 }
-ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );
-
-require_once __DIR__ . '/operations.php';
-require_once __DIR__ . '/artist-owner-operations.php';

--- a/inc/link-pages/artist-owner-operations.php
+++ b/inc/link-pages/artist-owner-operations.php
@@ -88,5 +88,3 @@ function ec_artist_link_page_operation_save( $resolved, $data ) {
 
 	return ec_artist_link_page_operation_read( $resolved );
 }
-
-ec_register_link_page_operation_provider( 'artist-platform', 'ec_artist_link_page_operation_provider' );

--- a/inc/link-pages/owner-reference.php
+++ b/inc/link-pages/owner-reference.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-const EC_LINK_PAGE_OWNER_META_KEY = '_ec_link_page_owner_reference';
-
 /**
  * Return the function-private owner compatibility registry.
  *

--- a/inc/link-pages/runtime-handoff.php
+++ b/inc/link-pages/runtime-handoff.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Coordinate the bundled and standalone Link Pages runtimes.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return whether WordPress is configured to load the standalone runtime.
+ *
+ * This reads configuration instead of runtime symbols because Artist Platform
+ * loads before the standalone plugin in the normal plugin load order.
+ *
+ * @return bool
+ */
+function extrachill_artist_platform_uses_external_link_pages_runtime() {
+	$plugin         = 'extrachill-link-pages/extrachill-link-pages.php';
+	$active_plugins = (array) get_option( 'active_plugins', array() );
+	if ( in_array( $plugin, $active_plugins, true ) ) {
+		return true;
+	}
+
+	$network_active = (array) get_site_option( 'active_sitewide_plugins', array() );
+	return isset( $network_active[ $plugin ] );
+}
+
+if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+	if ( ! defined( 'EC_LINK_PAGE_POST_TYPE' ) ) {
+		define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
+	}
+	if ( ! defined( 'EC_LINK_PAGE_OWNER_META_KEY' ) ) {
+		define( 'EC_LINK_PAGE_OWNER_META_KEY', '_ec_link_page_owner_reference' );
+	}
+}
+
+/**
+ * Return the exact generic function signatures consumed by Artist Platform.
+ *
+ * @return array<string,array{total:int,required:int}>
+ */
+function extrachill_artist_platform_link_pages_runtime_signatures() {
+	return array(
+		'ec_link_page_owner_compatibility_registry'           => array( 'total' => 0, 'required' => 0 ),
+		'ec_register_link_page_owner_compatibility_provider' => array( 'total' => 3, 'required' => 2 ),
+		'ec_parse_link_page_owner_reference'                  => array( 'total' => 1, 'required' => 1 ),
+		'ec_format_link_page_owner_reference'                 => array( 'total' => 1, 'required' => 1 ),
+		'ec_normalize_link_page_owner_reference'              => array( 'total' => 1, 'required' => 1 ),
+		'ec_get_stored_link_page_owner_references'            => array( 'total' => 1, 'required' => 1 ),
+		'ec_validate_link_page_owner_compatibility_claim'     => array( 'total' => 3, 'required' => 3 ),
+		'ec_restore_link_page_owner_provider_context'         => array( 'total' => 3, 'required' => 3 ),
+		'ec_invoke_link_page_owner_compatibility_provider'    => array( 'total' => 3, 'required' => 3 ),
+		'ec_collect_raw_link_page_owner_compatibility_claims' => array( 'total' => 2, 'required' => 2 ),
+		'ec_reconcile_link_page_owner_candidate'              => array( 'total' => 2, 'required' => 2 ),
+		'ec_collect_link_page_owner_compatibility_claims'     => array( 'total' => 2, 'required' => 2 ),
+		'ec_get_link_page_owner'                              => array( 'total' => 1, 'required' => 1 ),
+		'ec_get_link_page_id_for_owner'                       => array( 'total' => 2, 'required' => 1 ),
+		'ec_validate_link_page_owner_candidate_ids'           => array( 'total' => 1, 'required' => 1 ),
+		'ec_assign_link_page_owner'                           => array( 'total' => 3, 'required' => 2 ),
+		'ec_compensate_link_page_owner_assignment'            => array( 'total' => 4, 'required' => 4 ),
+		'ec_halt_link_page_owner_backfill'                    => array( 'total' => 4, 'required' => 4 ),
+		'ec_backfill_link_page_owner_references'              => array( 'total' => 2, 'required' => 0 ),
+		'ec_link_page_operation_provider_registry'            => array( 'total' => 0, 'required' => 0 ),
+		'ec_register_link_page_operation_provider'            => array( 'total' => 3, 'required' => 2 ),
+		'ec_resolve_link_page_operation_target'               => array( 'total' => 1, 'required' => 1 ),
+		'ec_invoke_link_page_operation_callback'              => array( 'total' => 2, 'required' => 2 ),
+		'ec_get_link_page_operation_provider'                 => array( 'total' => 1, 'required' => 1 ),
+		'ec_prepare_link_page_operation'                      => array( 'total' => 2, 'required' => 2 ),
+		'ec_read_link_page'                                   => array( 'total' => 1, 'required' => 1 ),
+		'ec_save_link_page'                                   => array( 'total' => 2, 'required' => 2 ),
+	);
+}
+
+/**
+ * Validate the generic API surface consumed by the artist adapters.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_artist_platform_validate_link_pages_runtime() {
+	$external = extrachill_artist_platform_uses_external_link_pages_runtime();
+	if ( ! defined( 'EC_LINK_PAGE_POST_TYPE' ) || ! defined( 'EC_LINK_PAGE_OWNER_META_KEY' ) ) {
+		return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not load its complete generic API.' );
+	}
+	if ( 'artist_link_page' !== EC_LINK_PAGE_POST_TYPE || '_ec_link_page_owner_reference' !== EC_LINK_PAGE_OWNER_META_KEY ) {
+		return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime uses an incompatible storage contract.' );
+	}
+	if ( $external && ! defined( 'EC_LINK_PAGES_RUNTIME_API_VERSION' ) ) {
+		return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not declare its API version.' );
+	}
+	if ( defined( 'EC_LINK_PAGES_RUNTIME_API_VERSION' ) && '1' !== EC_LINK_PAGES_RUNTIME_API_VERSION ) {
+		return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime API version is not supported.' );
+	}
+
+	foreach ( extrachill_artist_platform_link_pages_runtime_signatures() as $function => $signature ) {
+		if ( ! function_exists( $function ) ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not load its complete generic API.' );
+		}
+		$reflection = new ReflectionFunction( $function );
+		if ( $signature['total'] !== $reflection->getNumberOfParameters() || $signature['required'] !== $reflection->getNumberOfRequiredParameters() ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime exposes an incompatible generic function signature.' );
+		}
+	}
+	if ( $external && ! function_exists( 'ec_link_pages_runtime_ready' ) ) {
+		return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not expose its readiness marker.' );
+	}
+	if ( function_exists( 'ec_link_pages_runtime_ready' ) ) {
+		$readiness = new ReflectionFunction( 'ec_link_pages_runtime_ready' );
+		if ( 0 !== $readiness->getNumberOfParameters() || 0 !== $readiness->getNumberOfRequiredParameters() ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime exposes an incompatible readiness marker.' );
+		}
+		try {
+			$ready = ec_link_pages_runtime_ready();
+		} catch ( Throwable $throwable ) {
+			$ready = false;
+		}
+		if ( true !== $ready ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime reported that it is not ready.' );
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Register Artist Platform's owner adapters exactly once.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_artist_platform_register_link_page_adapters() {
+	static $registered = false;
+	if ( $registered ) {
+		return true;
+	}
+
+	$valid = extrachill_artist_platform_validate_link_pages_runtime();
+	if ( is_wp_error( $valid ) ) {
+		return $valid;
+	}
+
+	require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-compatibility.php';
+	require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-operations.php';
+
+	$owner_result = ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );
+	if ( is_wp_error( $owner_result ) ) {
+		return $owner_result;
+	}
+	$operation_result = ec_register_link_page_operation_provider( 'artist-platform', 'ec_artist_link_page_operation_provider' );
+	if ( is_wp_error( $operation_result ) ) {
+		return $operation_result;
+	}
+
+	$registered = true;
+	return true;
+}
+
+/**
+ * Load the rolling fallback when needed, then attach artist adapters.
+ *
+ * The standalone runtime contract requires generic APIs to be available by
+ * plugins_loaded priority 20. Its CPT registration remains its own init hook.
+ *
+ * @return true|WP_Error
+ */
+function extrachill_artist_platform_boot_link_pages_runtime() {
+	if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/owner-reference.php';
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/operations.php';
+	}
+
+	$result = extrachill_artist_platform_register_link_page_adapters();
+	if ( is_wp_error( $result ) ) {
+		$GLOBALS['extrachill_artist_platform_link_pages_runtime_error'] = $result;
+		add_action( 'admin_notices', 'extrachill_artist_platform_link_pages_runtime_notice' );
+	}
+
+	return $result;
+}
+
+/**
+ * Display an explicit operator-facing error for an incomplete runtime.
+ *
+ * @return void
+ */
+function extrachill_artist_platform_link_pages_runtime_notice() {
+	$error = $GLOBALS['extrachill_artist_platform_link_pages_runtime_error'] ?? null;
+	if ( ! is_wp_error( $error ) ) {
+		return;
+	}
+
+	printf(
+		'<div class="notice notice-error"><p>%s</p></div>',
+		esc_html( $error->get_error_message() )
+	);
+}

--- a/tests/LinkPageRuntimeHandoffTest.php
+++ b/tests/LinkPageRuntimeHandoffTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class LinkPageRuntimeHandoffTest extends TestCase {
+	private function runSmokeFixture( $fixture, $argument = '' ) {
+		$output = array();
+		$status = 0;
+		$command = escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( __DIR__ . '/fixtures/' . $fixture );
+		if ( '' !== $argument ) {
+			$command .= ' ' . escapeshellarg( $argument );
+		}
+		exec( $command, $output, $status );
+
+		$this->assertSame( 0, $status, implode( "\n", $output ) );
+		$result = json_decode( implode( "\n", $output ), true );
+		$this->assertIsArray( $result );
+		return $result;
+	}
+
+	public function test_fake_external_runtime_owns_generic_symbols_and_cpt_while_artist_adapter_registers_once(): void {
+		$result = $this->runSmokeFixture( 'link-pages-external-runtime-smoke.php' );
+
+		$this->assertTrue( $result['booted'] );
+		$this->assertSame( 'artist_link_page', $result['post_type_constant'] );
+		$this->assertSame( '_ec_link_page_owner_reference', $result['owner_meta_constant'] );
+		$this->assertSame( 1, $result['owner_providers'] );
+		$this->assertSame( 1, $result['operation_providers'] );
+		$this->assertSame( 'external-runtime', $result['link_page_cpt_owner'] );
+		$this->assertTrue( $result['artist_profile_exists'] );
+		$this->assertSame( 'post:4:artist_profile:20', $result['legacy_owner_reference'] );
+		$this->assertSame( 0, $result['write_calls'] );
+	}
+
+	public function test_configured_runtime_failure_is_explicit(): void {
+		$result = $this->runSmokeFixture( 'link-pages-missing-runtime-smoke.php' );
+
+		$this->assertSame( 'extrachill_link_pages_runtime_incomplete', $result['error_code'] );
+		$this->assertTrue( $result['notice_hooked'] );
+	}
+
+	/**
+	 * @dataProvider activationFailureProvider
+	 */
+	public function test_activation_fails_explicitly_for_invalid_configured_runtime( $mode, $message ): void {
+		$result = $this->runSmokeFixture( 'link-pages-activation-failure-smoke.php', $mode );
+
+		$this->assertTrue( $result['failed'] );
+		$this->assertStringContainsString( $message, $result['message'] );
+	}
+
+	public function activationFailureProvider(): array {
+		return array(
+			'missing runtime'       => array( 'missing', 'did not load its complete generic API' ),
+			'no API marker'         => array( 'no-marker', 'did not declare its API version' ),
+			'stale API version'     => array( 'stale-version', 'API version is not supported' ),
+			'wrong generic arity'   => array( 'wrong-arity', 'incompatible generic function signature' ),
+			'wrong required arity'  => array( 'wrong-required-arity', 'incompatible generic function signature' ),
+			'no readiness marker'   => array( 'no-readiness', 'did not expose its readiness marker' ),
+			'wrong readiness arity' => array( 'readiness-arity', 'incompatible readiness marker' ),
+		);
+	}
+
+	/**
+	 * @dataProvider incompatibleRuntimeProvider
+	 */
+	public function test_incompatible_external_runtime_fails_before_adapters_load( $mode, $error_code ): void {
+		$result = $this->runSmokeFixture( 'link-pages-runtime-validation-smoke.php', $mode );
+
+		$this->assertSame( $error_code, $result['error_code'] );
+		$this->assertTrue( $result['notice_hooked'] );
+	}
+
+	public function incompatibleRuntimeProvider(): array {
+		return array(
+			'post type contract' => array( 'post-type', 'extrachill_link_pages_runtime_incompatible' ),
+			'owner meta contract' => array( 'owner-meta', 'extrachill_link_pages_runtime_incompatible' ),
+			'no API marker'      => array( 'no-marker', 'extrachill_link_pages_runtime_incomplete' ),
+			'stale API version'  => array( 'stale-version', 'extrachill_link_pages_runtime_incompatible' ),
+			'wrong generic arity' => array( 'wrong-arity', 'extrachill_link_pages_runtime_incompatible' ),
+			'wrong required arity'=> array( 'wrong-required-arity', 'extrachill_link_pages_runtime_incompatible' ),
+			'no readiness marker'=> array( 'no-readiness', 'extrachill_link_pages_runtime_incomplete' ),
+			'readiness arity'    => array( 'readiness-arity', 'extrachill_link_pages_runtime_incompatible' ),
+			'not ready'          => array( 'readiness', 'extrachill_link_pages_runtime_incomplete' ),
+		);
+	}
+
+	public function test_first_activation_and_next_request_use_the_real_standalone_runtime_contract(): void {
+		$activation = $this->runSmokeFixture( 'link-pages-real-runtime-smoke.php', 'activation' );
+		$this->assertFalse( $activation['before_boot'] );
+		$this->assertTrue( $activation['after_boot'] );
+		$this->assertTrue( $activation['ready'] );
+		$this->assertTrue( $activation['contract_matches'] );
+		$this->assertSame( 1, $activation['link_registrations'] );
+		$this->assertSame( 1, $activation['owner_providers'] );
+		$this->assertSame( 1, $activation['operation_providers'] );
+		$this->assertSame( 1, $activation['flushes'] );
+
+		$external = $this->runSmokeFixture( 'link-pages-real-runtime-smoke.php', 'external' );
+		$this->assertFalse( $external['before_standalone'] );
+		$this->assertTrue( $external['after_standalone'] );
+		$this->assertTrue( $external['ready'] );
+		$this->assertTrue( $external['contract_matches'] );
+		$this->assertTrue( $external['second_boot'] );
+		$this->assertSame( 1, $external['link_registrations'] );
+		$this->assertSame( 1, $external['owner_providers'] );
+		$this->assertSame( 1, $external['operation_providers'] );
+	}
+
+	public function test_fallback_mode_remains_configured_without_a_hard_plugin_dependency(): void {
+		$source = file_get_contents( dirname( __DIR__ ) . '/extrachill-artist-platform.php' );
+
+		$this->assertStringNotContainsString( 'Requires Plugins: extrachill-link-pages', $source );
+		$this->assertTrue( defined( 'EC_LINK_PAGE_POST_TYPE' ) );
+		$this->assertTrue( function_exists( 'ec_get_link_page_owner' ) );
+		$this->assertTrue( function_exists( 'ec_read_link_page' ) );
+	}
+
+	public function test_site_and_network_active_configuration_select_the_external_runtime(): void {
+		$GLOBALS['ec_test']['options']['active_plugins'] = array( 'extrachill-link-pages/extrachill-link-pages.php' );
+		$this->assertTrue( extrachill_artist_platform_uses_external_link_pages_runtime() );
+
+		$GLOBALS['ec_test']['options']['active_plugins'] = array();
+		$GLOBALS['ec_test']['site_options']['active_sitewide_plugins'] = array(
+			'extrachill-link-pages/extrachill-link-pages.php' => 123,
+		);
+		$this->assertTrue( extrachill_artist_platform_uses_external_link_pages_runtime() );
+
+		$GLOBALS['ec_test']['site_options']['active_sitewide_plugins'] = array();
+		$this->assertFalse( extrachill_artist_platform_uses_external_link_pages_runtime() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,7 +6,7 @@ define( 'ABSPATH', __DIR__ . '/' );
 define( 'OBJECT', 'OBJECT' );
 define( 'MINUTE_IN_SECONDS', 60 );
 define( 'DAY_IN_SECONDS', 86400 );
-define( 'EC_LINK_PAGE_POST_TYPE', 'artist_link_page' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 
 function plugin_dir_path( $file ) {
 	return trailingslashit( dirname( $file ) );
@@ -1196,6 +1196,7 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-list-orphan-art
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/admin-cleanup-artist-relationships.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/data.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/permissions.php';
+require_once dirname( __DIR__ ) . '/inc/link-pages/runtime-handoff.php';
 require_once dirname( __DIR__ ) . '/inc/core/artist-platform-post-types.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-get.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-public-projections.php';
@@ -1211,6 +1212,8 @@ require_once dirname( __DIR__ ) . '/inc/abilities/handlers/onboard-external-arti
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/artist-invitation.php';
 require_once dirname( __DIR__ ) . '/inc/link-pages/owner-reference.php';
 require_once dirname( __DIR__ ) . '/inc/link-pages/artist-owner-compatibility.php';
+require_once dirname( __DIR__ ) . '/inc/link-pages/operations.php';
+require_once dirname( __DIR__ ) . '/inc/link-pages/artist-owner-operations.php';
 require_once dirname( __DIR__ ) . '/inc/core/filters/create.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-links.php';
 require_once dirname( __DIR__ ) . '/inc/abilities/handlers/save-link-page-styles.php';

--- a/tests/fixtures/fake-external-link-pages-runtime.php
+++ b/tests/fixtures/fake-external-link-pages-runtime.php
@@ -1,0 +1,154 @@
+<?php
+
+if ( empty( $GLOBALS['smoke']['omit_api_version'] ) ) {
+	define( 'EC_LINK_PAGES_RUNTIME_API_VERSION', $GLOBALS['smoke']['api_version'] ?? '1' );
+}
+define( 'EC_LINK_PAGE_POST_TYPE', $GLOBALS['smoke']['post_type_constant'] ?? 'artist_link_page' );
+define( 'EC_LINK_PAGE_OWNER_META_KEY', $GLOBALS['smoke']['owner_meta_constant'] ?? '_ec_link_page_owner_reference' );
+
+function ec_link_page_owner_compatibility_registry() {
+	return (object) array();
+}
+
+function ec_register_link_page_owner_compatibility_provider( $name, $callback, $priority = 10 ) {
+	if ( isset( $GLOBALS['smoke']['owner_providers'][ $name ] ) ) {
+		return new WP_Error( 'duplicate_link_page_owner_provider', 'Duplicate provider.' );
+	}
+	$GLOBALS['smoke']['owner_providers'][ $name ] = $callback;
+	return true;
+}
+
+function ec_register_link_page_operation_provider( $name, $callback, $priority = 10 ) {
+	if ( isset( $GLOBALS['smoke']['operation_providers'][ $name ] ) ) {
+		return new WP_Error( 'duplicate_link_page_operation_provider', 'Duplicate provider.' );
+	}
+	$GLOBALS['smoke']['operation_providers'][ $name ] = $callback;
+	return true;
+}
+
+function ec_format_link_page_owner_reference( $owner ) {
+	return sprintf( '%s:%d:%s:%d', $owner['kind'], $owner['blog_id'], $owner['subtype'], $owner['object_id'] );
+}
+
+function ec_parse_link_page_owner_reference( $reference ) {
+	list( $kind, $blog_id, $subtype, $object_id ) = explode( ':', $reference );
+	return array(
+		'kind'      => $kind,
+		'blog_id'   => (int) $blog_id,
+		'subtype'   => $subtype,
+		'object_id' => (int) $object_id,
+		'reference' => $reference,
+	);
+}
+
+function ec_normalize_link_page_owner_reference( $owner ) {
+	return is_array( $owner ) ? ec_format_link_page_owner_reference( $owner ) : $owner;
+}
+
+function ec_get_stored_link_page_owner_references( $link_page_id ) {
+	return array();
+}
+
+function ec_validate_link_page_owner_compatibility_claim( $claim, $operation, $context ) {
+	return $claim;
+}
+
+function ec_restore_link_page_owner_provider_context( $blog_id, $stack, $switched ) {
+	return true;
+}
+
+function ec_invoke_link_page_owner_compatibility_provider( $provider, $operation, $context ) {
+	return call_user_func( $provider['callback'], $operation, $context );
+}
+
+function ec_collect_raw_link_page_owner_compatibility_claims( $operation, $context ) {
+	return array();
+}
+
+function ec_reconcile_link_page_owner_candidate( $link_page_id, $owner_reference ) {
+	return true;
+}
+
+function ec_collect_link_page_owner_compatibility_claims( $operation, $context ) {
+	return array();
+}
+
+function ec_get_link_page_owner( $link_page_id ) {
+	$provider = $GLOBALS['smoke']['owner_providers']['artist-platform'];
+	$claims   = $provider( 'page_owner', array( 'link_page_id' => $link_page_id ) );
+	return ec_parse_link_page_owner_reference( $claims[0]['owner_reference'] );
+}
+
+function ec_get_link_page_id_for_owner( $owner, $allowed_link_pages = array() ) {
+	return 40;
+}
+
+function ec_validate_link_page_owner_candidate_ids( $candidate_ids ) {
+	return $candidate_ids;
+}
+
+function ec_assign_link_page_owner( $link_page_id, $owner, $replace_link_page_id = 0 ) {
+	return true;
+}
+
+function ec_compensate_link_page_owner_assignment( $link_page_id, $reference, $owner_meta_id, $error ) {
+	return $error;
+}
+
+function ec_halt_link_page_owner_backfill( $result, $link_page_id, $error_code, $offset ) {
+	return $result;
+}
+
+function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
+	return array( 'processed' => 0, 'updated' => 0, 'skipped' => 0, 'errors' => array(), 'next_offset' => $offset );
+}
+
+function ec_link_page_operation_provider_registry() {
+	return (object) array();
+}
+
+function ec_resolve_link_page_operation_target( $target ) {
+	return array( 'link_page_id' => 40, 'owner' => ec_get_link_page_owner( 40 ), 'owner_reference' => 'post:4:artist_profile:20' );
+}
+
+function ec_invoke_link_page_operation_callback( $callback, $arguments ) {
+	return call_user_func_array( $callback, $arguments );
+}
+
+function ec_get_link_page_operation_provider( $resolved ) {
+	return array();
+}
+
+function ec_prepare_link_page_operation( $target, $operation ) {
+	return array();
+}
+
+function ec_read_link_page( $target ) {
+	return array();
+}
+
+if ( ! empty( $GLOBALS['smoke']['wrong_save_arity'] ) ) {
+	function ec_save_link_page( $target ) {
+		return array();
+	}
+} elseif ( ! empty( $GLOBALS['smoke']['wrong_save_required_arity'] ) ) {
+	function ec_save_link_page( $target, $data = array() ) {
+		return $data;
+	}
+} else {
+	function ec_save_link_page( $target, $data ) {
+		return $data;
+	}
+}
+
+if ( empty( $GLOBALS['smoke']['omit_readiness'] ) ) {
+	if ( ! empty( $GLOBALS['smoke']['wrong_readiness_arity'] ) ) {
+		function ec_link_pages_runtime_ready( $context ) {
+			return true;
+		}
+	} else {
+		function ec_link_pages_runtime_ready() {
+			return $GLOBALS['smoke']['runtime_ready'] ?? true;
+		}
+	}
+}

--- a/tests/fixtures/link-pages-activation-failure-smoke.php
+++ b/tests/fixtures/link-pages-activation-failure-smoke.php
@@ -1,0 +1,104 @@
+<?php
+
+$root = dirname( __DIR__, 2 );
+$mode = $argv[1] ?? 'missing';
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+$GLOBALS['smoke'] = array( 'actions' => array() );
+
+function plugin_dir_path( $file ) {
+	return dirname( $file ) . '/';
+}
+
+function plugin_dir_url() {
+	return 'https://example.test/';
+}
+
+function plugin_basename( $file ) {
+	return basename( dirname( $file ) ) . '/' . basename( $file );
+}
+
+function get_option( $name, $default = false ) {
+	return 'active_plugins' === $name ? array( 'extrachill-link-pages/extrachill-link-pages.php' ) : $default;
+}
+
+function get_site_option( $name, $default = false ) {
+	return $default;
+}
+
+function add_action( $hook, $callback, $priority = 10 ) {
+	$GLOBALS['smoke']['actions'][] = array( $hook, $callback, $priority );
+}
+
+function register_activation_hook( $file, $callback ) {
+	$GLOBALS['smoke']['activation_callback'] = $callback;
+}
+
+function register_deactivation_hook() {
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function esc_html( $value ) {
+	return $value;
+}
+
+function wp_die( $message ) {
+	throw new RuntimeException( $message );
+}
+
+require_once $root . '/extrachill-artist-platform.php';
+
+if ( 'missing' !== $mode ) {
+	if ( 'stale-version' === $mode ) {
+		$GLOBALS['smoke']['api_version'] = '0';
+	} elseif ( 'no-marker' === $mode ) {
+		$GLOBALS['smoke']['omit_api_version'] = true;
+	} elseif ( 'wrong-arity' === $mode ) {
+		$GLOBALS['smoke']['wrong_save_arity'] = true;
+	} elseif ( 'wrong-required-arity' === $mode ) {
+		$GLOBALS['smoke']['wrong_save_required_arity'] = true;
+	} elseif ( 'no-readiness' === $mode ) {
+		$GLOBALS['smoke']['omit_readiness'] = true;
+	} elseif ( 'readiness-arity' === $mode ) {
+		$GLOBALS['smoke']['wrong_readiness_arity'] = true;
+	}
+	require_once __DIR__ . '/fake-external-link-pages-runtime.php';
+}
+
+$failed  = false;
+$message = '';
+try {
+	call_user_func( $GLOBALS['smoke']['activation_callback'] );
+} catch ( RuntimeException $exception ) {
+	$failed  = true;
+	$message = $exception->getMessage();
+}
+
+echo json_encode(
+	array(
+		'failed'  => $failed,
+		'message' => $message,
+	)
+);

--- a/tests/fixtures/link-pages-external-runtime-smoke.php
+++ b/tests/fixtures/link-pages-external-runtime-smoke.php
@@ -1,0 +1,144 @@
+<?php
+
+$root = dirname( __DIR__, 2 );
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $root . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+$GLOBALS['smoke'] = array(
+	'actions'                => array(),
+	'registered_post_types'  => array(),
+	'posts'                  => array(
+		20 => (object) array( 'ID' => 20, 'post_type' => 'artist_profile' ),
+		40 => (object) array( 'ID' => 40, 'post_type' => 'artist_link_page' ),
+	),
+	'post_meta'              => array(
+		40 => array( '_associated_artist_profile_id' => 20 ),
+	),
+	'post_meta_write_calls'  => 0,
+);
+
+function get_option( $name, $default = false ) {
+	return 'active_plugins' === $name ? array( 'extrachill-link-pages/extrachill-link-pages.php' ) : $default;
+}
+
+function get_site_option( $name, $default = false ) {
+	return $default;
+}
+
+function add_action( $hook, $callback, $priority = 10 ) {
+	$GLOBALS['smoke']['actions'][] = array( $hook, $callback, $priority );
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function absint( $value ) {
+	return abs( (int) $value );
+}
+
+function wp_json_encode( $value ) {
+	return json_encode( $value );
+}
+
+function get_current_blog_id() {
+	return 4;
+}
+
+function get_site( $blog_id ) {
+	return 4 === (int) $blog_id ? (object) array( 'blog_id' => 4 ) : null;
+}
+
+function switch_to_blog() {
+	return true;
+}
+
+function restore_current_blog() {
+	return true;
+}
+
+function get_post_type( $post_id ) {
+	return $GLOBALS['smoke']['posts'][ $post_id ]->post_type ?? false;
+}
+
+function post_type_exists( $post_type ) {
+	return isset( $GLOBALS['smoke']['registered_post_types'][ $post_type ] );
+}
+
+function get_post_meta( $post_id, $key, $single = false ) {
+	if ( ! array_key_exists( $key, $GLOBALS['smoke']['post_meta'][ $post_id ] ?? array() ) ) {
+		return $single ? '' : array();
+	}
+	$value = $GLOBALS['smoke']['post_meta'][ $post_id ][ $key ];
+	return $single ? $value : array( $value );
+}
+
+function update_post_meta() {
+	++$GLOBALS['smoke']['post_meta_write_calls'];
+	return true;
+}
+
+function get_posts( $args ) {
+	if ( '_associated_artist_profile_id' === ( $args['meta_key'] ?? '' ) && '20' === (string) ( $args['meta_value'] ?? '' ) ) {
+		return array( 40 );
+	}
+	return array();
+}
+
+function register_post_type( $post_type, $args ) {
+	$GLOBALS['smoke']['registered_post_types'][ $post_type ] = $args;
+	return (object) $args;
+}
+
+function __( $text ) {
+	return $text;
+}
+
+function _x( $text ) {
+	return $text;
+}
+
+// Simulate a standalone generic API loading after Artist Platform's handoff code.
+require_once $root . '/inc/link-pages/runtime-handoff.php';
+require_once __DIR__ . '/fake-external-link-pages-runtime.php';
+register_post_type( 'artist_link_page', array( 'owner' => 'external-runtime' ) );
+
+require_once $root . '/inc/core/artist-platform-post-types.php';
+$first  = extrachill_artist_platform_boot_link_pages_runtime();
+$second = extrachill_artist_platform_boot_link_pages_runtime();
+extrachill_register_artist_profile_cpt();
+extrachill_register_artist_link_page_cpt();
+$owner = ec_get_link_page_owner( 40 );
+
+echo json_encode(
+	array(
+		'booted'                => true === $first && true === $second,
+		'post_type_constant'     => EC_LINK_PAGE_POST_TYPE,
+		'owner_meta_constant'    => EC_LINK_PAGE_OWNER_META_KEY,
+		'owner_providers'        => count( $GLOBALS['smoke']['owner_providers'] ),
+		'operation_providers'    => count( $GLOBALS['smoke']['operation_providers'] ),
+		'link_page_cpt_owner'    => $GLOBALS['smoke']['registered_post_types']['artist_link_page']['owner'] ?? '',
+		'artist_profile_exists'  => isset( $GLOBALS['smoke']['registered_post_types']['artist_profile'] ),
+		'legacy_owner_reference'=> is_wp_error( $owner ) ? $owner->get_error_code() : $owner['reference'],
+		'write_calls'            => $GLOBALS['smoke']['post_meta_write_calls'],
+	)
+);

--- a/tests/fixtures/link-pages-missing-runtime-smoke.php
+++ b/tests/fixtures/link-pages-missing-runtime-smoke.php
@@ -1,0 +1,52 @@
+<?php
+
+$root = dirname( __DIR__, 2 );
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $root . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+$GLOBALS['smoke_actions'] = array();
+
+function get_option( $name, $default = false ) {
+	return 'active_plugins' === $name ? array( 'extrachill-link-pages/extrachill-link-pages.php' ) : $default;
+}
+
+function get_site_option( $name, $default = false ) {
+	return $default;
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function add_action( $hook, $callback ) {
+	$GLOBALS['smoke_actions'][] = array( $hook, $callback );
+}
+
+require_once $root . '/inc/link-pages/runtime-handoff.php';
+$result = extrachill_artist_platform_boot_link_pages_runtime();
+
+echo json_encode(
+	array(
+		'error_code'   => is_wp_error( $result ) ? $result->get_error_code() : '',
+		'notice_hooked'=> in_array( array( 'admin_notices', 'extrachill_artist_platform_link_pages_runtime_notice' ), $GLOBALS['smoke_actions'], true ),
+	)
+);

--- a/tests/fixtures/link-pages-real-runtime-smoke.php
+++ b/tests/fixtures/link-pages-real-runtime-smoke.php
@@ -1,0 +1,154 @@
+<?php
+
+$mode       = $argv[1] ?? '';
+$artist     = dirname( __DIR__, 2 );
+$standalone = getenv( 'LINK_PAGES_WORKTREE' ) ?: '/var/lib/datamachine/workspace/extrachill-link-pages@feat-1-owner-neutral-runtime';
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $artist . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+$GLOBALS['smoke'] = array(
+	'active'                => 'external' === $mode,
+	'actions'               => array(),
+	'activation_callbacks'  => array(),
+	'registered_post_types' => array(),
+	'registration_counts'   => array(),
+	'flushes'               => 0,
+);
+
+function get_option( $name, $default = false ) {
+	if ( 'active_plugins' === $name && $GLOBALS['smoke']['active'] ) {
+		return array( 'extrachill-link-pages/extrachill-link-pages.php' );
+	}
+	return $default;
+}
+
+function get_site_option( $name, $default = false ) {
+	return $default;
+}
+
+function plugin_dir_path( $file ) {
+	return dirname( $file ) . '/';
+}
+
+function plugin_basename( $file ) {
+	return basename( dirname( $file ) ) . '/' . basename( $file );
+}
+
+function add_action( $hook, $callback, $priority = 10 ) {
+	$GLOBALS['smoke']['actions'][ $hook ][ $priority ][] = $callback;
+}
+
+function do_action( $hook ) {
+	$priorities = $GLOBALS['smoke']['actions'][ $hook ] ?? array();
+	ksort( $priorities );
+	foreach ( $priorities as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			call_user_func( $callback );
+		}
+	}
+}
+
+function register_activation_hook( $file, $callback ) {
+	$GLOBALS['smoke']['activation_callbacks'][ plugin_basename( $file ) ] = $callback;
+}
+
+function register_deactivation_hook() {
+}
+
+function post_type_exists( $post_type ) {
+	return isset( $GLOBALS['smoke']['registered_post_types'][ $post_type ] );
+}
+
+function register_post_type( $post_type, $args ) {
+	$GLOBALS['smoke']['registered_post_types'][ $post_type ] = $args;
+	$GLOBALS['smoke']['registration_counts'][ $post_type ]   = ( $GLOBALS['smoke']['registration_counts'][ $post_type ] ?? 0 ) + 1;
+	return (object) $args;
+}
+
+function flush_rewrite_rules() {
+	++$GLOBALS['smoke']['flushes'];
+}
+
+function __( $text ) {
+	return $text;
+}
+
+function _x( $text ) {
+	return $text;
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+require_once $artist . '/inc/link-pages/runtime-handoff.php';
+require_once $artist . '/inc/core/artist-platform-post-types.php';
+add_action( 'plugins_loaded', 'extrachill_artist_platform_boot_link_pages_runtime', 20 );
+
+if ( 'activation' === $mode ) {
+	$before_boot = function_exists( 'ec_get_link_page_owner' );
+	do_action( 'plugins_loaded' );
+	$after_boot = function_exists( 'ec_get_link_page_owner' );
+	do_action( 'init' );
+	require_once $standalone . '/extrachill-link-pages.php';
+	$activation_callbacks = array_values( $GLOBALS['smoke']['activation_callbacks'] );
+	call_user_func( $activation_callbacks[0] );
+
+	echo json_encode(
+		array(
+			'before_boot'          => $before_boot,
+			'after_boot'           => $after_boot,
+			'ready'                => ec_link_pages_runtime_ready(),
+			'contract_matches'      => extrachill_artist_platform_link_pages_runtime_signatures() == ec_link_pages_runtime_function_contract(),
+			'link_registrations'   => $GLOBALS['smoke']['registration_counts']['artist_link_page'] ?? 0,
+			'owner_providers'      => count( ec_link_page_owner_compatibility_registry()->snapshot() ),
+			'operation_providers'  => count( ec_link_page_operation_provider_registry()->snapshot() ),
+			'flushes'              => $GLOBALS['smoke']['flushes'],
+		)
+	);
+	exit;
+}
+
+if ( 'external' === $mode ) {
+	$before_standalone = function_exists( 'ec_get_link_page_owner' );
+	require_once $standalone . '/extrachill-link-pages.php';
+	$after_standalone = function_exists( 'ec_get_link_page_owner' );
+	do_action( 'plugins_loaded' );
+	$second_boot = extrachill_artist_platform_boot_link_pages_runtime();
+	do_action( 'init' );
+
+	echo json_encode(
+		array(
+			'before_standalone'    => $before_standalone,
+			'after_standalone'     => $after_standalone,
+			'ready'                => ec_link_pages_runtime_ready(),
+			'contract_matches'      => extrachill_artist_platform_link_pages_runtime_signatures() == ec_link_pages_runtime_function_contract(),
+			'second_boot'          => true === $second_boot,
+			'link_registrations'   => $GLOBALS['smoke']['registration_counts']['artist_link_page'] ?? 0,
+			'owner_providers'      => count( ec_link_page_owner_compatibility_registry()->snapshot() ),
+			'operation_providers'  => count( ec_link_page_operation_provider_registry()->snapshot() ),
+		)
+	);
+	exit;
+}
+
+exit( 2 );

--- a/tests/fixtures/link-pages-runtime-validation-smoke.php
+++ b/tests/fixtures/link-pages-runtime-validation-smoke.php
@@ -1,0 +1,73 @@
+<?php
+
+$mode = $argv[1] ?? '';
+$root = dirname( __DIR__, 2 );
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $root . '/' );
+
+class WP_Error {
+	private $code;
+	private $message;
+
+	public function __construct( $code, $message ) {
+		$this->code    = $code;
+		$this->message = $message;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message() {
+		return $this->message;
+	}
+}
+
+$GLOBALS['smoke'] = array( 'actions' => array() );
+if ( 'post-type' === $mode ) {
+	$GLOBALS['smoke']['post_type_constant'] = 'link_page';
+} elseif ( 'owner-meta' === $mode ) {
+	$GLOBALS['smoke']['owner_meta_constant'] = '_other_owner';
+} elseif ( 'stale-version' === $mode ) {
+	$GLOBALS['smoke']['api_version'] = '0';
+} elseif ( 'no-marker' === $mode ) {
+	$GLOBALS['smoke']['omit_api_version'] = true;
+} elseif ( 'wrong-arity' === $mode ) {
+	$GLOBALS['smoke']['wrong_save_arity'] = true;
+} elseif ( 'wrong-required-arity' === $mode ) {
+	$GLOBALS['smoke']['wrong_save_required_arity'] = true;
+} elseif ( 'no-readiness' === $mode ) {
+	$GLOBALS['smoke']['omit_readiness'] = true;
+} elseif ( 'readiness-arity' === $mode ) {
+	$GLOBALS['smoke']['wrong_readiness_arity'] = true;
+} elseif ( 'readiness' === $mode ) {
+	$GLOBALS['smoke']['runtime_ready'] = false;
+}
+
+function get_option( $name, $default = false ) {
+	return 'active_plugins' === $name ? array( 'extrachill-link-pages/extrachill-link-pages.php' ) : $default;
+}
+
+function get_site_option( $name, $default = false ) {
+	return $default;
+}
+
+function is_wp_error( $value ) {
+	return $value instanceof WP_Error;
+}
+
+function add_action( $hook, $callback ) {
+	$GLOBALS['smoke']['actions'][] = array( $hook, $callback );
+}
+
+require_once $root . '/inc/link-pages/runtime-handoff.php';
+require_once __DIR__ . '/fake-external-link-pages-runtime.php';
+$result = extrachill_artist_platform_boot_link_pages_runtime();
+
+echo json_encode(
+	array(
+		'error_code'    => is_wp_error( $result ) ? $result->get_error_code() : '',
+		'notice_hooked' => in_array( array( 'admin_notices', 'extrachill_artist_platform_link_pages_runtime_notice' ), $GLOBALS['smoke']['actions'], true ),
+	)
+);


### PR DESCRIPTION
## Summary
- make Artist Platform coexist safely with a configured standalone Link Pages runtime while retaining a rolling fallback
- validate the complete owner-neutral API-v1 contract before registering artist compatibility and operation adapters
- defer `artist_link_page` CPT ownership externally without changing records, abilities, routes, blocks, templates, or legacy metadata

## Testing
- full Artist Platform: `294 tests, 1,540 assertions`
- handoff contract: `21 tests, 106 assertions`
- owner references: `50 tests, 130 assertions`
- operations: `19 tests, 76 assertions`
- coordinated standalone: `28 tests, 356 assertions`

## Deployment order
1. Deploy this compatibility build.
2. Install and activate `extrachill-link-pages`.
3. On subsequent requests Artist Platform defers generic runtime and CPT ownership.

Related: Extra-Chill/extrachill-link-pages#1
Part of #152