### PR TITLE
refactor: provide artist public runtime adapter

### DIFF
--- a/extrachill-artist-platform.php
+++ b/extrachill-artist-platform.php
@@ -70,9 +70,14 @@ class ExtraChillArtistPlatform {
     private function load_includes() {
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/class-templates.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-assets.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
+		$external_link_pages = extrachill_artist_platform_uses_external_link_pages_runtime();
+		if ( ! $external_link_pages ) {
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/artist-platform-rewrite-rules.php';
+		}
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/ids.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
+		if ( ! $external_link_pages ) {
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/defaults.php';
+		}
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/create.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/social-icons.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/core/filters/fonts.php';
@@ -100,11 +105,12 @@ class ExtraChillArtistPlatform {
         // / extrachill-analytics#94. AP consumes it via the
         // extrachill_get_link_page_analytics filter (see the artist-get-analytics
         // ability) and renders it through the artist-analytics block.
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/minimal-head-assets.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-head.php';
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-seo.php';
-
-        require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/management/advanced-tab/link-expiration.php';
+		if ( ! $external_link_pages ) {
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/minimal-head-assets.php';
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-head.php';
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/live/link-page-seo.php';
+			require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/management/advanced-tab/link-expiration.php';
+		}
 
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/manage-roster-ui.php';
         require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/artist-profiles/roster/roster-filter-handlers.php';

--- a/inc/abilities/handlers/artist-create-social.php
+++ b/inc/abilities/handlers/artist-create-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-create-social
  *
@@ -9,16 +8,14 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Create (append) a social link for an artist.
  *
- * @param array $input {
- *     @type int    $id   Artist profile post ID.
- *     @type string $type Social platform type.
- *     @type string $url  Social link URL.
- * }
+ * @param array $input Ability input.
  * @return array|WP_Error Updated social links.
  */
 function extrachill_artist_platform_ability_artist_create_social( array $input ): array|WP_Error {
@@ -46,42 +43,39 @@ function extrachill_artist_platform_ability_artist_create_social( array $input )
 		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
 	}
 
-	$social_manager = extrachill_artist_platform_social_links();
-	$existing       = $social_manager->get( $artist_id );
-
-	if ( ! is_array( $existing ) ) {
-		$existing = array();
-	}
-
-	// Append the new social link (ID will be assigned during sanitize).
-	$existing[] = array(
-		'id'   => '',
-		'type' => $type,
-		'url'  => $url,
-	);
-
-	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
-
-	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
-	$result    = $social_manager->save( $artist_id, $sanitized );
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	// Build enriched response.
-	$saved_socials = $social_manager->get( $artist_id );
-	$enriched      = array();
-
-	if ( is_array( $saved_socials ) ) {
-		foreach ( $saved_socials as $social_link ) {
-			if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
-				continue;
+	return ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) use ( $artist_id, $type, $url ) {
+			$social_manager = extrachill_artist_platform_social_links();
+			$existing       = $social_manager->get( $artist_id );
+			$existing       = is_array( $existing ) ? $existing : array();
+			$previous       = $existing;
+			$existing[]     = array(
+				'id'   => '',
+				'type' => $type,
+				'url'  => $url,
+			);
+			$sanitized      = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id );
+			$result         = $social_manager->save( $artist_id, $sanitized );
+			if ( is_wp_error( $result ) || false === $result ) {
+				$social_manager->save( $artist_id, $previous );
+				return is_wp_error( $result ) ? $result : new WP_Error( 'social_save_failed', 'Social links could not be persisted.' );
 			}
-			$social_link['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
-			$enriched[]                = $social_link;
+			$saved_socials = $social_manager->get( $artist_id );
+			$enriched      = array();
+			if ( is_array( $saved_socials ) ) {
+				foreach ( $saved_socials as $social_link ) {
+					if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
+						continue;
+					}
+					$social_link['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
+					$enriched[]                = $social_link;
+				}
+			}
+			if ( $link_page_id ) {
+				do_action( 'ec_link_page_save', $link_page_id );
+			}
+			return array( 'social_links' => $enriched );
 		}
-	}
-
-	return array( 'social_links' => $enriched );
+	);
 }

--- a/inc/abilities/handlers/artist-delete-social.php
+++ b/inc/abilities/handlers/artist-delete-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-delete-social
  *
@@ -9,15 +8,14 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Delete a single social link by social_id.
  *
- * @param array $input {
- *     @type int    $id        Artist profile post ID.
- *     @type string $social_id Social link ID to delete.
- * }
+ * @param array $input Ability input.
  * @return array|WP_Error Updated social links.
  */
 function extrachill_artist_platform_ability_artist_delete_social( array $input ): array|WP_Error {
@@ -44,50 +42,51 @@ function extrachill_artist_platform_ability_artist_delete_social( array $input )
 		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
 	}
 
-	$social_manager = extrachill_artist_platform_social_links();
-	$existing       = $social_manager->get( $artist_id );
-
-	if ( ! is_array( $existing ) ) {
-		return new WP_Error( 'not_found', 'Social link not found.' );
-	}
-
-	$filtered = array();
-	$found    = false;
-	foreach ( $existing as $social_link ) {
-		if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
-			$found = true;
-			continue; // Skip this one (delete it).
-		}
-		$filtered[] = $social_link;
-	}
-
-	if ( ! $found ) {
-		return new WP_Error( 'not_found', 'Social link not found.' );
-	}
-
-	$result = $social_manager->save( $artist_id, $filtered );
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	// Build enriched response.
-	$saved_socials = $social_manager->get( $artist_id );
-	$enriched      = array();
-
-	if ( is_array( $saved_socials ) ) {
-		foreach ( $saved_socials as $s ) {
-			if ( ! is_array( $s ) || empty( $s['type'] ) || empty( $s['id'] ) ) {
-				continue;
+	return ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) use ( $artist_id, $social_id ) {
+			$social_manager = extrachill_artist_platform_social_links();
+			$existing       = $social_manager->get( $artist_id );
+			if ( ! is_array( $existing ) ) {
+				return new WP_Error( 'not_found', 'Social link not found.' );
 			}
-			$s['icon_class'] = $social_manager->get_icon_class( $s['type'], $s );
-			$enriched[]      = $s;
+			$previous = $existing;
+			$filtered = array();
+			$found    = false;
+			foreach ( $existing as $social_link ) {
+				if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
+					$found = true;
+					continue;
+				}
+				$filtered[] = $social_link;
+			}
+			if ( ! $found ) {
+				return new WP_Error( 'not_found', 'Social link not found.' );
+			}
+			$result = $social_manager->save( $artist_id, $filtered );
+			if ( is_wp_error( $result ) || false === $result ) {
+				$social_manager->save( $artist_id, $previous );
+				return is_wp_error( $result ) ? $result : new WP_Error( 'social_save_failed', 'Social links could not be persisted.' );
+			}
+			$saved_socials = $social_manager->get( $artist_id );
+			$enriched      = array();
+			if ( is_array( $saved_socials ) ) {
+				foreach ( $saved_socials as $social ) {
+					if ( ! is_array( $social ) || empty( $social['type'] ) || empty( $social['id'] ) ) {
+						continue;
+					}
+					$social['icon_class'] = $social_manager->get_icon_class( $social['type'], $social );
+					$enriched[]           = $social;
+				}
+			}
+			if ( $link_page_id ) {
+				do_action( 'ec_link_page_save', $link_page_id );
+			}
+			return array(
+				'deleted'      => true,
+				'social_id'    => $social_id,
+				'social_links' => $enriched,
+			);
 		}
-	}
-
-	return array(
-		'deleted'      => true,
-		'social_id'    => $social_id,
-		'social_links' => $enriched,
 	);
 }

--- a/inc/abilities/handlers/artist-update-social.php
+++ b/inc/abilities/handlers/artist-update-social.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 /**
  * Handler: extrachill/artist-update-social
  *
@@ -9,17 +8,14 @@ declare(strict_types=1);
  * @since   1.9.0
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Update a single social link by social_id.
  *
- * @param array $input {
- *     @type int    $id        Artist profile post ID.
- *     @type string $social_id Social link ID to update.
- *     @type string $type      Social platform type (optional).
- *     @type string $url       Social link URL (optional).
- * }
+ * @param array $input Ability input.
  * @return array|WP_Error Updated social links.
  */
 function extrachill_artist_platform_ability_artist_update_social( array $input ): array|WP_Error {
@@ -46,54 +42,53 @@ function extrachill_artist_platform_ability_artist_update_social( array $input )
 		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
 	}
 
-	$social_manager = extrachill_artist_platform_social_links();
-	$existing       = $social_manager->get( $artist_id );
-
-	if ( ! is_array( $existing ) ) {
-		return new WP_Error( 'not_found', 'Social link not found.' );
-	}
-
-	$found = false;
-	foreach ( $existing as &$social_link ) {
-		if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
-			if ( isset( $input['type'] ) ) {
-				$social_link['type'] = sanitize_text_field( $input['type'] );
+	return ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) use ( $artist_id, $social_id, $input ) {
+			$social_manager = extrachill_artist_platform_social_links();
+			$existing       = $social_manager->get( $artist_id );
+			if ( ! is_array( $existing ) ) {
+				return new WP_Error( 'not_found', 'Social link not found.' );
 			}
-			if ( isset( $input['url'] ) ) {
-				$social_link['url'] = esc_url_raw( $input['url'] );
+			$previous = $existing;
+			$found    = false;
+			foreach ( $existing as &$social_link ) {
+				if ( is_array( $social_link ) && isset( $social_link['id'] ) && $social_link['id'] === $social_id ) {
+					if ( isset( $input['type'] ) ) {
+						$social_link['type'] = sanitize_text_field( $input['type'] );
+					}
+					if ( isset( $input['url'] ) ) {
+						$social_link['url'] = esc_url_raw( $input['url'] );
+					}
+					$found = true;
+					break;
+				}
 			}
-			$found = true;
-			break;
+			unset( $social_link );
+			if ( ! $found ) {
+				return new WP_Error( 'not_found', 'Social link not found.' );
+			}
+			$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id );
+			$result    = $social_manager->save( $artist_id, $sanitized );
+			if ( is_wp_error( $result ) || false === $result ) {
+				$social_manager->save( $artist_id, $previous );
+				return is_wp_error( $result ) ? $result : new WP_Error( 'social_save_failed', 'Social links could not be persisted.' );
+			}
+			$saved_socials = $social_manager->get( $artist_id );
+			$enriched      = array();
+			if ( is_array( $saved_socials ) ) {
+				foreach ( $saved_socials as $social ) {
+					if ( ! is_array( $social ) || empty( $social['type'] ) || empty( $social['id'] ) ) {
+						continue;
+					}
+					$social['icon_class'] = $social_manager->get_icon_class( $social['type'], $social );
+					$enriched[]           = $social;
+				}
+			}
+			if ( $link_page_id ) {
+				do_action( 'ec_link_page_save', $link_page_id );
+			}
+			return array( 'social_links' => $enriched );
 		}
-	}
-	unset( $social_link );
-
-	if ( ! $found ) {
-		return new WP_Error( 'not_found', 'Social link not found.' );
-	}
-
-	$link_page_id = function_exists( 'ec_get_link_page_for_artist' ) ? ec_get_link_page_for_artist( $artist_id ) : 0;
-
-	$sanitized = extrachill_artist_platform_sanitize_socials( $existing, $link_page_id ?: 0 );
-	$result    = $social_manager->save( $artist_id, $sanitized );
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	// Build enriched response.
-	$saved_socials = $social_manager->get( $artist_id );
-	$enriched      = array();
-
-	if ( is_array( $saved_socials ) ) {
-		foreach ( $saved_socials as $s ) {
-			if ( ! is_array( $s ) || empty( $s['type'] ) || empty( $s['id'] ) ) {
-				continue;
-			}
-			$s['icon_class'] = $social_manager->get_icon_class( $s['type'], $s );
-			$enriched[]      = $s;
-		}
-	}
-
-	return array( 'social_links' => $enriched );
+	);
 }

--- a/inc/abilities/handlers/save-link-page-links.php
+++ b/inc/abilities/handlers/save-link-page-links.php
@@ -36,7 +36,12 @@ function extrachill_artist_platform_ability_save_link_page_links( $input ) {
 		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
 	}
 
-	$sanitized_links = extrachill_artist_platform_sanitize_links( $links, $link_page_id );
+	$sanitized_links = function_exists( 'extrachill_artist_platform_uses_external_link_pages_runtime' ) && extrachill_artist_platform_uses_external_link_pages_runtime()
+		? $links
+		: extrachill_artist_platform_sanitize_links( $links, $link_page_id );
+	if ( is_wp_error( $sanitized_links ) ) {
+		return $sanitized_links;
+	}
 
 	$save_data = array( 'links' => $sanitized_links );
 	$result    = ec_save_link_page(

--- a/inc/abilities/handlers/save-link-page-styles.php
+++ b/inc/abilities/handlers/save-link-page-styles.php
@@ -40,6 +40,9 @@ function extrachill_artist_platform_ability_save_link_page_styles( $input ) {
 	$existing_vars = is_array( $existing_vars ) ? $existing_vars : array();
 
 	$sanitized_vars = extrachill_artist_platform_sanitize_css_vars( $css_vars );
+	if ( is_wp_error( $sanitized_vars ) ) {
+		return $sanitized_vars;
+	}
 	$merged_vars    = array_merge( $existing_vars, $sanitized_vars );
 
 	$save_data = array( 'css_vars' => $merged_vars );

--- a/inc/abilities/handlers/save-social-links.php
+++ b/inc/abilities/handlers/save-social-links.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Save social links for an artist profile. Full replacement.
  *
- * @param array $input { artist_id: int, social_links: array }
+ * @param array $input { artist_id: int, social_links: array }.
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_save_social_links( $input ) {
@@ -34,33 +34,32 @@ function extrachill_artist_platform_ability_save_social_links( $input ) {
 		return new WP_Error( 'dependency_missing', 'Social links manager not available.' );
 	}
 
-	$link_page_id = ec_get_link_page_for_artist( $artist_id );
-	if ( ! $link_page_id ) {
-		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
-	}
-
-	$sanitized_socials = extrachill_artist_platform_sanitize_socials( $social_links, $link_page_id );
-
-	$social_manager = extrachill_artist_platform_social_links();
-	$result         = $social_manager->save( $artist_id, $sanitized_socials );
-
-	if ( is_wp_error( $result ) ) {
-		return $result;
-	}
-
-	// Build enriched response.
-	$saved_socials = $social_manager->get( $artist_id );
-	$enriched      = array();
-
-	if ( is_array( $saved_socials ) ) {
-		foreach ( $saved_socials as $social_link ) {
-			if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
-				continue;
+	return ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) use ( $artist_id, $social_links ) {
+			$social_manager    = extrachill_artist_platform_social_links();
+			$previous_socials  = $social_manager->get( $artist_id );
+			$previous_socials  = is_array( $previous_socials ) ? $previous_socials : array();
+			$sanitized_socials = extrachill_artist_platform_sanitize_socials( $social_links, $link_page_id );
+			$result            = $social_manager->save( $artist_id, $sanitized_socials );
+			if ( is_wp_error( $result ) || false === $result ) {
+				$social_manager->save( $artist_id, $previous_socials );
+				return is_wp_error( $result ) ? $result : new WP_Error( 'social_save_failed', 'Social links could not be persisted.' );
 			}
-			$social_link['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
-			$enriched[]                = $social_link;
-		}
-	}
-
-	return array( 'social_links' => $enriched );
+			$saved_socials = $social_manager->get( $artist_id );
+			$enriched      = array();
+			if ( is_array( $saved_socials ) ) {
+				foreach ( $saved_socials as $social_link ) {
+					if ( ! is_array( $social_link ) || empty( $social_link['type'] ) || empty( $social_link['id'] ) ) {
+						continue;
+					}
+					$social_link['icon_class'] = $social_manager->get_icon_class( $social_link['type'], $social_link );
+					$enriched[]                = $social_link;
+				}
+			}
+			do_action( 'ec_link_page_save', $link_page_id );
+			return array( 'social_links' => $enriched );
+		},
+		true
+	);
 }

--- a/inc/abilities/handlers/update-artist.php
+++ b/inc/abilities/handlers/update-artist.php
@@ -11,10 +11,38 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Update an existing artist profile. Supports partial updates.
  *
- * @param array $input { artist_id: int, name?: string, bio?: string, local_city?: string, genre?: string, profile_image_id?: int, header_image_id?: int }
+ * @param array $input { artist_id: int, name?: string, bio?: string, local_city?: string, genre?: string, profile_image_id?: int, header_image_id?: int }.
  * @return array|WP_Error
  */
 function extrachill_artist_platform_ability_update_artist( $input ) {
+	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : 0;
+	if ( ! $artist_id ) {
+		return new WP_Error( 'missing_artist_id', 'artist_id is required.' );
+	}
+	if ( ! extrachill_artist_platform_ability_artist_permission( $input ) ) {
+		return new WP_Error( 'artist_access_denied', 'You are not allowed to manage this artist.' );
+	}
+	$projection_fields  = array( 'name', 'bio', 'genre', 'profile_image_id' );
+	$affects_projection = (bool) array_intersect( $projection_fields, array_keys( $input ) );
+	if ( ! $affects_projection ) {
+		return extrachill_artist_platform_ability_update_artist_under_lock( $input, 0 );
+	}
+	return ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) use ( $input ) {
+			return extrachill_artist_platform_ability_update_artist_under_lock( $input, $link_page_id );
+		}
+	);
+}
+
+/**
+ * Execute the profile mutation after any required Link Page lock is held.
+ *
+ * @param array $input        Ability input.
+ * @param int   $link_page_id Locked Link Page ID, or zero when unrelated.
+ * @return array|WP_Error
+ */
+function extrachill_artist_platform_ability_update_artist_under_lock( $input, $link_page_id ) {
 	$artist_id = isset( $input['artist_id'] ) ? absint( $input['artist_id'] ) : 0;
 
 	if ( ! $artist_id ) {
@@ -29,11 +57,15 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 	if ( ! $artist_blog_id ) {
 		return new WP_Error( 'dependency_missing', 'Multisite not configured.' );
 	}
-
-	switch_to_blog( $artist_blog_id );
+	$did_switch = get_current_blog_id() !== (int) $artist_blog_id;
+	if ( $did_switch && ( ! switch_to_blog( $artist_blog_id ) || get_current_blog_id() !== (int) $artist_blog_id ) ) {
+		return new WP_Error( 'dependency_missing', 'Multisite not configured.' );
+	}
 
 	if ( get_post_type( $artist_id ) !== 'artist_profile' ) {
-		restore_current_blog();
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
 		return new WP_Error( 'invalid_artist', 'Artist not found.' );
 	}
 
@@ -42,17 +74,17 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( isset( $input['name'] ) ) {
 		$post_data['post_title'] = sanitize_text_field( wp_unslash( $input['name'] ) );
-		$has_updates = true;
+		$has_updates             = true;
 	}
 
 	if ( isset( $input['bio'] ) ) {
 		$post_data['post_content'] = wp_kses_post( wp_unslash( $input['bio'] ) );
-		$has_updates = true;
+		$has_updates               = true;
 	}
 
 	if ( array_key_exists( 'local_city', $input ) ) {
 		$local_city = sanitize_text_field( wp_unslash( $input['local_city'] ) );
-		if ( $local_city === '' ) {
+		if ( '' === $local_city ) {
 			delete_post_meta( $artist_id, '_local_city' );
 		} else {
 			update_post_meta( $artist_id, '_local_city', $local_city );
@@ -61,7 +93,7 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( array_key_exists( 'genre', $input ) ) {
 		$genre = sanitize_text_field( wp_unslash( $input['genre'] ) );
-		if ( $genre === '' ) {
+		if ( '' === $genre ) {
 			delete_post_meta( $artist_id, '_genre' );
 		} else {
 			update_post_meta( $artist_id, '_genre', $genre );
@@ -70,7 +102,7 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( array_key_exists( 'profile_image_id', $input ) ) {
 		$profile_image_id = absint( $input['profile_image_id'] );
-		if ( $profile_image_id > 0 ) {
+		if ( 0 < $profile_image_id ) {
 			set_post_thumbnail( $artist_id, $profile_image_id );
 		} else {
 			delete_post_thumbnail( $artist_id );
@@ -79,7 +111,7 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 
 	if ( array_key_exists( 'header_image_id', $input ) ) {
 		$header_image_id = absint( $input['header_image_id'] );
-		if ( $header_image_id > 0 ) {
+		if ( 0 < $header_image_id ) {
 			update_post_meta( $artist_id, '_artist_profile_header_image_id', $header_image_id );
 		} else {
 			delete_post_meta( $artist_id, '_artist_profile_header_image_id' );
@@ -89,17 +121,25 @@ function extrachill_artist_platform_ability_update_artist( $input ) {
 	if ( $has_updates ) {
 		$result = wp_update_post( $post_data, true );
 		if ( is_wp_error( $result ) ) {
-			restore_current_blog();
+			if ( $did_switch ) {
+				restore_current_blog();
+			}
 			return $result;
 		}
 	}
 
-	restore_current_blog();
+	if ( $link_page_id ) {
+		do_action( 'ec_link_page_save', $link_page_id );
+	}
 
 	$get_ability = wp_get_ability( 'extrachill/get-artist-data' );
 	if ( $get_ability ) {
-		return $get_ability->execute( array( 'artist_id' => $artist_id ) );
+		$response = $get_ability->execute( array( 'artist_id' => $artist_id ) );
+	} else {
+		$response = array( 'id' => (int) $artist_id );
 	}
-
-	return array( 'id' => (int) $artist_id );
+	if ( $did_switch ) {
+		restore_current_blog();
+	}
+	return $response;
 }

--- a/inc/abilities/helpers.php
+++ b/inc/abilities/helpers.php
@@ -180,8 +180,15 @@ function extrachill_artist_platform_ability_link_page_belongs_to_artist( $artist
 	}
 
 	try {
-		return 'artist_link_page' === get_post_type( $link_page_id )
-			&& (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) === (int) $artist_id;
+		if ( 'artist_link_page' !== get_post_type( $link_page_id ) || (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) !== (int) $artist_id ) {
+			return false;
+		}
+		if ( function_exists( 'ec_get_link_page_owner' ) && function_exists( 'ec_artist_link_page_owner_reference' ) ) {
+			$owner     = ec_get_link_page_owner( $link_page_id );
+			$reference = ec_artist_link_page_owner_reference( $artist_id );
+			return ! is_wp_error( $owner ) && ! is_wp_error( $reference ) && $owner['reference'] === $reference;
+		}
+		return true;
 	} finally {
 		if ( $did_switch ) {
 			restore_current_blog();
@@ -286,7 +293,7 @@ function extrachill_artist_platform_sync_counter_from_id( $link_page_id, $type, 
  *
  * @param array $links        Raw links data (array of sections with nested links).
  * @param int   $link_page_id Link page post ID for counter-based ID generation.
- * @return array Sanitized links array.
+ * @return array|WP_Error Sanitized links array.
  */
 function extrachill_artist_platform_sanitize_links( $links, $link_page_id = 0 ) {
 	if ( ! is_array( $links ) ) {
@@ -350,9 +357,12 @@ function extrachill_artist_platform_sanitize_links( $links, $link_page_id = 0 ) 
  * Sanitize CSS variables for link page styles.
  *
  * @param array $vars Raw CSS variables.
- * @return array Sanitized CSS variables.
+ * @return array|WP_Error Sanitized CSS variables.
  */
 function extrachill_artist_platform_sanitize_css_vars( $vars ) {
+	if ( function_exists( 'extrachill_artist_platform_uses_external_link_pages_runtime' ) && extrachill_artist_platform_uses_external_link_pages_runtime() && function_exists( 'ec_sanitize_link_page_css_vars' ) ) {
+		return ec_sanitize_link_page_css_vars( $vars );
+	}
 	if ( ! is_array( $vars ) ) {
 		return array();
 	}

--- a/inc/core/actions/save.php
+++ b/inc/core/actions/save.php
@@ -18,6 +18,9 @@ function ec_handle_link_page_save( $link_page_id, $save_data = array(), $files_d
     if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
         return new WP_Error( 'invalid_link_page', 'Invalid link page ID' );
     }
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		return ec_handle_external_artist_link_page_save( $link_page_id, $save_data, $files_data );
+	}
 
     // Core link page data
     if ( isset( $save_data['links'] ) && is_array( $save_data['links'] ) ) {
@@ -128,6 +131,84 @@ function ec_handle_link_page_save( $link_page_id, $save_data = array(), $files_d
     return true;
 }
 
+/** Save generic fields through standalone and retain artist-owned side effects. */
+function ec_handle_external_artist_link_page_save( $link_page_id, $save_data, $files_data = array() ) {
+	return ec_with_link_page_lock_scope(
+		$link_page_id,
+		static function () use ( $link_page_id, $save_data, $files_data ) {
+			return ec_handle_external_artist_link_page_save_locked( $link_page_id, $save_data, $files_data );
+		},
+		'combined'
+	);
+}
+
+/** Execute the complete Artist save while the standalone page lock is held. */
+function ec_handle_external_artist_link_page_save_locked( $link_page_id, $save_data, $files_data = array() ) {
+	$owner = ec_get_link_page_owner( $link_page_id );
+	if ( is_wp_error( $owner ) || 'post' !== ( $owner['kind'] ?? '' ) || 'artist_profile' !== ( $owner['subtype'] ?? '' ) ) {
+		return new WP_Error( 'invalid_artist_link_page_owner', 'The Link Page is not canonically owned by an artist.' );
+	}
+	$artist_id = (int) $owner['object_id'];
+	if ( $artist_id !== (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) ) {
+		return new WP_Error( 'artist_link_page_owner_mismatch', 'The canonical and legacy Link Page owners do not match.' );
+	}
+	$generic_keys = array( 'links', 'css_vars', 'bio', 'link_expiration_enabled', 'redirect_enabled', 'redirect_target_url', 'youtube_embed_enabled', 'meta_pixel_id', 'google_tag_id', 'google_tag_manager_id', 'social_icons_position', 'profile_image_shape', 'background_image_id' );
+	$generic      = array_intersect_key( $save_data, array_flip( $generic_keys ) );
+	$generic_meta = array( '_link_page_links', '_link_page_custom_css_vars', '_link_page_bio_text', '_link_expiration_enabled', '_link_page_redirect_enabled', '_link_page_redirect_target_url', '_enable_youtube_inline_embed', '_link_page_meta_pixel_id', '_link_page_google_tag_id', '_link_page_google_tag_manager_id', '_link_page_social_icons_position', '_link_page_profile_img_shape', '_link_page_background_image_id', '_ec_link_page_next_section_id', '_ec_link_page_next_link_id' );
+	$snapshots    = array();
+	foreach ( array_merge( $generic_meta, array( '_link_page_subscribe_display_mode', '_link_page_subscribe_description' ) ) as $meta_key ) {
+		$snapshots[ $meta_key ] = ec_snapshot_link_page_meta( $link_page_id, $meta_key );
+	}
+	$old_socials  = get_post_meta( $artist_id, '_artist_profile_social_links', true );
+	$old_thumbnail = get_post_thumbnail_id( $artist_id );
+	$result       = ec_save_link_page_persistence( $link_page_id, $generic );
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+	foreach ( array( 'subscribe_display_mode' => '_link_page_subscribe_display_mode', 'subscribe_description' => '_link_page_subscribe_description' ) as $key => $meta_key ) {
+		if ( array_key_exists( $key, $save_data ) ) {
+			$value = null === $save_data[ $key ] ? '' : sanitize_text_field( wp_unslash( (string) $save_data[ $key ] ) );
+			if ( ! ec_write_link_page_meta( $link_page_id, $meta_key, $value, '' === $value ) ) {
+				$result = new WP_Error( 'artist_link_page_save_failed', 'Artist subscription settings could not be persisted.' );
+				break;
+			}
+		}
+	}
+	if ( ! is_wp_error( $result ) && isset( $save_data['social_icons'] ) && is_array( $save_data['social_icons'] ) ) {
+		$social_result = extrachill_artist_platform_social_links()->save( $artist_id, $save_data['social_icons'] );
+		if ( is_wp_error( $social_result ) || false === $social_result ) {
+			$result = is_wp_error( $social_result ) ? $social_result : new WP_Error( 'artist_social_save_failed', 'Artist social links could not be persisted.' );
+		}
+	}
+	if ( ! is_wp_error( $result ) && array_key_exists( 'profile_image_id', $save_data ) ) {
+		$image_id = absint( $save_data['profile_image_id'] );
+		$updated  = $image_id ? set_post_thumbnail( $artist_id, $image_id ) : delete_post_thumbnail( $artist_id );
+		if ( false === $updated && (int) get_post_thumbnail_id( $artist_id ) !== $image_id ) {
+			$result = new WP_Error( 'artist_profile_image_save_failed', 'The artist profile image could not be synchronized.' );
+		}
+	}
+	if ( ! is_wp_error( $result ) && ( ! empty( $files_data ) || isset( $save_data['remove_profile_image'] ) ) ) {
+		$upload_error = ec_handle_link_page_file_uploads( $link_page_id, $files_data, $save_data );
+		if ( $upload_error ) {
+			$result = new WP_Error( 'upload_error', 'File upload error', array( 'error_code' => $upload_error ) );
+		}
+	}
+	if ( is_wp_error( $result ) ) {
+		$restored = ec_restore_link_page_meta_snapshots( $link_page_id, $snapshots );
+		if ( isset( $save_data['social_icons'] ) ) {
+			$social_restore = extrachill_artist_platform_social_links()->save( $artist_id, is_array( $old_socials ) ? $old_socials : array() );
+			$restored       = ! is_wp_error( $social_restore ) && false !== $social_restore && $restored;
+		}
+		if ( array_key_exists( 'profile_image_id', $save_data ) || ! empty( $files_data ) || isset( $save_data['remove_profile_image'] ) ) {
+			$thumbnail_restored = $old_thumbnail ? set_post_thumbnail( $artist_id, $old_thumbnail ) : delete_post_thumbnail( $artist_id );
+			$restored           = ( false !== $thumbnail_restored || (int) get_post_thumbnail_id( $artist_id ) === (int) $old_thumbnail ) && $restored;
+		}
+		return $restored ? $result : new WP_Error( 'artist_link_page_save_compensation_failed', 'The failed artist Link Page save could not be compensated.', array( 'cause' => $result->get_error_code() ) );
+	}
+	do_action( 'ec_link_page_save', $link_page_id );
+	return true;
+}
+
 /**
  * Link page save completion handler
  * 
@@ -151,6 +232,7 @@ add_action( 'ec_link_page_save', 'ec_handle_link_page_save_completion', 10, 1 );
  * @param int $link_page_id The link page post ID.
  * @return string[] Public link page URLs.
  */
+if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
 function ec_get_link_page_public_urls( $link_page_id ) {
     if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
         return array();
@@ -222,6 +304,7 @@ function ec_purge_link_page_cache( $link_page_id ) {
     do_action( 'ec_link_page_cache_purged', $link_page_id, $urls );
 }
 add_action( 'ec_link_page_save', 'ec_purge_link_page_cache', 20, 1 );
+}
 
 
 /**
@@ -298,7 +381,7 @@ function ec_process_link_form_fields( $post_data ) {
                 $link_data = array(
                     'link_text' => $link_text,
                     'link_url' => $link_url,
-                    'id' => isset( $link_ids[$section_idx][$link_idx] ) ? sanitize_text_field( $link_ids[$section_idx][$link_idx] ) : 'link_' . time() . '_' . wp_rand()
+                    'id' => isset( $link_ids[$section_idx][$link_idx] ) ? sanitize_text_field( $link_ids[$section_idx][$link_idx] ) : ( extrachill_artist_platform_uses_external_link_pages_runtime() ? '' : 'link_' . time() . '_' . wp_rand() )
                 );
                 
                 // Add expiration if available
@@ -650,8 +733,8 @@ function ec_prepare_artist_profile_save_data( $post_data ) {
  */
 function ec_admin_post_save_link_page() {
     // Verify nonce
-    if ( ! isset( $_POST['ec_save_link_page_nonce'] ) ||
-         ! wp_verify_nonce( $_POST['ec_save_link_page_nonce'], 'ec_save_link_page_action' ) ) {
+	if ( ! isset( $_POST['ec_save_link_page_nonce'] ) ||
+		 ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['ec_save_link_page_nonce'] ) ), 'ec_save_link_page_action' ) ) {
         wp_die( __( 'Security check failed.', 'extrachill-artist-platform' ) );
     }
     
@@ -661,17 +744,20 @@ function ec_admin_post_save_link_page() {
     }
     
     // Get link page and artist IDs directly from form data
-    $link_page_id = absint($_POST['link_page_id']);
-    $artist_id = absint($_POST['artist_id']);
+	$link_page_id = isset( $_POST['link_page_id'] ) ? absint( $_POST['link_page_id'] ) : 0;
+	$artist_id    = isset( $_POST['artist_id'] ) ? absint( $_POST['artist_id'] ) : 0;
     
     if ( ! $link_page_id || get_post_type( $link_page_id ) !== 'artist_link_page' ) {
         wp_die( __( 'Invalid link page.', 'extrachill-artist-platform' ) );
     }
     
     // Check user permissions
-    if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
+	if ( ! ec_can_manage_artist( get_current_user_id(), $artist_id ) ) {
         wp_die( __( 'Permission denied: You do not have access to manage this artist.', 'extrachill-artist-platform' ) );
-    }
+	}
+	if ( ! function_exists( 'extrachill_artist_platform_ability_link_page_belongs_to_artist' ) || ! extrachill_artist_platform_ability_link_page_belongs_to_artist( $artist_id, $link_page_id ) ) {
+		wp_die( __( 'Permission denied: This Link Page does not belong to the submitted artist.', 'extrachill-artist-platform' ) );
+	}
     
     // Prepare and save data using centralized functions
     $save_data = ec_prepare_link_page_save_data( $_POST );

--- a/inc/core/class-templates.php
+++ b/inc/core/class-templates.php
@@ -32,7 +32,9 @@ class ExtraChillArtistPlatform_PageTemplates {
      * Sets up filters for custom template loading for post types.
      */
     private function init_hooks() {
-        add_filter( 'template_include', array( $this, 'load_artist_link_page_template' ), 10 );
+		if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+			add_filter( 'template_include', array( $this, 'load_artist_link_page_template' ), 10 );
+		}
         add_filter( 'extrachill_template_archive', array( $this, 'load_artist_profile_archive_template' ), 10 );
     }
 

--- a/inc/core/filters/create.php
+++ b/inc/core/filters/create.php
@@ -162,6 +162,9 @@ function ec_create_link_page( $artist_id, $force = false ) {
 			);
 		}
 	}
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		return ec_create_artist_link_page_with_external_runtime( $artist_id, $owner_reference, $link_page_title, $artist_profile_slug, $previous_link_page_id, $force );
+	}
 
 	$new_link_page_id = wp_insert_post(
 		array(
@@ -287,6 +290,70 @@ function ec_create_link_page( $artist_id, $force = false ) {
     do_action( 'ec_link_page_created', $new_link_page_id, $artist_id, $force );
 
 	return $new_link_page_id;
+}
+
+/** Compose standalone provisioning while retaining reciprocal artist metadata. */
+function ec_create_artist_link_page_with_external_runtime( $artist_id, $owner_reference, $title, $slug, $previous_link_page_id, $force ) {
+	$new_link_page_id = ec_create_owned_link_page( $owner_reference, $title, $slug, $force );
+	if ( is_wp_error( $new_link_page_id ) ) {
+		return $new_link_page_id;
+	}
+	if ( (int) $new_link_page_id === (int) $previous_link_page_id ) {
+		return (int) $new_link_page_id;
+	}
+
+	update_post_meta( $new_link_page_id, '_associated_artist_profile_id', $artist_id );
+	update_post_meta( $artist_id, '_extrch_link_page_id', $new_link_page_id );
+	$associated = (int) get_post_meta( $new_link_page_id, '_associated_artist_profile_id', true );
+	$reciprocal = (int) get_post_meta( $artist_id, '_extrch_link_page_id', true );
+	if ( $associated !== (int) $artist_id || $reciprocal !== (int) $new_link_page_id ) {
+		$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+		if ( is_wp_error( $rollback ) ) {
+			return $rollback;
+		}
+		if ( $previous_link_page_id ) {
+			$owner_restored = ec_assign_link_page_owner( $previous_link_page_id, $owner_reference );
+			$slug_restored  = wp_update_post(
+				array(
+					'ID'        => $previous_link_page_id,
+					'post_name' => $slug,
+				),
+				true
+			);
+			$stored = ec_get_stored_link_page_owner_references( $previous_link_page_id );
+			if ( is_wp_error( $owner_restored ) || is_wp_error( $slug_restored ) || array( $owner_reference ) !== $stored || $slug !== get_post_field( 'post_name', $previous_link_page_id ) ) {
+				return new WP_Error( 'link_page_association_compensation_failed', 'Link page association compensation failed. Manual reconciliation is required.', array( 'retryable' => false ) );
+			}
+		}
+		return new WP_Error( 'link_page_association_failed', 'Link page association could not be persisted. No link page was created.', array( 'retryable' => true ) );
+	}
+
+	if ( $force && $previous_link_page_id ) {
+		delete_post_meta( $previous_link_page_id, '_associated_artist_profile_id', $artist_id );
+		if ( $artist_id === (int) get_post_meta( $previous_link_page_id, '_associated_artist_profile_id', true ) ) {
+			$rollback = ec_rollback_created_link_page( $artist_id, $new_link_page_id, $previous_link_page_id );
+			if ( is_wp_error( $rollback ) ) {
+				return $rollback;
+			}
+			$owner_restored = ec_assign_link_page_owner( $previous_link_page_id, $owner_reference );
+			$slug_restored  = wp_update_post(
+				array(
+					'ID'        => $previous_link_page_id,
+					'post_name' => $slug,
+				),
+				true
+			);
+			if ( is_wp_error( $owner_restored ) || is_wp_error( $slug_restored ) || array( $owner_reference ) !== ec_get_stored_link_page_owner_references( $previous_link_page_id ) || $slug !== get_post_field( 'post_name', $previous_link_page_id ) ) {
+				return new WP_Error( 'link_page_association_compensation_failed', 'Link page association compensation failed. Manual reconciliation is required.', array( 'retryable' => false ) );
+			}
+			return new WP_Error( 'link_page_previous_detach_failed', 'The previous link page could not be detached. The original association was restored.', array( 'retryable' => true ) );
+		}
+	}
+	do_action( 'ec_link_page_created', $new_link_page_id, $artist_id, (bool) $force );
+	if ( function_exists( 'ec_purge_link_page_after_mutation' ) ) {
+		ec_purge_link_page_after_mutation( $new_link_page_id );
+	}
+	return (int) $new_link_page_id;
 }
 
 /**

--- a/inc/core/filters/data.php
+++ b/inc/core/filters/data.php
@@ -74,6 +74,10 @@ function ec_get_link_page_data( $artist_id, $link_page_id = null, $overrides = a
         return array();
     }
 
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		return ec_get_external_artist_link_page_data( $artist_id, $link_page_id, $overrides );
+	}
+
     $all_meta = get_post_meta( $link_page_id );
 
     $data = array(
@@ -201,6 +205,75 @@ function ec_get_link_page_data( $artist_id, $link_page_id = null, $overrides = a
     return apply_filters( 'extrachill_artist_get_link_page_data', $display_data, $artist_id, $link_page_id, $overrides );
 }
 
+/** Build the legacy artist response around standalone generic persistence. */
+function ec_get_external_artist_link_page_data( $artist_id, $link_page_id, $overrides = array() ) {
+	$persistence = ec_read_link_page_persistence( $link_page_id );
+	if ( is_wp_error( $persistence ) ) {
+		return array();
+	}
+	$socials = get_post_meta( $artist_id, '_artist_profile_social_links', true );
+	$socials = is_array( $socials ) ? $socials : array();
+	$css_vars = $persistence['css_vars'];
+	$raw_fonts = array(
+		'title_font' => $css_vars['--link-page-title-font-family'] ?? '',
+		'body_font'  => $css_vars['--link-page-body-font-family'] ?? '',
+	);
+	if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
+		$css_vars = ExtraChillArtistPlatform_Fonts::instance()->process_font_css_vars( $css_vars );
+	}
+	$settings = array_merge(
+		$persistence['settings'],
+		array(
+			'subscribe_display_mode' => get_post_meta( $link_page_id, '_link_page_subscribe_display_mode', true ) ?: 'icon_modal',
+			'subscribe_description'  => (string) get_post_meta( $link_page_id, '_link_page_subscribe_description', true ),
+			'profile_image_id'       => get_post_thumbnail_id( $artist_id ) ?: '',
+		)
+	);
+	$data = array(
+		'display_title' => ! empty( $overrides['artist_profile_title'] ) ? $overrides['artist_profile_title'] : (string) get_the_title( $artist_id ),
+		'bio' => ! empty( $overrides['link_page_bio_text'] ) ? $overrides['link_page_bio_text'] : $persistence['bio'],
+		'profile_img_url' => ! empty( $overrides['profile_img_url'] ) ? $overrides['profile_img_url'] : ( get_the_post_thumbnail_url( $artist_id, 'large' ) ?: '' ),
+		'social_links' => isset( $overrides['social_links'] ) ? $overrides['social_links'] : $socials,
+		'socials' => $socials,
+		'link_sections' => $persistence['link_sections'],
+		'css_vars' => $css_vars,
+		'background_type' => $css_vars['--link-page-background-type'] ?? 'color',
+		'background_style' => '',
+		'powered_by' => true,
+		'artist_id' => (int) $artist_id,
+		'link_page_id' => (int) $link_page_id,
+		'profile_img_shape' => $settings['profile_image_shape'],
+		'_link_page_social_icons_position' => $settings['social_icons_position'],
+		'_link_page_subscribe_display_mode' => $settings['subscribe_display_mode'],
+		'_link_page_subscribe_description' => $settings['subscribe_description'],
+		'_actual_link_page_id_for_template' => (int) $link_page_id,
+		'artist_profile' => get_post( $artist_id ),
+		'settings' => $settings,
+		'links' => $persistence['links'],
+		'raw_font_values' => $raw_fonts,
+		'background_image_id' => $persistence['background_image_id'],
+		'background_image_url' => $persistence['background_image_url'],
+	);
+	if ( isset( $overrides['artist_profile_social_links_json'] ) ) {
+		$decoded = json_decode( $overrides['artist_profile_social_links_json'], true );
+		if ( is_array( $decoded ) ) {
+			$data['social_links'] = $decoded;
+			$data['socials']      = $decoded;
+		}
+	}
+	if ( isset( $overrides['link_page_links_json'] ) ) {
+		$decoded = json_decode( $overrides['link_page_links_json'], true );
+		if ( is_array( $decoded ) ) {
+			$data['links']         = $decoded;
+			$data['link_sections'] = isset( $decoded[0]['links'] ) || empty( $decoded ) ? $decoded : array( array( 'section_title' => '', 'links' => $decoded ) );
+		}
+	}
+	if ( isset( $overrides['css_vars'] ) ) {
+		$data['css_vars'] = is_array( $overrides['css_vars'] ) ? $overrides['css_vars'] : array();
+	}
+	return apply_filters( 'extrachill_artist_get_link_page_data', $data, $artist_id, $link_page_id, $overrides );
+}
+
 /**
  * Single source of truth for artist profile data.
  * Centralizes meta access, normalization, and derived display fields.
@@ -272,6 +345,7 @@ function ec_get_artist_profile_data( $artist_id, $overrides = array() ) {
     return $data;
 }
 
+if ( ( ! function_exists( 'extrachill_artist_platform_uses_external_link_pages_runtime' ) || ! extrachill_artist_platform_uses_external_link_pages_runtime() ) && ! function_exists( 'ec_generate_css_variables_style_block' ) ) {
 function ec_generate_css_variables_style_block( $css_vars, $element_id = 'link-page-custom-vars' ) {
     if ( empty( $css_vars ) || ! is_array( $css_vars ) ) {
         return '';
@@ -286,6 +360,7 @@ function ec_generate_css_variables_style_block( $css_vars, $element_id = 'link-p
     $output .= '}</style>';
 
     return $output;
+}
 }
 
 function ec_render_single_link( $link_data, $args = array() ) {

--- a/inc/link-pages/artist-owner-operations.php
+++ b/inc/link-pages/artist-owner-operations.php
@@ -88,3 +88,127 @@ function ec_artist_link_page_operation_save( $resolved, $data ) {
 
 	return ec_artist_link_page_operation_read( $resolved );
 }
+
+/**
+ * Execute an Artist mutation under the exact associated Link Page lock.
+ *
+ * Standalone supplies the advisory scope. Rolling fallback uses an equivalent
+ * request-local guard so current production does not gain a hard dependency.
+ *
+ * @param int      $artist_id        Artist profile ID.
+ * @param callable $callback         Mutation callback receiving the Link Page ID.
+ * @param bool     $require_link_page Whether absence should retain the historical error.
+ * @return mixed|WP_Error
+ */
+function ec_artist_with_link_page_lock( $artist_id, $callback, $require_link_page = false ) {
+	if ( ! is_callable( $callback ) ) {
+		return new WP_Error( 'invalid_artist_link_page_callback', 'The Artist Link Page mutation callback is invalid.' );
+	}
+	if ( function_exists( 'ec_with_link_page_storage_blog' ) && function_exists( 'ec_get_link_page_storage_blog_id' ) ) {
+		return ec_with_link_page_storage_blog(
+			static function () use ( $artist_id, $callback, $require_link_page ) {
+				return ec_artist_with_link_page_lock_on_storage( $artist_id, $callback, $require_link_page );
+			}
+		);
+	}
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+	$did_switch     = $artist_blog_id && get_current_blog_id() !== $artist_blog_id;
+	if ( $did_switch && ( ! switch_to_blog( $artist_blog_id ) || get_current_blog_id() !== $artist_blog_id ) ) {
+		return new WP_Error( 'artist_blog_switch_failed', 'The Artist mutation could not enter the Artist site.' );
+	}
+	try {
+		return ec_artist_with_link_page_lock_on_storage( $artist_id, $callback, $require_link_page );
+	} finally {
+		if ( $did_switch ) {
+			restore_current_blog();
+		}
+	}
+}
+
+/**
+ * Resolve, lock, revalidate, and mutate from canonical storage context.
+ *
+ * @param int      $artist_id        Artist profile ID.
+ * @param callable $callback         Mutation callback.
+ * @param bool     $require_link_page Whether the Link Page is required.
+ * @return mixed|WP_Error
+ */
+function ec_artist_with_link_page_lock_on_storage( $artist_id, $callback, $require_link_page = false ) {
+	if ( ! is_callable( $callback ) ) {
+		return new WP_Error( 'invalid_artist_link_page_callback', 'The Artist Link Page mutation callback is invalid.' );
+	}
+	$artist_id    = absint( $artist_id );
+	$link_page_id = 0;
+	$reference    = function_exists( 'ec_artist_link_page_owner_reference' ) ? ec_artist_link_page_owner_reference( $artist_id ) : null;
+	if ( ! is_wp_error( $reference ) && $reference && function_exists( 'ec_get_link_page_id_for_owner' ) ) {
+		$resolved = ec_get_link_page_id_for_owner( $reference );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		$link_page_id = (int) $resolved;
+	} elseif ( function_exists( 'ec_get_reciprocal_link_page_id' ) ) {
+		$resolved = ec_get_reciprocal_link_page_id( $artist_id, false );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
+		}
+		$link_page_id = (int) $resolved;
+	} elseif ( function_exists( 'ec_get_link_page_for_artist' ) ) {
+		$link_page_id = (int) ec_get_link_page_for_artist( $artist_id );
+	}
+	if ( $require_link_page && ! $link_page_id ) {
+		return new WP_Error( 'no_link_page', 'No link page exists for this artist.' );
+	}
+	$locked_callback = static function () use ( $artist_id, $link_page_id, $reference, $callback ) {
+		if ( $link_page_id ) {
+			if ( (int) get_post_meta( $link_page_id, '_associated_artist_profile_id', true ) !== $artist_id ) {
+				return new WP_Error( 'artist_link_page_owner_mismatch', 'The Link Page no longer belongs to this artist.' );
+			}
+			if ( $reference && ! is_wp_error( $reference ) && function_exists( 'ec_get_link_page_owner' ) ) {
+				$owner = ec_get_link_page_owner( $link_page_id );
+				if ( is_wp_error( $owner ) || $owner['reference'] !== $reference ) {
+					return new WP_Error( 'artist_link_page_owner_mismatch', 'The canonical Link Page owner changed before the mutation.' );
+				}
+			}
+		}
+		return call_user_func( $callback, $link_page_id );
+	};
+	if ( $link_page_id && function_exists( 'ec_with_link_page_lock_scope' ) ) {
+		return ec_with_link_page_lock_scope( $link_page_id, $locked_callback, 'separate' );
+	}
+	$scope = $GLOBALS['ec_artist_link_page_local_lock'] ?? null;
+	$key   = $artist_id . ':' . $link_page_id;
+	if ( $scope && $scope !== $key ) {
+		return new WP_Error( 'link_page_lock_scope_conflict', 'A different Artist Link Page mutation is already active.' );
+	}
+	$outer = ! $scope;
+	if ( $outer ) {
+		$GLOBALS['ec_artist_link_page_local_lock'] = $key;
+	}
+	try {
+		return $locked_callback();
+	} finally {
+		if ( $outer ) {
+			unset( $GLOBALS['ec_artist_link_page_local_lock'] );
+		}
+	}
+}
+
+/**
+ * Complete a successful owner-only mutation that changes public Link Page output.
+ *
+ * @param int $artist_id Artist profile ID.
+ * @return bool
+ */
+function ec_artist_link_page_complete_owner_save( $artist_id ) {
+	$result = ec_artist_with_link_page_lock(
+		$artist_id,
+		static function ( $link_page_id ) {
+			if ( ! $link_page_id ) {
+				return false;
+			}
+			do_action( 'ec_link_page_save', $link_page_id );
+			return true;
+		}
+	);
+	return ! is_wp_error( $result ) && true === $result;
+}

--- a/inc/link-pages/artist-public-runtime-adapter.php
+++ b/inc/link-pages/artist-public-runtime-adapter.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Artist projection and compatibility adapter for the standalone public runtime.
+ *
+ * @package ExtraChillArtistPlatform
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Return an artist projection for a supported Link Page owner.
+ *
+ * @param array $context Public runtime context.
+ * @return array|null
+ */
+function ec_artist_link_page_public_projection_provider( $context ) {
+	$owner          = $context['owner'];
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : get_current_blog_id();
+	if ( 'post' !== $owner['kind'] || $artist_blog_id !== (int) $owner['blog_id'] || 'artist_profile' !== $owner['subtype'] ) {
+		return null;
+	}
+
+	$artist_id = (int) $owner['object_id'];
+	$artist    = get_post( $artist_id );
+	if ( ! $artist || 'artist_profile' !== $artist->post_type || 'publish' !== $artist->post_status ) {
+		return new WP_Error( 'link_page_public_owner_unavailable', 'The Link Page public owner is unavailable.', array( 'status' => 404 ) );
+	}
+	$link_page_id    = (int) $context['link_page_id'];
+	$data            = ec_get_link_page_data( $artist_id, $link_page_id );
+	$artist_site_url = ec_get_site_url( 'artist' );
+	$api_base        = $artist_site_url . '/wp-json/extrachill/v1';
+	$seo             = extrachill_artist_link_page_seo_context( $artist_id, $link_page_id );
+
+	return array(
+		'display_title'         => (string) $data['display_title'],
+		'bio'                   => (string) $data['bio'],
+		'profile_img_url'       => (string) $data['profile_img_url'],
+		'social_links'          => $data['social_links'],
+		'social_renderer'       => 'ec_artist_link_page_render_socials',
+		'management_url'        => $artist_site_url . '/manage-link-page/?artist_id=' . $artist_id,
+		'body_attributes'       => array(
+			'data-extrch-artist-id'           => (string) $artist_id,
+			'data-extrch-permissions-api-url' => $api_base . '/artists/' . $artist_id . '/permissions',
+			'data-extrch-token-handoff-url'   => $artist_site_url . '/wp-admin/admin-post.php?action=ec_link_token_handoff',
+			'data-extrch-subscribe-api-url'   => $api_base . '/artists/' . $artist_id . '/subscribe',
+		),
+		'seo'                   => $seo,
+		'tracking_url'          => $api_base . '/analytics/click',
+		'css_vars'              => $data['css_vars'],
+		'components'            => array(
+			'head'           => array( 'ec_artist_link_page_render_tracking_head' ),
+			'body_start'     => array( 'ec_artist_link_page_render_tracking_body' ),
+			'header_actions' => 'icon_modal' === $data['_link_page_subscribe_display_mode'] ? array( 'ec_artist_link_page_render_subscribe_trigger' ) : array(),
+			'after_links'    => 'disabled' === $data['_link_page_subscribe_display_mode'] ? array() : array( 'ec_artist_link_page_render_subscription' ),
+		),
+		'assets'                => 'ec_artist_link_page_enqueue_asset_extensions',
+		'legacy_head_arguments' => array( $artist_id ),
+	);
+}
+
+/** Preserve the historical public query variable. */
+function ec_artist_link_page_public_query_var() {
+	return 'artist_link_page';
+}
+
+/**
+ * Preserve historical Artist public query variables.
+ *
+ * @param string[] $vars Public query variables.
+ * @return string[]
+ */
+function ec_artist_link_page_public_query_vars( $vars ) {
+	return array_values( array_unique( array_merge( $vars, array( 'artist_link_page', 'dev_view_link_page', 'artist_id' ) ) ) );
+}
+
+/**
+ * Preserve historical Artist route exclusions.
+ *
+ * @param string[] $excluded Public route exclusions.
+ * @return string[]
+ */
+function ec_artist_link_page_public_exclusions( $excluded ) {
+	return array_values( array_unique( array_merge( $excluded, array( 'manage-artist', 'manage-link-page', 'join' ) ) ) );
+}
+
+/**
+ * Project the historical join redirect without teaching generic routing its policy.
+ *
+ * @param mixed  $route Existing special route projection.
+ * @param string $path  Requested public path.
+ * @return mixed
+ */
+function ec_artist_link_page_public_special_route( $route, $path ) {
+	if ( 'join' !== $path ) {
+		return $route;
+	}
+	return array(
+		'url'    => ec_get_site_url( 'artist' ) . '/login/?from_join=true',
+		'status' => 301,
+		'safe'   => false,
+	);
+}
+
+/**
+ * Render artist socials through the retained Artist Platform template contract.
+ *
+ * @param array  $social_links Artist social projections.
+ * @param string $position     Social icon position.
+ * @return string
+ */
+function ec_artist_link_page_render_socials( $social_links, $position ) {
+	return ec_render_social_icons_container( $social_links, $position );
+}
+
+/** Render the historical subscription bell in the header action slot. */
+function ec_artist_link_page_render_subscribe_trigger() {
+	return '<button class="extrch-share-trigger extrch-subscribe-icon-trigger extrch-bell-page-trigger" aria-label="Subscribe to this artist"><i class="fas fa-bell"></i></button>';
+}
+
+/**
+ * Render the configured artist subscription component.
+ *
+ * @param array $context    Public runtime context.
+ * @param array $projection Artist public projection.
+ * @return string
+ */
+function ec_artist_link_page_render_subscription( $context, $projection ) {
+	$artist_id = (int) $context['owner']['object_id'];
+	$data      = ec_get_link_page_data( $artist_id, (int) $context['link_page_id'] );
+	$template  = 'inline_form' === $data['_link_page_subscribe_display_mode'] ? 'subscribe-inline-form' : 'subscribe-modal';
+	return ec_render_template(
+		$template,
+		array(
+			'artist_id'         => $artist_id,
+			'data'              => $data,
+			'subscribe_api_url' => $projection['body_attributes']['data-extrch-subscribe-api-url'],
+		)
+	);
+}
+
+/**
+ * Enqueue only artist-owned public asset extensions.
+ *
+ * @param array $context Public runtime context.
+ * @return true
+ */
+function ec_artist_link_page_enqueue_asset_extensions( $context ) {
+	foreach ( array(
+		'extrch-subscribe'   => 'inc/link-pages/live/assets/js/link-page-subscribe.js',
+		'extrch-edit-button' => 'inc/link-pages/live/assets/js/link-page-edit-button.js',
+	) as $handle => $path ) {
+		$file = EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . $path;
+		if ( file_exists( $file ) ) {
+			wp_enqueue_script( $handle, EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . $path, array(), filemtime( $file ), true );
+		}
+	}
+	if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
+		$data    = ec_get_link_page_data( (int) $context['owner']['object_id'], (int) $context['link_page_id'] );
+		$values  = array_filter( array( $data['raw_font_values']['title_font'] ?? '', $data['raw_font_values']['body_font'] ?? '' ) );
+		$manager = ExtraChillArtistPlatform_Fonts::instance();
+		$url     = $manager->get_google_fonts_url( $values );
+		$css     = $manager->get_local_fonts_css( $values );
+		if ( $url ) {
+			wp_enqueue_style( 'extrch-link-page-artist-fonts', $url, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Google Fonts URLs are immutable for their family query.
+		}
+		if ( $css ) {
+			wp_add_inline_style( 'extrch-link-page', $css );
+		}
+	}
+	return true;
+}
+
+/** Render the network-wide GTM head snippet retained by artist pages. */
+function ec_artist_link_page_render_tracking_head() {
+	return '<!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({\'gtm.start\':new Date().getTime(),event:\'gtm.js\'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!=\'dataLayer\'?\'&l=\'+l:\'\';j.async=true;j.src=\'https://www.googletagmanager.com/gtm.js?id=\'+i+dl;f.parentNode.insertBefore(j,f);})(window,document,\'script\',\'dataLayer\',\'GTM-NXKDLFD\');</script><!-- End Google Tag Manager -->';
+}
+
+/** Render the network-wide GTM body fallback retained by artist pages. */
+function ec_artist_link_page_render_tracking_body() {
+	return '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NXKDLFD" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>';
+}
+
+/**
+ * Build artist-owned SEO and schema projection data.
+ *
+ * @param int $artist_id    Artist profile ID.
+ * @param int $link_page_id Link Page ID.
+ * @return array
+ */
+function extrachill_artist_link_page_seo_context( $artist_id, $link_page_id ) {
+	$artist = get_post( $artist_id );
+	if ( ! $artist ) {
+		return array();
+	}
+	$artist_data = ec_get_artist_profile_data( $artist_id );
+	$canonical   = ec_get_link_page_public_url( $link_page_id );
+	$description = wp_strip_all_tags( $artist->post_excerpt ? $artist->post_excerpt : $artist->post_content );
+	if ( strlen( $description ) > 160 ) {
+		$description = substr( $description, 0, 157 );
+		$space       = strrpos( $description, ' ' );
+		$description = ( false === $space ? $description : substr( $description, 0, $space ) ) . '...';
+	}
+	if ( '' === $description ) {
+		$description = sprintf( '%s — all important links in one place on Extra Chill.', $artist->post_title );
+	}
+	$profile_url = get_permalink( $artist_id );
+	$music_group = array(
+		'@type' => 'MusicGroup',
+		'@id'   => $profile_url . '#musicgroup',
+		'name'  => $artist->post_title,
+		'url'   => $profile_url,
+	);
+	foreach ( array(
+		'bio'               => 'description',
+		'genre'             => 'genre',
+		'profile_image_url' => 'image',
+	) as $source => $target ) {
+		if ( ! empty( $artist_data[ $source ] ) ) {
+			$music_group[ $target ] = 'bio' === $source ? wp_strip_all_tags( $artist_data[ $source ] ) : $artist_data[ $source ];
+		}
+	}
+	$same_as = array_filter( array( $artist_data['website_url'] ?? '', $artist_data['spotify_url'] ?? '', $artist_data['apple_music_url'] ?? '', $artist_data['bandcamp_url'] ?? '' ) );
+	foreach ( $artist_data['social_links'] ?? array() as $social ) {
+		if ( ! empty( $social['url'] ) ) {
+			$same_as[] = $social['url'];
+		}
+	}
+	if ( $same_as ) {
+		$music_group['sameAs'] = array_values( array_unique( $same_as ) );
+	}
+	return array(
+		'title'       => $artist->post_title . ' | extrachill.link',
+		'description' => $description,
+		'canonical'   => $canonical,
+		'image'       => $artist_data['profile_image_url'] ?? '',
+		'image_alt'   => ! empty( $artist_data['profile_image_id'] ) ? ( get_post_meta( $artist_data['profile_image_id'], '_wp_attachment_image_alt', true ) ? get_post_meta( $artist_data['profile_image_id'], '_wp_attachment_image_alt', true ) : $artist->post_title ) : $artist->post_title,
+		'og_type'     => 'profile',
+		'schema'      => array(
+			$music_group,
+			array(
+				'@type'      => 'ProfilePage',
+				'@id'        => $canonical . '#profilepage',
+				'url'        => $canonical,
+				'name'       => $artist->post_title,
+				'mainEntity' => array( '@id' => $profile_url . '#musicgroup' ),
+			),
+		),
+	);
+}
+
+/** Preserve legacy defaults globals while standalone owns their implementation. */
+function ec_get_link_page_defaults() {
+	return ec_link_page_defaults();
+}
+
+/**
+ * Return one legacy defaults category from standalone storage.
+ *
+ * @param string $category Defaults category.
+ * @return array
+ */
+function ec_get_link_page_defaults_for( $category ) {
+	return ec_link_page_defaults_for( $category );
+}
+
+/**
+ * Return one legacy default value from standalone storage.
+ *
+ * @param string $category Defaults category.
+ * @param string $key      Defaults key.
+ * @param mixed  $fallback Fallback value.
+ * @return mixed
+ */
+function ec_get_link_page_default( $category, $key, $fallback = null ) {
+	return ec_link_page_default( $category, $key, $fallback );
+}
+
+/**
+ * Preserve the historical head function for direct external consumers.
+ *
+ * @param int $artist_id    Artist profile ID.
+ * @param int $link_page_id Link Page ID.
+ * @return void
+ */
+function extrachill_artist_link_page_custom_head( $artist_id, $link_page_id ) {
+	$projection = ec_get_link_page_public_projection( $link_page_id );
+	$data       = ec_read_link_page_persistence( $link_page_id );
+	if ( ! is_wp_error( $projection ) && ! is_wp_error( $data ) ) {
+		$projection = ec_prepare_link_page_public_render( $projection, $data );
+	}
+	if ( ! is_wp_error( $projection ) && ! is_wp_error( $data ) ) {
+		ec_render_link_page_public_head( $link_page_id, $data, $projection );
+	}
+}

--- a/inc/link-pages/runtime-handoff.php
+++ b/inc/link-pages/runtime-handoff.php
@@ -8,6 +8,27 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Resolve the canonical Link Page storage blog through the platform site map.
+ *
+ * @param int $blog_id Default storage blog ID.
+ * @return int
+ */
+function ec_artist_link_page_storage_blog_id( $blog_id ) {
+	$artist_blog_id = function_exists( 'ec_get_blog_id' ) ? (int) ec_get_blog_id( 'artist' ) : 0;
+	return $artist_blog_id > 0 ? $artist_blog_id : $blog_id;
+}
+
+/** Register canonical storage before either runtime can initialize or activate. */
+function extrachill_artist_platform_register_link_page_storage() {
+	static $registered = false;
+	if ( ! $registered ) {
+		add_filter( 'ec_link_page_storage_blog_id', 'ec_artist_link_page_storage_blog_id' );
+		$registered = true;
+	}
+}
+add_action( 'plugins_loaded', 'extrachill_artist_platform_register_link_page_storage', 1 );
+
+/**
  * Return whether WordPress is configured to load the standalone runtime.
  *
  * This reads configuration instead of runtime symbols because Artist Platform
@@ -42,33 +63,178 @@ if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
  */
 function extrachill_artist_platform_link_pages_runtime_signatures() {
 	return array(
-		'ec_link_page_owner_compatibility_registry'           => array( 'total' => 0, 'required' => 0 ),
-		'ec_register_link_page_owner_compatibility_provider' => array( 'total' => 3, 'required' => 2 ),
-		'ec_parse_link_page_owner_reference'                  => array( 'total' => 1, 'required' => 1 ),
-		'ec_format_link_page_owner_reference'                 => array( 'total' => 1, 'required' => 1 ),
-		'ec_normalize_link_page_owner_reference'              => array( 'total' => 1, 'required' => 1 ),
-		'ec_get_stored_link_page_owner_references'            => array( 'total' => 1, 'required' => 1 ),
-		'ec_validate_link_page_owner_compatibility_claim'     => array( 'total' => 3, 'required' => 3 ),
-		'ec_restore_link_page_owner_provider_context'         => array( 'total' => 3, 'required' => 3 ),
-		'ec_invoke_link_page_owner_compatibility_provider'    => array( 'total' => 3, 'required' => 3 ),
-		'ec_collect_raw_link_page_owner_compatibility_claims' => array( 'total' => 2, 'required' => 2 ),
-		'ec_reconcile_link_page_owner_candidate'              => array( 'total' => 2, 'required' => 2 ),
-		'ec_collect_link_page_owner_compatibility_claims'     => array( 'total' => 2, 'required' => 2 ),
-		'ec_get_link_page_owner'                              => array( 'total' => 1, 'required' => 1 ),
-		'ec_get_link_page_id_for_owner'                       => array( 'total' => 2, 'required' => 1 ),
-		'ec_validate_link_page_owner_candidate_ids'           => array( 'total' => 1, 'required' => 1 ),
-		'ec_assign_link_page_owner'                           => array( 'total' => 3, 'required' => 2 ),
-		'ec_compensate_link_page_owner_assignment'            => array( 'total' => 4, 'required' => 4 ),
-		'ec_halt_link_page_owner_backfill'                    => array( 'total' => 4, 'required' => 4 ),
-		'ec_backfill_link_page_owner_references'              => array( 'total' => 2, 'required' => 0 ),
-		'ec_link_page_operation_provider_registry'            => array( 'total' => 0, 'required' => 0 ),
-		'ec_register_link_page_operation_provider'            => array( 'total' => 3, 'required' => 2 ),
-		'ec_resolve_link_page_operation_target'               => array( 'total' => 1, 'required' => 1 ),
-		'ec_invoke_link_page_operation_callback'              => array( 'total' => 2, 'required' => 2 ),
-		'ec_get_link_page_operation_provider'                 => array( 'total' => 1, 'required' => 1 ),
-		'ec_prepare_link_page_operation'                      => array( 'total' => 2, 'required' => 2 ),
-		'ec_read_link_page'                                   => array( 'total' => 1, 'required' => 1 ),
-		'ec_save_link_page'                                   => array( 'total' => 2, 'required' => 2 ),
+		'ec_link_page_owner_compatibility_registry'        => array(
+			'total'    => 0,
+			'required' => 0,
+		),
+		'ec_register_link_page_owner_compatibility_provider' => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_parse_link_page_owner_reference'               => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_format_link_page_owner_reference'              => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_normalize_link_page_owner_reference'           => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_get_stored_link_page_owner_references'         => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_validate_link_page_owner_compatibility_claim'  => array(
+			'total'    => 3,
+			'required' => 3,
+		),
+		'ec_restore_link_page_owner_provider_context'      => array(
+			'total'    => 3,
+			'required' => 3,
+		),
+		'ec_invoke_link_page_owner_compatibility_provider' => array(
+			'total'    => 3,
+			'required' => 3,
+		),
+		'ec_collect_raw_link_page_owner_compatibility_claims' => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_reconcile_link_page_owner_candidate'           => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_collect_link_page_owner_compatibility_claims'  => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_get_link_page_owner'                           => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_get_link_page_id_for_owner'                    => array(
+			'total'    => 2,
+			'required' => 1,
+		),
+		'ec_validate_link_page_owner_candidate_ids'        => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_assign_link_page_owner'                        => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_compensate_link_page_owner_assignment'         => array(
+			'total'    => 4,
+			'required' => 4,
+		),
+		'ec_halt_link_page_owner_backfill'                 => array(
+			'total'    => 4,
+			'required' => 4,
+		),
+		'ec_backfill_link_page_owner_references'           => array(
+			'total'    => 2,
+			'required' => 0,
+		),
+		'ec_link_page_operation_provider_registry'         => array(
+			'total'    => 0,
+			'required' => 0,
+		),
+		'ec_register_link_page_operation_provider'         => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_resolve_link_page_operation_target'            => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_invoke_link_page_operation_callback'           => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_get_link_page_operation_provider'              => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_prepare_link_page_operation'                   => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_read_link_page'                                => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_save_link_page'                                => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_link_page_defaults'                            => array(
+			'total'    => 0,
+			'required' => 0,
+		),
+		'ec_link_page_defaults_for'                        => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_link_page_default'                             => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_sanitize_link_page_links'                      => array(
+			'total'    => 2,
+			'required' => 1,
+		),
+		'ec_sanitize_link_page_css_vars'                   => array(
+			'total'    => 2,
+			'required' => 1,
+		),
+		'ec_sanitize_link_page_settings'                   => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_read_link_page_persistence'                    => array(
+			'total'    => 2,
+			'required' => 1,
+		),
+		'ec_save_link_page_persistence'                    => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_create_owned_link_page'                        => array(
+			'total'    => 4,
+			'required' => 3,
+		),
+		'ec_with_link_page_lock_scope'                     => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_link_page_public_projection_registry'          => array(
+			'total'    => 0,
+			'required' => 0,
+		),
+		'ec_register_link_page_public_projection_provider' => array(
+			'total'    => 3,
+			'required' => 2,
+		),
+		'ec_get_link_page_public_projection'               => array(
+			'total'    => 2,
+			'required' => 1,
+		),
+		'ec_render_link_page_public_components'            => array(
+			'total'    => 2,
+			'required' => 2,
+		),
+		'ec_get_link_page_public_url'                      => array(
+			'total'    => 1,
+			'required' => 1,
+		),
+		'ec_link_page_public_urls'                         => array(
+			'total'    => 1,
+			'required' => 1,
+		),
 	);
 }
 
@@ -88,11 +254,24 @@ function extrachill_artist_platform_validate_link_pages_runtime() {
 	if ( $external && ! defined( 'EC_LINK_PAGES_RUNTIME_API_VERSION' ) ) {
 		return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not declare its API version.' );
 	}
-	if ( defined( 'EC_LINK_PAGES_RUNTIME_API_VERSION' ) && '1' !== EC_LINK_PAGES_RUNTIME_API_VERSION ) {
+	if ( $external && '2' !== EC_LINK_PAGES_RUNTIME_API_VERSION ) {
 		return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime API version is not supported.' );
 	}
+	if ( $external ) {
+		if ( ! function_exists( 'ec_validate_link_pages_runtime' ) ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not expose complete readiness validation.' );
+		}
+		$standalone_valid = ec_validate_link_pages_runtime();
+		if ( is_wp_error( $standalone_valid ) ) {
+			return new WP_Error( 'extrachill_link_pages_runtime_incompatible', $standalone_valid->get_error_message(), array( 'cause' => $standalone_valid->get_error_code() ) );
+		}
+	}
 
-	foreach ( extrachill_artist_platform_link_pages_runtime_signatures() as $function => $signature ) {
+	$signatures = extrachill_artist_platform_link_pages_runtime_signatures();
+	if ( ! $external ) {
+		$signatures = array_slice( $signatures, 0, 27, true );
+	}
+	foreach ( $signatures as $function => $signature ) {
 		if ( ! function_exists( $function ) ) {
 			return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not load its complete generic API.' );
 		}
@@ -140,6 +319,15 @@ function extrachill_artist_platform_register_link_page_adapters() {
 
 	require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-compatibility.php';
 	require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-owner-operations.php';
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/artist-public-runtime-adapter.php';
+	}
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		add_filter( 'ec_link_page_public_query_var', 'ec_artist_link_page_public_query_var' );
+		add_filter( 'ec_link_page_public_query_vars', 'ec_artist_link_page_public_query_vars' );
+		add_filter( 'ec_link_page_public_exclusions', 'ec_artist_link_page_public_exclusions' );
+		add_filter( 'ec_link_page_public_special_route', 'ec_artist_link_page_public_special_route', 10, 2 );
+	}
 
 	$owner_result = ec_register_link_page_owner_compatibility_provider( 'artist-platform', 'ec_artist_link_page_owner_compatibility_provider' );
 	if ( is_wp_error( $owner_result ) ) {
@@ -148,6 +336,12 @@ function extrachill_artist_platform_register_link_page_adapters() {
 	$operation_result = ec_register_link_page_operation_provider( 'artist-platform', 'ec_artist_link_page_operation_provider' );
 	if ( is_wp_error( $operation_result ) ) {
 		return $operation_result;
+	}
+	if ( extrachill_artist_platform_uses_external_link_pages_runtime() ) {
+		$projection_result = ec_register_link_page_public_projection_provider( 'artist-platform', 'ec_artist_link_page_public_projection_provider' );
+		if ( is_wp_error( $projection_result ) ) {
+			return $projection_result;
+		}
 	}
 
 	$registered = true;
@@ -163,6 +357,7 @@ function extrachill_artist_platform_register_link_page_adapters() {
  * @return true|WP_Error
  */
 function extrachill_artist_platform_boot_link_pages_runtime() {
+	extrachill_artist_platform_register_link_page_storage();
 	if ( ! extrachill_artist_platform_uses_external_link_pages_runtime() ) {
 		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/owner-reference.php';
 		require_once EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'inc/link-pages/operations.php';

--- a/inc/link-pages/runtime-handoff.php
+++ b/inc/link-pages/runtime-handoff.php
@@ -18,11 +18,14 @@ function ec_artist_link_page_storage_blog_id( $blog_id ) {
 	return $artist_blog_id > 0 ? $artist_blog_id : $blog_id;
 }
 
-/** Register canonical storage before either runtime can initialize or activate. */
+/** Seed canonical storage once before either runtime can initialize or activate. */
 function extrachill_artist_platform_register_link_page_storage() {
 	static $registered = false;
 	if ( ! $registered ) {
-		add_filter( 'ec_link_page_storage_blog_id', 'ec_artist_link_page_storage_blog_id' );
+		$blog_id = ec_artist_link_page_storage_blog_id( 0 );
+		if ( $blog_id > 0 && get_site( $blog_id ) && ! (int) get_site_option( 'ec_link_page_storage_blog_id', 0 ) ) {
+			update_site_option( 'ec_link_page_storage_blog_id', $blog_id );
+		}
 		$registered = true;
 	}
 }
@@ -71,6 +74,7 @@ function extrachill_artist_platform_link_pages_runtime_signatures() {
 			'total'    => 3,
 			'required' => 2,
 		),
+		'ec_can_register_link_page_owner_compatibility_provider' => array( 'total' => 3, 'required' => 2 ),
 		'ec_parse_link_page_owner_reference'               => array(
 			'total'    => 1,
 			'required' => 1,
@@ -147,6 +151,7 @@ function extrachill_artist_platform_link_pages_runtime_signatures() {
 			'total'    => 3,
 			'required' => 2,
 		),
+		'ec_can_register_link_page_operation_provider'     => array( 'total' => 3, 'required' => 2 ),
 		'ec_resolve_link_page_operation_target'            => array(
 			'total'    => 1,
 			'required' => 1,
@@ -207,6 +212,9 @@ function extrachill_artist_platform_link_pages_runtime_signatures() {
 			'total'    => 4,
 			'required' => 3,
 		),
+		'ec_provision_owned_link_page'                     => array( 'total' => 5, 'required' => 3 ),
+		'ec_invoke_link_page_provision_precondition'       => array( 'total' => 2, 'required' => 2 ),
+		'ec_create_owned_link_page_unlocked'               => array( 'total' => 4, 'required' => 3 ),
 		'ec_with_link_page_lock_scope'                     => array(
 			'total'    => 3,
 			'required' => 2,
@@ -219,6 +227,11 @@ function extrachill_artist_platform_link_pages_runtime_signatures() {
 			'total'    => 3,
 			'required' => 2,
 		),
+		'ec_can_register_link_page_public_projection_provider' => array( 'total' => 3, 'required' => 2 ),
+		'ec_sanitize_link_page_public_projection_snapshot' => array( 'total' => 1, 'required' => 1 ),
+		'ec_save_link_page_public_projection_snapshot'     => array( 'total' => 3, 'required' => 3 ),
+		'ec_read_link_page_public_projection_snapshot'     => array( 'total' => 2, 'required' => 1 ),
+		'ec_render_stored_link_page_social_links'          => array( 'total' => 1, 'required' => 1 ),
 		'ec_get_link_page_public_projection'               => array(
 			'total'    => 2,
 			'required' => 1,
@@ -254,7 +267,7 @@ function extrachill_artist_platform_validate_link_pages_runtime() {
 	if ( $external && ! defined( 'EC_LINK_PAGES_RUNTIME_API_VERSION' ) ) {
 		return new WP_Error( 'extrachill_link_pages_runtime_incomplete', 'The configured Extra Chill Link Pages runtime did not declare its API version.' );
 	}
-	if ( $external && '2' !== EC_LINK_PAGES_RUNTIME_API_VERSION ) {
+	if ( $external && '3' !== EC_LINK_PAGES_RUNTIME_API_VERSION ) {
 		return new WP_Error( 'extrachill_link_pages_runtime_incompatible', 'The configured Extra Chill Link Pages runtime API version is not supported.' );
 	}
 	if ( $external ) {
@@ -269,6 +282,7 @@ function extrachill_artist_platform_validate_link_pages_runtime() {
 
 	$signatures = extrachill_artist_platform_link_pages_runtime_signatures();
 	if ( ! $external ) {
+		$signatures = array_diff_key( $signatures, array_flip( array( 'ec_can_register_link_page_owner_compatibility_provider', 'ec_can_register_link_page_operation_provider', 'ec_provision_owned_link_page', 'ec_invoke_link_page_provision_precondition', 'ec_create_owned_link_page_unlocked', 'ec_can_register_link_page_public_projection_provider', 'ec_sanitize_link_page_public_projection_snapshot', 'ec_save_link_page_public_projection_snapshot', 'ec_read_link_page_public_projection_snapshot', 'ec_render_stored_link_page_social_links' ) ) );
 		$signatures = array_slice( $signatures, 0, 27, true );
 	}
 	foreach ( $signatures as $function => $signature ) {

--- a/src/blocks/link-page-editor/render.php
+++ b/src/blocks/link-page-editor/render.php
@@ -4,13 +4,15 @@
  *
  * Renders the link page editor React app on the frontend.
  * Handles authentication, artist resolution, and data localization.
+ *
+ * @package ExtraChillArtistPlatform
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Authentication check
+// Authentication check.
 if ( ! is_user_logged_in() ) {
 	echo '<div class="notice notice-info">';
 	echo '<p>' . esc_html__( 'Please log in to manage your link page.', 'extrachill-artist-platform' ) . '</p>';
@@ -20,7 +22,7 @@ if ( ! is_user_logged_in() ) {
 
 $current_user_id = get_current_user_id();
 
-// Get user's artists
+// Get the user's artists.
 if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
 	echo '<div class="notice notice-error">';
 	echo '<p>' . esc_html__( 'Artist platform is not properly configured.', 'extrachill-artist-platform' ) . '</p>';
@@ -30,18 +32,7 @@ if ( ! function_exists( 'ec_get_artists_for_user' ) ) {
 
 $user_artists = ec_get_artists_for_user( $current_user_id, true );
 
-// Auto-create link pages for any artists that don't have them yet
-if ( function_exists( 'ec_create_link_page' ) && function_exists( 'ec_get_link_page_for_artist' ) ) {
-	foreach ( $user_artists as $artist_id ) {
-		$existing_link_page_id = ec_get_link_page_for_artist( $artist_id );
-		if ( ! $existing_link_page_id ) {
-			// Create link page for this artist
-			ec_create_link_page( $artist_id );
-		}
-	}
-}
-
-// No artists - show creation prompt
+// No artists: show the creation prompt.
 if ( empty( $user_artists ) ) {
 	if ( function_exists( 'ec_can_create_artist_profiles' ) && ec_can_create_artist_profiles( $current_user_id ) ) {
 		echo '<div class="notice notice-info">';
@@ -56,60 +47,61 @@ if ( empty( $user_artists ) ) {
 	return;
 }
 
-// Build user artists data for switcher (only artists with link pages)
-$user_artists_data = array();
+// Build switcher data for artists with Link Pages.
+$user_artists_data               = array();
 $user_artist_ids_with_link_pages = array();
 
 foreach ( $user_artists as $ua_id ) {
-    $artist_post = get_post( $ua_id );
-    if ( ! $artist_post || $artist_post->post_status !== 'publish' ) {
-        continue;
-    }
+	$artist_post = get_post( $ua_id );
+	if ( ! $artist_post || 'publish' !== $artist_post->post_status ) {
+		continue;
+	}
 
-    $link_page_id = function_exists( 'ec_get_link_page_for_artist' )
-        ? ec_get_link_page_for_artist( $ua_id )
-        : 0;
+	$link_page_id = function_exists( 'ec_get_link_page_for_artist' )
+		? ec_get_link_page_for_artist( $ua_id )
+		: 0;
 
-    if ( $link_page_id && get_post_status( $link_page_id ) === 'publish' ) {
-        $user_artists_data[] = array(
-            'id'   => (int) $ua_id,
-            'name' => $artist_post->post_title,
-            'slug' => $artist_post->post_name,
-        );
-        $user_artist_ids_with_link_pages[] = (int) $ua_id;
-    }
+	if ( $link_page_id && get_post_status( $link_page_id ) === 'publish' ) {
+		$user_artists_data[]               = array(
+			'id'   => (int) $ua_id,
+			'name' => $artist_post->post_title,
+			'slug' => $artist_post->post_name,
+		);
+		$user_artist_ids_with_link_pages[] = (int) $ua_id;
+	}
 }
 
-// No link pages yet for this user (should not happen due to auto-creation above)
+// Provisioning is mutation-only; rendering the editor must never write on GET.
 if ( empty( $user_artists_data ) ) {
-    echo '<div class="notice notice-error">';
-    echo '<p>' . esc_html__( 'Unable to create link page. Please try refreshing the page or contact support.', 'extrachill-artist-platform' ) . '</p>';
-    echo '</div>';
-    return;
+	echo '<div class="notice notice-info" data-link-page-setup-state="required">';
+	echo '<p>' . esc_html__( 'Your Link Page has not been provisioned yet. Complete artist setup to create it.', 'extrachill-artist-platform' ) . '</p>';
+	echo '<a href="' . esc_url( site_url( '/manage-artist/' ) ) . '" class="button-1">' . esc_html__( 'Complete Artist Setup', 'extrachill-artist-platform' ) . '</a>';
+	echo '</div>';
+	return;
 }
 
-// Get the artist to edit (prefer latest with a link page)
+// Get the artist to edit, preferring the latest with a Link Page.
 $artist_id = 0;
 if ( function_exists( 'ec_get_latest_artist_for_user' ) ) {
-    $latest_artist_id = ec_get_latest_artist_for_user( $current_user_id );
-    if ( $latest_artist_id && in_array( (int) $latest_artist_id, $user_artist_ids_with_link_pages, true ) ) {
-        $artist_id = (int) $latest_artist_id;
-    }
+	$latest_artist_id = ec_get_latest_artist_for_user( $current_user_id );
+	if ( $latest_artist_id && in_array( (int) $latest_artist_id, $user_artist_ids_with_link_pages, true ) ) {
+		$artist_id = (int) $latest_artist_id;
+	}
 }
 
 if ( ! $artist_id ) {
-    $artist_id = (int) $user_artists_data[0]['id'];
+	$artist_id = (int) $user_artists_data[0]['id'];
 }
 
 if ( ! $artist_id ) {
-    echo '<div class="notice notice-error">';
-    echo '<p>' . esc_html__( 'Could not determine which artist to edit.', 'extrachill-artist-platform' ) . '</p>';
-    echo '</div>';
-    return;
+	echo '<div class="notice notice-error">';
+	echo '<p>' . esc_html__( 'Could not determine which artist to edit.', 'extrachill-artist-platform' ) . '</p>';
+	echo '</div>';
+	return;
 }
 
 
-// Get fonts for dropdown and local font CSS for defaults
+// Get fonts for the dropdown and local default CSS.
 $fonts_data      = array();
 $local_fonts_css = '';
 if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
@@ -123,25 +115,25 @@ if ( class_exists( 'ExtraChillArtistPlatform_Fonts' ) ) {
 	);
 }
 
-// Get social link types and transform to array format for React
+// Get social link types and transform them for React.
 $social_types = array();
 if ( function_exists( 'extrachill_artist_platform_social_links' ) ) {
 	$social_manager = extrachill_artist_platform_social_links();
 	$raw_types      = $social_manager->get_supported_types();
-	
-    // Transform associative array to indexed array with id/label/icon_class for React
-    foreach ( $raw_types as $type_id => $type_data ) {
-        $icon_value = isset( $type_data['icon'] ) ? $type_data['icon'] : '';
-        $social_types[] = array(
-            'id'         => $type_id,
-            'label'      => $type_data['label'],
-            'icon_class' => $icon_value,
-        );
-    }
+
+	// Transform the associative map to indexed React options.
+	foreach ( $raw_types as $type_id => $type_data ) {
+		$icon_value     = isset( $type_data['icon'] ) ? $type_data['icon'] : '';
+		$social_types[] = array(
+			'id'         => $type_id,
+			'label'      => $type_data['label'],
+			'icon_class' => $icon_value,
+		);
+	}
 }
 
 
-// Localize configuration data
+// Localize configuration data.
 $config = array(
 	'artistId'          => (int) $artist_id,
 	'userArtists'       => $user_artists_data,
@@ -150,15 +142,15 @@ $config = array(
 	'fonts'             => $fonts_data,
 	'localFontsCss'     => $local_fonts_css,
 	'socialTypes'       => $social_types,
-'linkPageCssUrl'     => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/extrch-links.css',
-    'socialIconsCssUrl' => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/custom-social-icons.css',
-    'shareModalCssUrl'  => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/extrch-share-modal.css',
-    'fontAwesomeUrl'    => '//cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css',
-    'iconSpriteUrl'     => get_template_directory_uri() . '/assets/fonts/extrachill.svg?v=' . filemtime( get_template_directory() . '/assets/fonts/extrachill.svg' ),
+	'linkPageCssUrl'    => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/extrch-links.css',
+	'socialIconsCssUrl' => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/custom-social-icons.css',
+	'shareModalCssUrl'  => EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL . 'assets/css/extrch-share-modal.css',
+	'fontAwesomeUrl'    => '//cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css',
+	'iconSpriteUrl'     => get_template_directory_uri() . '/assets/fonts/extrachill.svg?v=' . filemtime( get_template_directory() . '/assets/fonts/extrachill.svg' ),
 );
 
 
-// Enqueue the frontend script with localized data
+// Enqueue the frontend script with localized data.
 $asset_file = include EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR . 'build/blocks/link-page-editor/view.asset.php';
 
 wp_enqueue_script(
@@ -171,11 +163,13 @@ wp_enqueue_script(
 
 wp_localize_script( 'ec-link-page-editor-frontend', 'ecLinkPageEditorConfig', $config );
 
-// Render mount point
-$wrapper_attributes = get_block_wrapper_attributes( array(
-	'class' => 'ec-link-page-editor',
-) );
+// Render the mount point.
+$wrapper_attributes = get_block_wrapper_attributes(
+	array(
+		'class' => 'ec-link-page-editor',
+	)
+);
 
-echo '<div ' . $wrapper_attributes . '>';
+echo '<div ' . $wrapper_attributes . '>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated by get_block_wrapper_attributes().
 echo '<div id="ec-link-page-editor-root" data-artist-id="' . esc_attr( $artist_id ) . '"></div>';
 echo '</div>';

--- a/tests/AbilityAuthorizationTest.php
+++ b/tests/AbilityAuthorizationTest.php
@@ -159,6 +159,28 @@ final class AbilityAuthorizationTest extends TestCase {
 		$this->assertSame( 'invalid_link_page', $result->get_error_code() );
 	}
 
+	public function test_legacy_match_cannot_override_conflicting_canonical_owner(): void {
+		$GLOBALS['ec_test']['current_user_id']    = 7;
+		$GLOBALS['ec_test']['managed_artists'][7] = array( 42 );
+		$GLOBALS['ec_test']['blogs'][4] = array(
+			'posts' => array(
+				42 => (object) array( 'ID' => 42, 'post_type' => 'artist_profile', 'post_status' => 'publish' ),
+				84 => (object) array( 'ID' => 84, 'post_type' => 'artist_profile', 'post_status' => 'publish' ),
+				99 => (object) array( 'ID' => 99, 'post_type' => 'artist_link_page', 'post_status' => 'publish' ),
+			),
+			'post_meta' => array(
+				99 => array(
+					'_associated_artist_profile_id' => 42,
+					EC_LINK_PAGE_OWNER_META_KEY     => 'post:4:artist_profile:84',
+				),
+			),
+		);
+
+		$this->assertFalse( extrachill_artist_platform_ability_link_page_belongs_to_artist( 42, 99 ) );
+		$result = extrachill_artist_platform_ability_get_link_page_data( array( 'artist_id' => 42, 'link_page_id' => 99 ) );
+		$this->assertSame( 'invalid_link_page', $result->get_error_code() );
+	}
+
 	public function test_rest_exposed_sensitive_abilities_deny_unrelated_users_before_handlers(): void {
 		$GLOBALS['ec_test']['current_user_id'] = 7;
 

--- a/tests/LinkPageOwnerReferenceTest.php
+++ b/tests/LinkPageOwnerReferenceTest.php
@@ -675,4 +675,26 @@ final class LinkPageOwnerReferenceTest extends TestCase {
 		$this->assertStringNotContainsString( 'artist', $source );
 		$this->assertStringNotContainsString( 'venue', $source );
 	}
+
+	public function test_fallback_cross_blog_mutation_uses_artist_site_guard_and_restores_context(): void {
+		$GLOBALS['ec_test']['blogs'][1] = array( 'terms' => array(), 'term_meta' => array(), 'posts' => array(), 'post_meta' => array() );
+		$this->addPost( 4, 40, 'artist_link_page', 'test-artist' );
+		update_post_meta( 40, '_associated_artist_profile_id', 20 );
+		update_post_meta( 40, EC_LINK_PAGE_OWNER_META_KEY, 'post:4:artist_profile:20' );
+		update_post_meta( 20, '_extrch_link_page_id', 40 );
+		switch_to_blog( 1 );
+		$entry_stack = $GLOBALS['_wp_switched_stack'];
+		$result = ec_artist_with_link_page_lock(
+			20,
+			static function ( $link_page_id ) {
+				return array( 'link_page_id' => $link_page_id, 'blog_id' => get_current_blog_id() );
+			},
+			true
+		);
+		$this->assertSame( array( 'link_page_id' => 40, 'blog_id' => 4 ), $result );
+		$this->assertSame( 1, get_current_blog_id() );
+		$this->assertSame( $entry_stack, $GLOBALS['_wp_switched_stack'] );
+		$this->assertArrayNotHasKey( 'ec_artist_link_page_local_lock', $GLOBALS );
+		restore_current_blog();
+	}
 }

--- a/tests/LinkPageRuntimeHandoffTest.php
+++ b/tests/LinkPageRuntimeHandoffTest.php
@@ -26,6 +26,7 @@ final class LinkPageRuntimeHandoffTest extends TestCase {
 		$this->assertSame( '_ec_link_page_owner_reference', $result['owner_meta_constant'] );
 		$this->assertSame( 1, $result['owner_providers'] );
 		$this->assertSame( 1, $result['operation_providers'] );
+		$this->assertSame( 1, $result['projection_providers'] );
 		$this->assertSame( 'external-runtime', $result['link_page_cpt_owner'] );
 		$this->assertTrue( $result['artist_profile_exists'] );
 		$this->assertSame( 'post:4:artist_profile:20', $result['legacy_owner_reference'] );
@@ -95,6 +96,12 @@ final class LinkPageRuntimeHandoffTest extends TestCase {
 		$this->assertSame( 1, $activation['owner_providers'] );
 		$this->assertSame( 1, $activation['operation_providers'] );
 		$this->assertSame( 1, $activation['flushes'] );
+		$this->assertTrue( $activation['storage_provider_before_standalone'] );
+		$this->assertSame( 4, $activation['storage_blog_id'] );
+		$site_activation = $this->runSmokeFixture( 'link-pages-real-runtime-smoke.php', 'activation-site' );
+		$this->assertTrue( $site_activation['storage_provider_before_standalone'] );
+		$this->assertSame( 4, $site_activation['storage_blog_id'] );
+		$this->assertSame( 1, $site_activation['flushes'] );
 
 		$external = $this->runSmokeFixture( 'link-pages-real-runtime-smoke.php', 'external' );
 		$this->assertFalse( $external['before_standalone'] );
@@ -105,6 +112,167 @@ final class LinkPageRuntimeHandoffTest extends TestCase {
 		$this->assertSame( 1, $external['link_registrations'] );
 		$this->assertSame( 1, $external['owner_providers'] );
 		$this->assertSame( 1, $external['operation_providers'] );
+		$this->assertSame( 1, $external['projection_providers'] );
+	}
+
+	public function test_real_combined_runtime_executes_artist_lifecycle_against_standalone(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php' );
+
+		$this->assertIsInt( $result['created'] );
+		$this->assertTrue( $result['read_shape'] );
+		$this->assertTrue( $result['saved'] );
+		$this->assertTrue( $result['owner_writes_locked'] );
+		$this->assertSame( 'Updated bio', $result['saved_bio'] );
+		$this->assertSame( 'Ability bio', $result['persisted_bio'] );
+		$this->assertSame( array( 'links' => true, 'styles' => true, 'settings' => true, 'socials' => true ), $result['ability_results'] );
+		$this->assertSame( 1, $result['social_count'] );
+		$this->assertSame( 55, $result['thumbnail'] );
+		$this->assertSame( 'Combined Artist', $result['projection_title'] );
+		$this->assertTrue( $result['projection_schema'] );
+		$this->assertSame( 'Combined Artist portrait', $result['projection_alt'] );
+		$this->assertSame( 'https://extrachill.link/combined-artist/', $result['projection_canonical'] );
+		$this->assertTrue( $result['rendered_body'] );
+		$this->assertTrue( $result['rendered_subscribe'] );
+		$this->assertTrue( $result['snapshot_parity'] );
+		$this->assertTrue( $result['head_hook'] );
+		$this->assertSame( 'https://artist.extrachill.com/login/?from_join=true', $result['join_redirect'] );
+		$this->assertIsInt( $result['forced'] );
+		$this->assertTrue( $result['legacy_detached'] );
+		$this->assertSame( 5, $result['final_hook_count'] );
+		$this->assertSame( 1, $result['delete_purge_delta'] );
+		$this->assertContains( 'https://extrachill.link/combined-artist/', $result['cache_deleted_urls'] );
+		$this->assertGreaterThanOrEqual( 7, $result['cache_action_count'] );
+		$this->assertSame( 1, $result['save_cache_delta'] );
+		$this->assertSame( 4, $result['ability_cache_delta'] );
+		$this->assertSame( 4, $result['caller_blog'] );
+		foreach ( array( 1, 7 ) as $caller_blog_id ) {
+			$this->assertSame( $result['created'], $result['cross_blog_resolution'][ $caller_blog_id ]['id'] );
+			$this->assertSame( $result['created'], $result['cross_blog_resolution'][ $caller_blog_id ]['read'] );
+			$this->assertSame( array( 'https://extrachill.link/combined-artist/' ), $result['cross_blog_resolution'][ $caller_blog_id ]['urls'] );
+			$this->assertSame( $caller_blog_id, $result['cross_blog_resolution'][ $caller_blog_id ]['caller'] );
+			$this->assertSame( 40, $result['cross_blog_resolution'][ $caller_blog_id ]['existing'] );
+		}
+	}
+
+	public function test_real_combined_runtime_compensates_force_detach_failure(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'force-failure' );
+
+		$this->assertSame( 'link_page_previous_detach_failed', $result['forced'] );
+		$this->assertSame( $result['created'], $result['force_restored_id'] );
+		$this->assertSame( 'combined-artist', $result['force_restored_slug'] );
+		$this->assertSame( 1, $result['force_new_count'] );
+		$this->assertFalse( $result['legacy_detached'] );
+		$this->assertSame( 5, $result['final_hook_count'] );
+	}
+
+	public function test_owner_save_failure_rolls_back_generic_fields_without_final_hook(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'owner-save-failure' );
+
+		$this->assertSame( 'social_failure', $result['saved'] );
+		$this->assertSame( '', $result['persisted_bio'] );
+		$this->assertSame( 0, $result['social_count'] );
+		$this->assertSame( 0, $result['final_hook_count'] );
+		$this->assertSame( 0, $result['save_cache_delta'] );
+		$this->assertSame( 0, $result['ability_cache_delta'] );
+		$this->assertTrue( $result['owner_writes_locked'] );
+		$this->assertSame( '0', (string) $result['failure_contention'] );
+	}
+
+	public function test_combined_authorized_saves_serialize_without_stale_compensation(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'contention' );
+
+		$this->assertTrue( $result['contention']['first'] );
+		$this->assertSame( '0', (string) $result['contention']['blocked'] );
+		$this->assertTrue( $result['contention']['second'] );
+		$this->assertSame( 'Second authorized save', $result['contention']['final'] );
+		$this->assertTrue( $result['owner_writes_locked'] );
+	}
+
+	public function test_failed_save_compensates_before_next_authorized_save_wins(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'interleaving-failure' );
+
+		$this->assertSame( 'social_failure', $result['saved'] );
+		$this->assertSame( '', $result['persisted_after_failed_save'] );
+		$this->assertTrue( $result['post_failure_save'] );
+		$this->assertSame( 'https://bandcamp.com/authoritative', $result['post_failure_social_url'] );
+		$this->assertSame( '0', (string) $result['failure_contention'] );
+		$this->assertTrue( $result['owner_writes_locked'] );
+	}
+
+	public function test_separate_and_combined_mutations_reject_reverse_interleaving(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'separate-contention' );
+
+		$this->assertSame( 'link_page_lock_scope_conflict', $result['separate_contention']['during_combined_social'] );
+		$this->assertSame( 'link_page_lock_scope_conflict', $result['separate_contention']['during_combined_profile'] );
+		$this->assertSame( 'link_page_lock_scope_conflict', $result['separate_contention']['during_separate'] );
+		$this->assertTrue( $result['separate_contention']['social_after'] );
+		$this->assertTrue( $result['separate_contention']['profile_after'] );
+		$this->assertTrue( $result['separate_contention']['combined_after'] );
+		$this->assertSame( 'Combined after separate release', $result['separate_contention']['final_bio'] );
+		$this->assertSame( 'https://example.com/after', $result['separate_contention']['final_social_url'] );
+		$this->assertSame( 'Profile after release', $result['separate_contention']['final_profile_title'] );
+	}
+
+	/** @dataProvider crossBlogMutationProvider */
+	public function test_cross_blog_social_mutation_uses_blog_four_lock_and_cache( $mode, $caller_blog ): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', $mode );
+		$mutation = $result['cross_blog_mutation'];
+
+		$this->assertTrue( $mutation['result'] );
+		$this->assertSame( 4, $mutation['lock_blog'] );
+		$this->assertSame( $result['created'], $mutation['lock_page'] );
+		$this->assertSame( 4, $mutation['mutation_blog'] );
+		$this->assertTrue( $mutation['profile_result'] );
+		$this->assertSame( 4, $mutation['profile_lock_blog'] );
+		$this->assertSame( $result['created'], $mutation['profile_lock_page'] );
+		$this->assertSame( 4, $mutation['profile_mutation_blog'] );
+		$this->assertSame( 4, $mutation['cache_blog'] );
+		$this->assertSame( 2, $mutation['cache_delta'] );
+		$this->assertSame( '0', (string) $mutation['contender'] );
+		$this->assertSame( $caller_blog, $mutation['caller_after'] );
+		$this->assertTrue( $mutation['stack_restored'] );
+	}
+
+	public function crossBlogMutationProvider(): array {
+		return array(
+			'blog one'   => array( 'cross-blog-1', 1 ),
+			'blog seven' => array( 'cross-blog-7', 7 ),
+		);
+	}
+
+	public function test_cross_blog_social_failure_restores_context_without_purge(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'cross-blog-failure' );
+		$mutation = $result['cross_blog_mutation'];
+
+		$this->assertSame( 'social_failure', $mutation['result'] );
+		$this->assertSame( 4, $mutation['lock_blog'] );
+		$this->assertSame( 4, $mutation['mutation_blog'] );
+		$this->assertSame( 0, $mutation['cache_delta'] );
+		$this->assertSame( '0', (string) $mutation['contender'] );
+		$this->assertSame( 7, $mutation['caller_after'] );
+		$this->assertTrue( $mutation['stack_restored'] );
+	}
+
+	public function test_orphaned_or_unpublished_owner_renders_404(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'orphan-owner' );
+
+		$this->assertSame( 'link_page_public_owner_unavailable', $result['projection_title'] );
+		$this->assertSame( 404, $result['public_status'] );
+	}
+
+	public function test_deleted_canonical_owner_metadata_renders_404(): void {
+		$result = $this->runSmokeFixture( 'combined-runtime-smoke.php', 'deleted-owner' );
+
+		$this->assertSame( 'invalid_link_page_owner_object', $result['projection_title'] );
+		$this->assertSame( 404, $result['public_status'] );
+	}
+
+	public function test_editor_get_reports_setup_without_provisioning(): void {
+		$result = $this->runSmokeFixture( 'editor-no-write-smoke.php' );
+
+		$this->assertSame( 0, $result['writes'] );
+		$this->assertTrue( $result['setup_state'] );
+		$this->assertTrue( $result['cta'] );
 	}
 
 	public function test_fallback_mode_remains_configured_without_a_hard_plugin_dependency(): void {

--- a/tests/fixtures/combined-runtime-smoke.php
+++ b/tests/fixtures/combined-runtime-smoke.php
@@ -1,0 +1,342 @@
+<?php
+
+$artist_root = dirname( __DIR__, 2 );
+$standalone  = getenv( 'LINK_PAGES_WORKTREE' ) ?: '/var/lib/datamachine/workspace/extrachill-link-pages@feat-3-public-runtime';
+
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $artist_root . '/' );
+define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_URL', 'https://artist.example/plugins/artist/' );
+
+function ec_get_blog_id( $type ) { return 'artist' === $type ? 4 : 1; }
+function ec_get_site_url( $type ) { return 'artist' === $type ? 'https://artist.extrachill.com' : 'https://extrachill.com'; }
+function get_the_title( $id ) { $post = get_post( $id ); return $post ? $post->post_title : ''; }
+function get_permalink( $id ) { return 'https://artist.extrachill.com/artists/' . get_post_field( 'post_name', $id ) . '/'; }
+function get_the_post_thumbnail_url( $id ) { $thumb = get_post_thumbnail_id( $id ); return $thumb ? wp_get_attachment_url( $thumb ) : false; }
+function get_post_thumbnail_id( $id ) { return (int) get_post_meta( $id, '_thumbnail_id', true ); }
+function set_post_thumbnail( $id, $thumb ) { return update_post_meta( $id, '_thumbnail_id', (int) $thumb ); }
+function delete_post_thumbnail( $id ) { return delete_post_meta( $id, '_thumbnail_id' ); }
+function wp_get_attachment_image_url( $id ) { return wp_get_attachment_url( $id ); }
+function get_post_status( $id ) { $post = get_post( $id ); return $post ? $post->post_status : false; }
+function maybe_unserialize( $value ) { return $value; }
+function get_current_user_id() { return 7; }
+function ec_user_can() { return true; }
+function ec_render_template( $template, $args = array() ) {
+	if ( 'link-section' === $template ) {
+		$output = '';
+		foreach ( $args['links'] ?? array() as $link ) { $output .= '<span class="extrch-link-page-link-text">' . esc_attr( $link['link_text'] ) . '</span>'; }
+		return $output;
+	}
+	return '<div data-template="' . esc_attr( $template ) . '"></div>';
+}
+function wp_add_inline_style() { return true; }
+function wp_enqueue_script() { return true; }
+function wp_enqueue_style() { return true; }
+function language_attributes() { echo 'lang="en-US"'; }
+function get_bloginfo() { return 'UTF-8'; }
+function get_site_icon_url() { return ''; }
+function wp_print_styles() {}
+function wp_print_footer_scripts() {}
+function untrailingslashit( $value ) { return rtrim( $value, '/' ); }
+function wp_parse_args( $args, $defaults ) { return array_merge( $defaults, is_array( $args ) ? $args : array() ); }
+function wp_get_ability() { return null; }
+function ec_combined_cache_purge_post( $post_id ) {
+	$urls = apply_filters( 'extrachill_cache_post_change_urls', null, $post_id, get_post_type( $post_id ) );
+	$GLOBALS['ec_test']['cache_action_blogs'][] = get_current_blog_id();
+	foreach ( is_array( $urls ) ? $urls : array() as $url ) { $GLOBALS['ec_test']['cache_deleted_urls'][] = $url; }
+}
+
+class EcCombinedSocials {
+	public function save( $artist_id, $socials ) {
+		if ( ! empty( $GLOBALS['probe_cross_context'] ) ) {
+			global $wpdb;
+			$scope = $GLOBALS['ec_link_page_lock_scope'] ?? array();
+			$GLOBALS['cross_lock_blog'] = $scope['blog_id'] ?? 0;
+			$GLOBALS['cross_lock_page'] = $scope['link_page_id'] ?? 0;
+			$GLOBALS['cross_mutation_blog'] = get_current_blog_id();
+			$GLOBALS['cross_contention_result'] = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 5)', 'ec_link_page_ids:4:' . ( $scope['link_page_id'] ?? 0 ) ) );
+		}
+		if ( ! empty( $GLOBALS['record_owner_lock'] ) ) {
+			$GLOBALS['owner_writes_locked'] = ! empty( $GLOBALS['ec_link_page_lock_scope'] ) && ( $GLOBALS['owner_writes_locked'] ?? true );
+		}
+		if ( ! empty( $GLOBALS['fail_social_once'] ) ) {
+			global $wpdb;
+			$GLOBALS['failure_contention_result'] = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 5)', 'ec_link_page_ids:4:101' ) );
+			unset( $GLOBALS['fail_social_once'] );
+			return new WP_Error( 'social_failure', 'Social save failed.' );
+		}
+		update_post_meta( $artist_id, '_artist_profile_social_links', $socials );
+		return true;
+	}
+	public function get( $artist_id ) { $socials = get_post_meta( $artist_id, '_artist_profile_social_links', true ); return is_array( $socials ) ? $socials : array(); }
+	public function get_icon_class( $type ) { return 'icon-' . $type; }
+}
+class EcCombinedQuery {
+	public $queried_object;
+	public function get_queried_object() { return $this->queried_object; }
+}
+function extrachill_artist_platform_social_links() { static $manager; if ( ! $manager ) { $manager = new EcCombinedSocials(); } return $manager; }
+
+require $standalone . '/tests/bootstrap.php';
+
+$GLOBALS['ec_test']['options']['active_plugins'] = array( 'extrachill-link-pages/extrachill-link-pages.php' );
+add_filter( 'ec_get_artist_id', static function ( $value, $input = null ) {
+	$id = is_numeric( $input ) ? (int) $input : ( is_numeric( $value ) ? (int) $value : 0 );
+	return EC_LINK_PAGE_POST_TYPE === get_post_type( $id ) ? (int) get_post_meta( $id, '_associated_artist_profile_id', true ) : $value;
+}, 10, 2 );
+
+require_once $artist_root . '/inc/link-pages/runtime-handoff.php';
+require_once $artist_root . '/inc/core/filters/data.php';
+require_once $artist_root . '/inc/core/filters/create.php';
+require_once $artist_root . '/inc/core/actions/save.php';
+require_once $artist_root . '/inc/abilities/helpers.php';
+require_once $artist_root . '/inc/abilities/handlers/save-link-page-links.php';
+require_once $artist_root . '/inc/abilities/handlers/save-link-page-styles.php';
+require_once $artist_root . '/inc/abilities/handlers/save-link-page-settings.php';
+require_once $artist_root . '/inc/abilities/handlers/save-social-links.php';
+require_once $artist_root . '/inc/abilities/handlers/update-artist.php';
+$registered = extrachill_artist_platform_register_link_page_adapters();
+if ( is_wp_error( $registered ) ) { echo wp_json_encode( array( 'bootstrap_error' => $registered->get_error_code() ) ); exit( 1 ); }
+add_action( 'extrachill_cache_purge_post', 'ec_combined_cache_purge_post' );
+$GLOBALS['ec_test']['execute_actions'] = true;
+
+$GLOBALS['ec_test']['blogs'][4]['posts'][20] = (object) array(
+	'ID'           => 20,
+	'post_type'    => 'artist_profile',
+	'post_status'  => 'publish',
+	'post_title'   => 'Combined Artist',
+	'post_name'    => 'combined-artist',
+	'post_excerpt' => 'Combined artist excerpt.',
+	'post_content' => 'Combined artist biography.',
+);
+$GLOBALS['ec_test']['blogs'][4]['posts'][21] = (object) array( 'ID' => 21, 'post_type' => 'artist_profile', 'post_status' => 'publish', 'post_title' => 'Existing Artist', 'post_name' => 'existing-artist', 'post_excerpt' => '', 'post_content' => '' );
+$GLOBALS['ec_test']['blogs'][4]['posts'][40] = (object) array( 'ID' => 40, 'post_type' => EC_LINK_PAGE_POST_TYPE, 'post_status' => 'publish', 'post_title' => 'Existing Artist', 'post_name' => 'existing-artist' );
+$GLOBALS['ec_test']['blogs'][4]['post_meta'][40] = array( EC_LINK_PAGE_OWNER_META_KEY => 'post:4:artist_profile:21', '_associated_artist_profile_id' => 21 );
+
+$created = ec_create_link_page( 20 );
+$cache_actions_before_save = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+$GLOBALS['ec_test']['blogs'][1] = array( 'posts' => array(), 'post_meta' => array(), 'terms' => array() );
+$cross_blog_resolution = array();
+foreach ( array( 1, 7 ) as $caller_blog_id ) {
+	switch_to_blog( $caller_blog_id );
+	$reference = ec_artist_link_page_owner_reference( 20 );
+	$cross_blog_resolution[ $caller_blog_id ] = array(
+		'id'   => ec_get_link_page_id_for_owner( $reference ),
+		'read' => ec_read_link_page_persistence( $created )['link_page_id'] ?? 0,
+		'urls' => ec_link_page_public_urls( $created ),
+		'caller' => get_current_blog_id(),
+		'existing' => ec_get_link_page_id_for_owner( ec_artist_link_page_owner_reference( 21 ) ),
+	);
+	restore_current_blog();
+}
+$read    = is_wp_error( $created ) ? $created : ec_read_link_page( $created );
+$mode = $argv[1] ?? '';
+if ( in_array( $mode, array( 'owner-save-failure', 'interleaving-failure' ), true ) ) {
+	$GLOBALS['fail_social_once'] = true;
+}
+$GLOBALS['record_owner_lock'] = true;
+$saved   = is_wp_error( $created ) ? $created : ec_save_link_page(
+	$created,
+	array(
+		'bio'                    => 'Updated bio',
+		'links'                  => array( array( 'id' => 'new-section', 'section_title' => 'Listen', 'links' => array( array( 'id' => 'new-link', 'link_text' => 'Song', 'link_url' => 'https://example.com/song' ) ) ) ),
+		'css_vars'               => array( '--link-page-text-color' => '#abcdef' ),
+		'subscribe_display_mode' => 'inline_form',
+		'social_icons'           => array( array( 'type' => 'instagram', 'url' => 'https://instagram.com/example' ) ),
+		'profile_image_id'       => 55,
+	)
+);
+$combined_owner_writes_locked = $GLOBALS['owner_writes_locked'] ?? false;
+unset( $GLOBALS['record_owner_lock'] );
+$contention = array();
+if ( 'contention' === ( $argv[1] ?? '' ) && ! is_wp_error( $created ) ) {
+	$contention['first'] = ec_with_link_page_lock_scope(
+		$created,
+		static function () use ( $created, &$contention ) {
+			global $wpdb;
+			$first = ec_save_link_page( $created, array( 'bio' => 'First authorized save' ) );
+			$contention['blocked'] = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 5)', 'ec_link_page_ids:4:' . $created ) );
+			return $first;
+		}
+	);
+	$contention['second'] = ec_save_link_page( $created, array( 'bio' => 'Second authorized save' ) );
+	$contention['final']  = get_post_meta( $created, '_link_page_bio_text', true );
+}
+$cache_actions_after_save = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+$persisted_after_failed_save = is_wp_error( $created ) ? '' : get_post_meta( $created, '_link_page_bio_text', true );
+$post_failure_save = null;
+if ( 'interleaving-failure' === $mode ) {
+	$post_failure_save = extrachill_artist_platform_ability_save_social_links( array( 'artist_id' => 20, 'social_links' => array( array( 'type' => 'bandcamp', 'url' => 'https://bandcamp.com/authoritative' ) ) ) );
+}
+$ability_results = array();
+$cache_actions_before_abilities = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+if ( ! in_array( $mode, array( 'owner-save-failure', 'interleaving-failure', 'separate-contention' ), true ) ) {
+	$ability_results['links'] = extrachill_artist_platform_ability_save_link_page_links(
+		array(
+			'artist_id' => 20,
+			'links'     => array( array( 'id' => '101-section-1', 'section_title' => 'Listen', 'links' => array( array( 'id' => '101-link-1', 'link_text' => 'Song updated', 'link_url' => 'https://example.com/song' ) ) ) ),
+		)
+	);
+	$ability_results['styles'] = extrachill_artist_platform_ability_save_link_page_styles( array( 'artist_id' => 20, 'css_vars' => array( '--link-page-text-color' => '#fedcba' ) ) );
+	$ability_results['settings'] = extrachill_artist_platform_ability_save_link_page_settings( array( 'artist_id' => 20, 'bio' => 'Ability bio', 'profile_image_id' => 55 ) );
+	$ability_results['socials'] = extrachill_artist_platform_ability_save_social_links( array( 'artist_id' => 20, 'social_links' => array( array( 'type' => 'instagram', 'url' => 'https://instagram.com/example' ) ) ) );
+}
+$separate_contention = array();
+if ( 'separate-contention' === $mode ) {
+	$separate_contention['during_combined'] = ec_with_link_page_lock_scope(
+		$created,
+		static function () {
+			return array(
+				'social'  => extrachill_artist_platform_ability_save_social_links( array( 'artist_id' => 20, 'social_links' => array( array( 'type' => 'blocked', 'url' => 'https://example.com/blocked' ) ) ) ),
+				'profile' => extrachill_artist_platform_ability_update_artist( array( 'artist_id' => 20, 'name' => 'Blocked profile mutation' ) ),
+			);
+		},
+		'combined'
+	);
+	$separate_contention['during_separate'] = ec_artist_with_link_page_lock(
+		20,
+		static function () use ( $created ) {
+			return ec_save_link_page( $created, array( 'bio' => 'Blocked combined save' ) );
+		}
+	);
+	$separate_contention['social_after'] = extrachill_artist_platform_ability_save_social_links( array( 'artist_id' => 20, 'social_links' => array( array( 'type' => 'after', 'url' => 'https://example.com/after' ) ) ) );
+	$separate_contention['profile_after'] = extrachill_artist_platform_ability_update_artist( array( 'artist_id' => 20, 'name' => 'Profile after release' ) );
+	$separate_contention['combined_after'] = ec_save_link_page( $created, array( 'bio' => 'Combined after separate release' ) );
+}
+$cache_actions_after_abilities = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+$cross_blog_mutation = array();
+if ( in_array( $mode, array( 'cross-blog-1', 'cross-blog-7', 'cross-blog-failure' ), true ) ) {
+	$caller_blog_id = 'cross-blog-1' === $mode ? 1 : 7;
+	if ( 'cross-blog-failure' === $mode ) {
+		$GLOBALS['fail_social_once'] = true;
+	}
+	$GLOBALS['probe_cross_context'] = true;
+	$GLOBALS['probe_profile_context'] = true;
+	$before_cache = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+	switch_to_blog( $caller_blog_id );
+	$entry_stack = $GLOBALS['_wp_switched_stack'];
+	$cross_result = extrachill_artist_platform_ability_save_social_links( array( 'artist_id' => 20, 'social_links' => array( array( 'type' => 'cross', 'url' => 'https://example.com/cross' ) ) ) );
+	$profile_result = null;
+	if ( 'cross-blog-failure' !== $mode ) {
+		$profile_result = extrachill_artist_platform_ability_update_artist( array( 'artist_id' => 20, 'name' => 'Cross-blog profile' ) );
+	}
+	$after_cache = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+	$cross_blog_mutation = array(
+		'result'          => is_wp_error( $cross_result ) ? $cross_result->get_error_code() : true,
+		'profile_result'  => null === $profile_result ? null : ! is_wp_error( $profile_result ),
+		'lock_blog'       => $GLOBALS['cross_lock_blog'] ?? 0,
+		'lock_page'       => $GLOBALS['cross_lock_page'] ?? 0,
+		'mutation_blog'   => $GLOBALS['cross_mutation_blog'] ?? 0,
+		'profile_lock_blog' => $GLOBALS['profile_lock_blog'] ?? 0,
+		'profile_lock_page' => $GLOBALS['profile_lock_page'] ?? 0,
+		'profile_mutation_blog' => $GLOBALS['profile_mutation_blog'] ?? 0,
+		'cache_blog'      => end( $GLOBALS['ec_test']['cache_action_blogs'] ) ?: 0,
+		'cache_delta'     => $after_cache - $before_cache,
+		'contender'       => $GLOBALS['cross_contention_result'] ?? null,
+		'caller_after'    => get_current_blog_id(),
+		'stack_restored'  => $entry_stack === $GLOBALS['_wp_switched_stack'],
+	);
+	restore_current_blog();
+	unset( $GLOBALS['probe_cross_context'] );
+	unset( $GLOBALS['probe_profile_context'] );
+}
+update_post_meta( 55, '_wp_attachment_image_alt', 'Combined Artist portrait' );
+if ( 'orphan-owner' === ( $argv[1] ?? '' ) ) {
+	$GLOBALS['ec_test']['blogs'][4]['posts'][20]->post_status = 'draft';
+} elseif ( 'deleted-owner' === ( $argv[1] ?? '' ) ) {
+	unset( $GLOBALS['ec_test']['blogs'][4]['posts'][20] );
+}
+$projection = is_wp_error( $created ) ? $created : ec_get_link_page_public_projection( $created );
+$rendered = '';
+$fallback_rendered = '';
+if ( ! is_wp_error( $created ) ) {
+	$GLOBALS['wp_query'] = new EcCombinedQuery();
+	$GLOBALS['wp_query']->queried_object = get_post( $created );
+	ob_start();
+	require $standalone . '/templates/single-link-page.php';
+	$rendered = ob_get_clean();
+	if ( 'deleted-owner' !== ( $argv[1] ?? '' ) ) {
+		ob_start();
+		require $artist_root . '/inc/link-pages/live/templates/single-artist_link_page.php';
+		$fallback_rendered = ob_get_clean();
+	}
+}
+$GLOBALS['wp_query'] = (object) array( 'posts' => array(), 'query_vars' => array(), 'is_404' => true );
+$_SERVER['HTTP_HOST'] = 'extrachill.link';
+$_SERVER['REQUEST_URI'] = '/join/';
+ec_resolve_link_page_public_query();
+$join_redirect = $GLOBALS['ec_test']['redirect'] ?? array();
+$force_failure = 'force-failure' === ( $argv[1] ?? '' );
+if ( $force_failure ) {
+	$GLOBALS['ec_test']['fail_meta_write_calls'] = array( $GLOBALS['ec_test']['meta_write_calls'] + 5 );
+}
+$forced     = is_wp_error( $created ) ? $created : ec_create_link_page( 20, true );
+$purges_before_delete = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+if ( ! is_wp_error( $forced ) ) {
+	ec_purge_link_page_before_delete( $forced );
+	wp_delete_post( $forced, true );
+}
+$purges_after_delete = count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) );
+$final_hooks = array_values( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'ec_link_page_save' === $action[0]; } ) );
+
+echo wp_json_encode(
+	array(
+		'created'             => is_wp_error( $created ) ? $created->get_error_code() : $created,
+		'read_shape'          => is_array( $read ) && isset( $read['artist_id'], $read['settings'], $read['links'] ),
+		'saved'               => is_wp_error( $saved ) ? $saved->get_error_code() : true,
+		'saved_bio'           => is_array( $saved ) ? $saved['bio'] : '',
+		'persisted_bio'       => is_wp_error( $created ) ? '' : get_post_meta( $created, '_link_page_bio_text', true ),
+		'persisted_after_failed_save' => $persisted_after_failed_save,
+		'post_failure_save'   => null === $post_failure_save ? null : ! is_wp_error( $post_failure_save ),
+		'post_failure_social_url' => ( get_post_meta( 20, '_artist_profile_social_links', true )[0]['url'] ?? '' ),
+		'ability_results'     => array_map( static function ( $result ) { return is_wp_error( $result ) ? $result->get_error_code() : is_array( $result ); }, $ability_results ),
+		'owner_writes_locked' => $combined_owner_writes_locked,
+		'failure_contention'  => $GLOBALS['failure_contention_result'] ?? null,
+		'contention'          => array(
+			'first'   => isset( $contention['first'] ) && ! is_wp_error( $contention['first'] ),
+			'blocked' => $contention['blocked'] ?? null,
+			'second'  => isset( $contention['second'] ) && ! is_wp_error( $contention['second'] ),
+			'final'   => $contention['final'] ?? '',
+		),
+		'separate_contention' => array(
+			'during_combined_social' => isset( $separate_contention['during_combined']['social'] ) && is_wp_error( $separate_contention['during_combined']['social'] ) ? $separate_contention['during_combined']['social']->get_error_code() : null,
+			'during_combined_profile' => isset( $separate_contention['during_combined']['profile'] ) && is_wp_error( $separate_contention['during_combined']['profile'] ) ? $separate_contention['during_combined']['profile']->get_error_code() : null,
+			'during_separate' => isset( $separate_contention['during_separate'] ) && is_wp_error( $separate_contention['during_separate'] ) ? $separate_contention['during_separate']->get_error_code() : null,
+			'social_after'    => isset( $separate_contention['social_after'] ) && ! is_wp_error( $separate_contention['social_after'] ),
+			'profile_after'   => isset( $separate_contention['profile_after'] ) && ! is_wp_error( $separate_contention['profile_after'] ),
+			'combined_after'  => isset( $separate_contention['combined_after'] ) && ! is_wp_error( $separate_contention['combined_after'] ),
+			'final_bio'       => get_post_meta( $created, '_link_page_bio_text', true ),
+			'final_social_url'=> ( get_post_meta( 20, '_artist_profile_social_links', true )[0]['url'] ?? '' ),
+			'final_profile_title' => get_the_title( 20 ),
+		),
+		'cross_blog_mutation' => $cross_blog_mutation,
+		'social_count'        => count( get_post_meta( 20, '_artist_profile_social_links', true ) ?: array() ),
+		'thumbnail'           => get_post_thumbnail_id( 20 ),
+		'projection_title'    => is_wp_error( $projection ) ? $projection->get_error_code() : $projection['display_title'],
+		'projection_schema'   => ! is_wp_error( $projection ) && 2 === count( $projection['seo']['schema'] ),
+		'projection_alt'      => is_wp_error( $projection ) ? '' : $projection['seo']['image_alt'],
+		'projection_canonical'=> is_wp_error( $projection ) ? '' : $projection['seo']['canonical'],
+		'public_status'       => $GLOBALS['ec_test']['status'] ?? 200,
+		'rendered_body'       => false !== strpos( $rendered, 'data-extrch-artist-id="20"' ) && false !== strpos( $rendered, 'extrch-link-page' ),
+		'rendered_subscribe'  => false !== strpos( $rendered, 'data-template="subscribe-inline-form"' ),
+		'snapshot_parity'     => false !== strpos( $rendered, 'extrch-link-page-title">Combined Artist</h1>' )
+			&& false !== strpos( $fallback_rendered, 'extrch-link-page-title">Combined Artist</h1>' )
+			&& false !== strpos( $rendered, 'extrch-link-page-link-text">Song updated</span>' )
+			&& false !== strpos( $fallback_rendered, 'extrch-link-page-link-text">Song updated</span>' )
+			&& false !== strpos( $rendered, 'data-extrch-artist-id="20"' )
+			&& false !== strpos( $fallback_rendered, 'data-extrch-artist-id="20"' ),
+		'head_hook'           => 1 <= count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_artist_link_page_minimal_head' === $action[0] && 20 === $action[1][1]; } ) ),
+		'join_redirect'       => $join_redirect[0] ?? '',
+		'forced'              => is_wp_error( $forced ) ? $forced->get_error_code() : $forced,
+		'force_restored_id'   => (int) get_post_meta( 20, '_extrch_link_page_id', true ),
+		'force_restored_slug' => get_post_field( 'post_name', $created ),
+		'force_new_count'     => count( get_posts( array( 'post_type' => EC_LINK_PAGE_POST_TYPE, 'post_status' => 'any', 'fields' => 'ids', 'posts_per_page' => -1, 'meta_key' => '_associated_artist_profile_id', 'meta_value' => '20' ) ) ),
+		'legacy_detached'     => is_wp_error( $created ) ? false : '' === get_post_meta( $created, '_associated_artist_profile_id', true ),
+		'final_hook_count'    => count( $final_hooks ),
+		'delete_purge_delta'  => $purges_after_delete - $purges_before_delete,
+		'cache_deleted_urls'  => array_values( array_unique( $GLOBALS['ec_test']['cache_deleted_urls'] ?? array() ) ),
+		'cache_action_count'  => count( array_filter( $GLOBALS['ec_test']['fired_actions'], static function ( $action ) { return 'extrachill_cache_purge_post' === $action[0]; } ) ),
+		'save_cache_delta'    => $cache_actions_after_save - $cache_actions_before_save,
+		'ability_cache_delta' => $cache_actions_after_abilities - $cache_actions_before_abilities,
+		'caller_blog'         => get_current_blog_id(),
+		'cross_blog_resolution'=> $cross_blog_resolution,
+	)
+);

--- a/tests/fixtures/editor-no-write-smoke.php
+++ b/tests/fixtures/editor-no-write-smoke.php
@@ -1,0 +1,26 @@
+<?php
+
+define( 'ABSPATH', __DIR__ . '/' );
+$GLOBALS['writes'] = 0;
+function is_user_logged_in() { return true; }
+function get_current_user_id() { return 7; }
+function ec_get_artists_for_user() { return array( 20 ); }
+function get_post( $id ) { return 20 === (int) $id ? (object) array( 'ID' => 20, 'post_status' => 'publish', 'post_title' => 'Artist', 'post_name' => 'artist' ) : null; }
+function ec_get_link_page_for_artist() { return false; }
+function ec_create_link_page() { ++$GLOBALS['writes']; return 40; }
+function get_post_status() { return false; }
+function esc_html__( $text ) { return $text; }
+function esc_url( $url ) { return $url; }
+function site_url( $path = '' ) { return 'https://artist.example' . $path; }
+
+ob_start();
+require dirname( __DIR__, 2 ) . '/src/blocks/link-page-editor/render.php';
+$html = ob_get_clean();
+
+echo json_encode(
+	array(
+		'writes'      => $GLOBALS['writes'],
+		'setup_state' => false !== strpos( $html, 'data-link-page-setup-state="required"' ),
+		'cta'         => false !== strpos( $html, 'Complete Artist Setup' ),
+	)
+);

--- a/tests/fixtures/fake-external-link-pages-runtime.php
+++ b/tests/fixtures/fake-external-link-pages-runtime.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( empty( $GLOBALS['smoke']['omit_api_version'] ) ) {
-	define( 'EC_LINK_PAGES_RUNTIME_API_VERSION', $GLOBALS['smoke']['api_version'] ?? '2' );
+	define( 'EC_LINK_PAGES_RUNTIME_API_VERSION', $GLOBALS['smoke']['api_version'] ?? '3' );
 }
 define( 'EC_LINK_PAGE_POST_TYPE', $GLOBALS['smoke']['post_type_constant'] ?? 'artist_link_page' );
 define( 'EC_LINK_PAGE_OWNER_META_KEY', $GLOBALS['smoke']['owner_meta_constant'] ?? '_ec_link_page_owner_reference' );
@@ -17,6 +17,7 @@ function ec_register_link_page_owner_compatibility_provider( $name, $callback, $
 	$GLOBALS['smoke']['owner_providers'][ $name ] = $callback;
 	return true;
 }
+function ec_can_register_link_page_owner_compatibility_provider( $name, $callback, $priority = 10 ) { return true; }
 
 function ec_register_link_page_operation_provider( $name, $callback, $priority = 10 ) {
 	if ( isset( $GLOBALS['smoke']['operation_providers'][ $name ] ) ) {
@@ -25,6 +26,7 @@ function ec_register_link_page_operation_provider( $name, $callback, $priority =
 	$GLOBALS['smoke']['operation_providers'][ $name ] = $callback;
 	return true;
 }
+function ec_can_register_link_page_operation_provider( $name, $callback, $priority = 10 ) { return true; }
 
 function ec_format_link_page_owner_reference( $owner ) {
 	return sprintf( '%s:%d:%s:%d', $owner['kind'], $owner['blog_id'], $owner['subtype'], $owner['object_id'] );
@@ -116,6 +118,9 @@ function ec_sanitize_link_page_settings( $settings ) { return $settings; }
 function ec_read_link_page_persistence( $link_page_id, $overrides = array() ) { return $overrides; }
 function ec_save_link_page_persistence( $link_page_id, $data ) { return $data; }
 function ec_create_owned_link_page( $owner, $title, $slug, $force = false ) { return 40; }
+function ec_provision_owned_link_page( $owner, $title, $slug, $force = false, $precondition = null ) { return array( 'link_page_id' => 40, 'created' => true ); }
+function ec_invoke_link_page_provision_precondition( $precondition, $owner ) { return true; }
+function ec_create_owned_link_page_unlocked( $owner, $title, $slug, $force = false ) { return 40; }
 function ec_with_link_page_lock_scope( $id, $callback, $scope = 'generic' ) { return call_user_func( $callback ); }
 function ec_link_page_public_projection_registry() { return (object) array(); }
 function ec_register_link_page_public_projection_provider( $name, $callback, $priority = 10 ) {
@@ -125,6 +130,11 @@ function ec_register_link_page_public_projection_provider( $name, $callback, $pr
 	$GLOBALS['smoke']['projection_providers'][ $name ] = $callback;
 	return true;
 }
+function ec_can_register_link_page_public_projection_provider( $name, $callback, $priority = 10 ) { return true; }
+function ec_sanitize_link_page_public_projection_snapshot( $projection ) { return $projection; }
+function ec_save_link_page_public_projection_snapshot( $id, $owner, $projection ) { return array(); }
+function ec_read_link_page_public_projection_snapshot( $id, $owner = '' ) { return array(); }
+function ec_render_stored_link_page_social_links( $links ) { return ''; }
 function ec_get_link_page_public_projection( $link_page_id, $request = array() ) { return array(); }
 function ec_render_link_page_public_components( $projection, $slot ) { return ''; }
 function ec_get_link_page_public_url( $link_page_id ) { return 'https://extrachill.link/example/'; }

--- a/tests/fixtures/fake-external-link-pages-runtime.php
+++ b/tests/fixtures/fake-external-link-pages-runtime.php
@@ -1,7 +1,7 @@
 <?php
 
 if ( empty( $GLOBALS['smoke']['omit_api_version'] ) ) {
-	define( 'EC_LINK_PAGES_RUNTIME_API_VERSION', $GLOBALS['smoke']['api_version'] ?? '1' );
+	define( 'EC_LINK_PAGES_RUNTIME_API_VERSION', $GLOBALS['smoke']['api_version'] ?? '2' );
 }
 define( 'EC_LINK_PAGE_POST_TYPE', $GLOBALS['smoke']['post_type_constant'] ?? 'artist_link_page' );
 define( 'EC_LINK_PAGE_OWNER_META_KEY', $GLOBALS['smoke']['owner_meta_constant'] ?? '_ec_link_page_owner_reference' );
@@ -106,6 +106,30 @@ function ec_backfill_link_page_owner_references( $limit = 100, $offset = 0 ) {
 function ec_link_page_operation_provider_registry() {
 	return (object) array();
 }
+
+function ec_link_page_defaults() { return array( 'styles' => array(), 'settings' => array() ); }
+function ec_link_page_defaults_for( $category ) { return ec_link_page_defaults()[ $category ] ?? array(); }
+function ec_link_page_default( $category, $key, $fallback = null ) { return $fallback; }
+function ec_sanitize_link_page_links( $links, $link_page_id = 0 ) { return $links; }
+function ec_sanitize_link_page_css_vars( $vars, $existing = array() ) { return $vars; }
+function ec_sanitize_link_page_settings( $settings ) { return $settings; }
+function ec_read_link_page_persistence( $link_page_id, $overrides = array() ) { return $overrides; }
+function ec_save_link_page_persistence( $link_page_id, $data ) { return $data; }
+function ec_create_owned_link_page( $owner, $title, $slug, $force = false ) { return 40; }
+function ec_with_link_page_lock_scope( $id, $callback, $scope = 'generic' ) { return call_user_func( $callback ); }
+function ec_link_page_public_projection_registry() { return (object) array(); }
+function ec_register_link_page_public_projection_provider( $name, $callback, $priority = 10 ) {
+	if ( isset( $GLOBALS['smoke']['projection_providers'][ $name ] ) ) {
+		return new WP_Error( 'duplicate_link_page_public_projection_provider', 'Duplicate provider.' );
+	}
+	$GLOBALS['smoke']['projection_providers'][ $name ] = $callback;
+	return true;
+}
+function ec_get_link_page_public_projection( $link_page_id, $request = array() ) { return array(); }
+function ec_render_link_page_public_components( $projection, $slot ) { return ''; }
+function ec_get_link_page_public_url( $link_page_id ) { return 'https://extrachill.link/example/'; }
+function ec_link_page_public_urls( $link_page_id ) { return array( ec_get_link_page_public_url( $link_page_id ) ); }
+function ec_validate_link_pages_runtime( $check_readiness = true ) { return true; }
 
 function ec_resolve_link_page_operation_target( $target ) {
 	return array( 'link_page_id' => 40, 'owner' => ec_get_link_page_owner( 40 ), 'owner_reference' => 'post:4:artist_profile:20' );

--- a/tests/fixtures/link-pages-activation-failure-smoke.php
+++ b/tests/fixtures/link-pages-activation-failure-smoke.php
@@ -49,6 +49,9 @@ function add_action( $hook, $callback, $priority = 10 ) {
 	$GLOBALS['smoke']['actions'][] = array( $hook, $callback, $priority );
 }
 
+function add_filter() {
+}
+
 function register_activation_hook( $file, $callback ) {
 	$GLOBALS['smoke']['activation_callback'] = $callback;
 }

--- a/tests/fixtures/link-pages-external-runtime-smoke.php
+++ b/tests/fixtures/link-pages-external-runtime-smoke.php
@@ -48,6 +48,9 @@ function add_action( $hook, $callback, $priority = 10 ) {
 	$GLOBALS['smoke']['actions'][] = array( $hook, $callback, $priority );
 }
 
+function add_filter() {
+}
+
 function is_wp_error( $value ) {
 	return $value instanceof WP_Error;
 }
@@ -136,6 +139,7 @@ echo json_encode(
 		'owner_meta_constant'    => EC_LINK_PAGE_OWNER_META_KEY,
 		'owner_providers'        => count( $GLOBALS['smoke']['owner_providers'] ),
 		'operation_providers'    => count( $GLOBALS['smoke']['operation_providers'] ),
+		'projection_providers'   => count( $GLOBALS['smoke']['projection_providers'] ),
 		'link_page_cpt_owner'    => $GLOBALS['smoke']['registered_post_types']['artist_link_page']['owner'] ?? '',
 		'artist_profile_exists'  => isset( $GLOBALS['smoke']['registered_post_types']['artist_profile'] ),
 		'legacy_owner_reference'=> is_wp_error( $owner ) ? $owner->get_error_code() : $owner['reference'],

--- a/tests/fixtures/link-pages-missing-runtime-smoke.php
+++ b/tests/fixtures/link-pages-missing-runtime-smoke.php
@@ -40,6 +40,8 @@ function is_wp_error( $value ) {
 function add_action( $hook, $callback ) {
 	$GLOBALS['smoke_actions'][] = array( $hook, $callback );
 }
+function add_filter() {
+}
 
 require_once $root . '/inc/link-pages/runtime-handoff.php';
 $result = extrachill_artist_platform_boot_link_pages_runtime();

--- a/tests/fixtures/link-pages-real-runtime-smoke.php
+++ b/tests/fixtures/link-pages-real-runtime-smoke.php
@@ -34,6 +34,7 @@ $GLOBALS['smoke'] = array(
 	'flushes'               => 0,
 	'current_blog_id'       => 4,
 	'filters'               => array(),
+	'site_options'          => array(),
 );
 
 function get_option( $name, $default = false ) {
@@ -44,8 +45,9 @@ function get_option( $name, $default = false ) {
 }
 
 function get_site_option( $name, $default = false ) {
-	return $default;
+	return $GLOBALS['smoke']['site_options'][ $name ] ?? $default;
 }
+function update_site_option( $name, $value ) { $GLOBALS['smoke']['site_options'][ $name ] = $value; return true; }
 
 function plugin_dir_path( $file ) {
 	return dirname( $file ) . '/';
@@ -129,7 +131,7 @@ if ( in_array( $mode, array( 'activation', 'activation-site' ), true ) ) {
 	$before_boot = function_exists( 'ec_get_link_page_owner' );
 	do_action( 'plugins_loaded' );
 	$after_boot = function_exists( 'ec_get_link_page_owner' );
-	$storage_provider_before_standalone = has_filter( 'ec_link_page_storage_blog_id' );
+	$storage_provider_before_standalone = 4 === (int) get_site_option( 'ec_link_page_storage_blog_id', 0 );
 	require_once $standalone . '/extrachill-link-pages.php';
 	$activation_callbacks = array_values( $GLOBALS['smoke']['activation_callbacks'] );
 	call_user_func( $activation_callbacks[0], 'activation' === $mode );

--- a/tests/fixtures/link-pages-real-runtime-smoke.php
+++ b/tests/fixtures/link-pages-real-runtime-smoke.php
@@ -2,7 +2,7 @@
 
 $mode       = $argv[1] ?? '';
 $artist     = dirname( __DIR__, 2 );
-$standalone = getenv( 'LINK_PAGES_WORKTREE' ) ?: '/var/lib/datamachine/workspace/extrachill-link-pages@feat-1-owner-neutral-runtime';
+$standalone = getenv( 'LINK_PAGES_WORKTREE' ) ?: '/var/lib/datamachine/workspace/extrachill-link-pages@feat-3-public-runtime';
 
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'EXTRACHILL_ARTIST_PLATFORM_PLUGIN_DIR', $artist . '/' );
@@ -32,6 +32,8 @@ $GLOBALS['smoke'] = array(
 	'registered_post_types' => array(),
 	'registration_counts'   => array(),
 	'flushes'               => 0,
+	'current_blog_id'       => 4,
+	'filters'               => array(),
 );
 
 function get_option( $name, $default = false ) {
@@ -56,6 +58,25 @@ function plugin_basename( $file ) {
 function add_action( $hook, $callback, $priority = 10 ) {
 	$GLOBALS['smoke']['actions'][ $hook ][ $priority ][] = $callback;
 }
+
+function add_filter( $hook, $callback, $priority = 10, $accepted_args = 1 ) {
+	$GLOBALS['smoke']['filters'][ $hook ][] = array( $callback, $priority, $accepted_args );
+}
+
+function apply_filters( $hook, $value, ...$args ) {
+	foreach ( $GLOBALS['smoke']['filters'][ $hook ] ?? array() as $filter ) {
+		$value = call_user_func_array( $filter[0], array_slice( array_merge( array( $value ), $args ), 0, $filter[2] ) );
+	}
+	return $value;
+}
+function has_filter( $hook ) { return ! empty( $GLOBALS['smoke']['filters'][ $hook ] ); }
+function get_current_blog_id() { return $GLOBALS['smoke']['current_blog_id']; }
+function get_main_site_id() { return 4; }
+function get_site( $blog_id ) { return 4 === (int) $blog_id ? (object) array( 'blog_id' => 4 ) : null; }
+function switch_to_blog( $blog_id ) { $GLOBALS['smoke']['current_blog_id'] = (int) $blog_id; return true; }
+function restore_current_blog() { $GLOBALS['smoke']['current_blog_id'] = 4; return true; }
+function is_multisite() { return true; }
+function ec_get_blog_id( $type ) { return 'artist' === $type ? 4 : 0; }
 
 function do_action( $hook ) {
 	$priorities = $GLOBALS['smoke']['actions'][ $hook ] ?? array();
@@ -104,25 +125,27 @@ require_once $artist . '/inc/link-pages/runtime-handoff.php';
 require_once $artist . '/inc/core/artist-platform-post-types.php';
 add_action( 'plugins_loaded', 'extrachill_artist_platform_boot_link_pages_runtime', 20 );
 
-if ( 'activation' === $mode ) {
+if ( in_array( $mode, array( 'activation', 'activation-site' ), true ) ) {
 	$before_boot = function_exists( 'ec_get_link_page_owner' );
 	do_action( 'plugins_loaded' );
 	$after_boot = function_exists( 'ec_get_link_page_owner' );
-	do_action( 'init' );
+	$storage_provider_before_standalone = has_filter( 'ec_link_page_storage_blog_id' );
 	require_once $standalone . '/extrachill-link-pages.php';
 	$activation_callbacks = array_values( $GLOBALS['smoke']['activation_callbacks'] );
-	call_user_func( $activation_callbacks[0] );
+	call_user_func( $activation_callbacks[0], 'activation' === $mode );
 
 	echo json_encode(
 		array(
 			'before_boot'          => $before_boot,
 			'after_boot'           => $after_boot,
 			'ready'                => ec_link_pages_runtime_ready(),
-			'contract_matches'      => extrachill_artist_platform_link_pages_runtime_signatures() == ec_link_pages_runtime_function_contract(),
+			'contract_matches'      => true === extrachill_artist_platform_validate_link_pages_runtime(),
 			'link_registrations'   => $GLOBALS['smoke']['registration_counts']['artist_link_page'] ?? 0,
 			'owner_providers'      => count( ec_link_page_owner_compatibility_registry()->snapshot() ),
 			'operation_providers'  => count( ec_link_page_operation_provider_registry()->snapshot() ),
 			'flushes'              => $GLOBALS['smoke']['flushes'],
+			'storage_provider_before_standalone' => $storage_provider_before_standalone,
+			'storage_blog_id'      => ec_get_link_page_storage_blog_id(),
 		)
 	);
 	exit;
@@ -134,18 +157,19 @@ if ( 'external' === $mode ) {
 	$after_standalone = function_exists( 'ec_get_link_page_owner' );
 	do_action( 'plugins_loaded' );
 	$second_boot = extrachill_artist_platform_boot_link_pages_runtime();
-	do_action( 'init' );
+	ec_register_link_page_post_type_if_ready();
 
 	echo json_encode(
 		array(
 			'before_standalone'    => $before_standalone,
 			'after_standalone'     => $after_standalone,
 			'ready'                => ec_link_pages_runtime_ready(),
-			'contract_matches'      => extrachill_artist_platform_link_pages_runtime_signatures() == ec_link_pages_runtime_function_contract(),
+			'contract_matches'      => true === extrachill_artist_platform_validate_link_pages_runtime(),
 			'second_boot'          => true === $second_boot,
 			'link_registrations'   => $GLOBALS['smoke']['registration_counts']['artist_link_page'] ?? 0,
 			'owner_providers'      => count( ec_link_page_owner_compatibility_registry()->snapshot() ),
 			'operation_providers'  => count( ec_link_page_operation_provider_registry()->snapshot() ),
+			'projection_providers' => count( ec_link_page_public_projection_registry()->snapshot() ),
 		)
 	);
 	exit;

--- a/tests/fixtures/link-pages-runtime-validation-smoke.php
+++ b/tests/fixtures/link-pages-runtime-validation-smoke.php
@@ -61,6 +61,9 @@ function add_action( $hook, $callback ) {
 	$GLOBALS['smoke']['actions'][] = array( $hook, $callback );
 }
 
+function add_filter() {
+}
+
 require_once $root . '/inc/link-pages/runtime-handoff.php';
 require_once __DIR__ . '/fake-external-link-pages-runtime.php';
 $result = extrachill_artist_platform_boot_link_pages_runtime();


### PR DESCRIPTION
## Summary
- make Artist Platform the artist owner/projection/persistence adapter for standalone Link Pages API v2
- preserve artist abilities, REST/CLI/Roadie, editor, subscriptions, socials, SEO, token handoff, legacy metadata, create/force/delete and fallback behavior
- serialize combined and separate cross-blog mutations through the canonical page lock and finalize cache only after complete owner saves

## Testing
- Artist Platform: `308 tests, 1,691 assertions`
- Artist JS: 5 suites, 12 tests
- Gutenberg build
- standalone coordinated suite: `55 tests, 313 assertions`
- combined create/read/save/render/route/cache/SEO/force/delete/editor/cross-blog contention fixtures

## Stack
- Based on #198
- Depends on Extra-Chill/extrachill-link-pages#4
- Requires Extra-Chill/extrachill-cache#20

Closes #199